### PR TITLE
feat(ui): reset search state and scroll position on window open

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -222,6 +222,10 @@ export class PromptLineRenderer {
     try {
       this.lifecycleManager.handleWindowShown(data);
       this.updateHistoryAndSettings(data);
+      
+      // Reset search mode and scroll position when window is shown
+      this.searchManager?.exitSearchMode();
+      this.resetHistoryScrollPosition();
     } catch (error) {
       console.error('Error handling window shown:', error);
     }
@@ -283,6 +287,12 @@ export class PromptLineRenderer {
     if (!isSearchMode) {
       // Return focus to main textarea when exiting search
       this.searchManager?.focusMainTextarea();
+    }
+  }
+
+  private resetHistoryScrollPosition(): void {
+    if (this.domManager.historyList) {
+      this.domManager.historyList.scrollTop = 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- Reset search mode to normal state when window is opened
- Reset history list scroll position to top when window is opened

## Changes
- Added `searchManager?.exitSearchMode()` call in `handleWindowShown()` method
- Added `resetHistoryScrollPosition()` method to reset scroll position
- These changes ensure consistent UI state when the window is opened

## Test plan
- [x] Open window and verify search mode is not active
- [x] Scroll history list, close window, reopen and verify scroll position is at top
- [x] Search history, close window, reopen and verify search is cleared

🤖 Generated with [Claude Code](https://claude.ai/code)