### PR TITLE
feat(settings): add configurable search shortcut key setting

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -61,7 +61,8 @@ class AppConfigClass {
       paste: 'Cmd+Enter',
       close: 'Escape',
       historyNext: 'Ctrl+j',
-      historyPrev: 'Ctrl+k'
+      historyPrev: 'Ctrl+k',
+      search: 'Cmd+f'
     };
 
     const userDataDir = path.join(os.homedir(), '.prompt-line');

--- a/src/managers/settings-manager.ts
+++ b/src/managers/settings-manager.ts
@@ -19,7 +19,8 @@ class SettingsManager {
         paste: 'Cmd+Enter',
         close: 'Escape',
         historyNext: 'Ctrl+j',
-        historyPrev: 'Ctrl+k'
+        historyPrev: 'Ctrl+k',
+        search: 'Cmd+f'
       },
       window: {
         position: 'active-window-center',

--- a/src/renderer/event-handler.ts
+++ b/src/renderer/event-handler.ts
@@ -164,15 +164,17 @@ export class EventHandler {
         }
       }
 
-      // Handle Cmd+F for search
-      if (e.key === 'f' && e.metaKey) {
-        // Skip shortcut if IME is active
-        if (this.isComposing || e.isComposing) {
+      // Handle search shortcut
+      if (this.userSettings?.shortcuts?.search) {
+        if (matchesShortcutString(e, this.userSettings.shortcuts.search)) {
+          // Skip shortcut if IME is active
+          if (this.isComposing || e.isComposing) {
+            return;
+          }
+          e.preventDefault();
+          this.onSearchToggle();
           return;
         }
-        e.preventDefault();
-        this.onSearchToggle();
-        return;
       }
 
       // Handle Cmd+V for image paste

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -27,6 +27,7 @@ export interface UserSettings {
     close: string;
     historyNext: string;
     historyPrev: string;
+    search: string;
   };
   window: {
     position: string;

--- a/src/renderer/utils/shortcut-formatter.ts
+++ b/src/renderer/utils/shortcut-formatter.ts
@@ -20,6 +20,7 @@ export function updateShortcutsDisplay(
     close: string;
     historyNext?: string;
     historyPrev?: string;
+    search?: string;
   }
 ): void {
   // Update header shortcuts
@@ -47,5 +48,12 @@ export function updateShortcutsDisplay(
     const prevKey = historyPrev.split('+').pop() || 'k';
     
     historyShortcutsEl.innerHTML = `<kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">${nextKey}</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">${prevKey}</kbd>`;
+  }
+
+  // Update search button tooltip
+  const searchButtonEl = document.getElementById('searchButton');
+  if (searchButtonEl && shortcuts.search) {
+    const searchKey = formatShortcut(shortcuts.search);
+    searchButtonEl.title = `Search history (${searchKey})`;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,7 @@ export interface ShortcutsConfig {
   close: string;
   historyNext: string;
   historyPrev: string;
+  search: string;
 }
 
 export interface PathsConfig {
@@ -165,6 +166,7 @@ export interface UserSettings {
     close: string;
     historyNext: string;
     historyPrev: string;
+    search: string;
   };
   window: {
     position: StartupPosition;

--- a/tests/integration/app-integration.test.ts
+++ b/tests/integration/app-integration.test.ts
@@ -79,7 +79,7 @@ describe('DOM Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -113,7 +113,7 @@ describe('DOM Integration Tests', () => {
 
         test('should handle empty history', () => {
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -136,7 +136,7 @@ describe('DOM Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -158,7 +158,7 @@ describe('DOM Integration Tests', () => {
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 

--- a/tests/integration/error-handling.test.ts
+++ b/tests/integration/error-handling.test.ts
@@ -107,7 +107,7 @@ describe('Error Handling Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -223,7 +223,7 @@ more broken content: }}}
 
             // Test partial settings
             const partialSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             } as any;
 
@@ -253,7 +253,7 @@ window:
             }));
 
             const invalidSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Enter', close: 'Escape' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 'not_a_number', height: 400 }
             } as any;
 
@@ -334,7 +334,7 @@ window:
 
             // Simulate disk space issues by testing with very large settings objects
             const hugeSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 },
                 // Add large data to simulate memory pressure
                 largeData: new Array(1000).fill('large_data_item')
@@ -360,7 +360,7 @@ window:
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -390,7 +390,7 @@ window:
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -435,7 +435,7 @@ window:
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -514,7 +514,7 @@ window:
             // Rapidly re-render with different settings
             for (let i = 1; i <= 20; i++) {
                 const settings: UserSettings = {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                     window: { position: 'cursor', width: 800 + i * 10, height: 400 }
                 };
 
@@ -551,7 +551,7 @@ window:
             
             for (const width of stressWidths) {
                 const settings: UserSettings = {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                     window: { position: 'cursor', width: width, height: 400 }
                 };
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -426,7 +426,7 @@ describe('IPCHandlers', () => {
             const windowData = {
                 history: [{ text: 'test', timestamp: Date.now(), id: 'test-1' }],
                 settings: {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'ArrowDown', historyPrev: 'ArrowUp' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'ArrowDown', historyPrev: 'ArrowUp', search: 'Cmd+f' },
                     window: { position: 'cursor' as const, width: 800, height: 400 }
                 }
             };

--- a/tests/unit/settings-manager.test.ts
+++ b/tests/unit/settings-manager.test.ts
@@ -28,7 +28,7 @@ jest.mock('js-yaml', () => ({
   load: jest.fn((data: string) => {
     if (data.includes('main: Alt+Space')) {
       return {
-        shortcuts: { main: 'Alt+Space', paste: 'Enter', close: 'Escape' },
+        shortcuts: { main: 'Alt+Space', paste: 'Enter', close: 'Escape', search: 'Cmd+f' },
         window: { position: 'center', width: 800, height: 400 }
       };
     }
@@ -119,7 +119,8 @@ window:
           paste: 'Cmd+Enter',
           close: 'Escape',
           historyNext: 'Ctrl+j',
-          historyPrev: 'Ctrl+k'
+          historyPrev: 'Ctrl+k',
+          search: 'Cmd+f'
         },
         window: {
           position: 'active-window-center',
@@ -136,7 +137,8 @@ window:
           paste: 'Enter',
           close: 'Escape',
           historyNext: 'Ctrl+j',
-          historyPrev: 'Ctrl+k'
+          historyPrev: 'Ctrl+k',
+          search: 'Cmd+f'
         }
       };
 
@@ -211,7 +213,8 @@ window:
           paste: 'Cmd+Enter',
           close: 'Escape',
           historyNext: 'Ctrl+j',
-          historyPrev: 'Ctrl+k'
+          historyPrev: 'Ctrl+k',
+          search: 'Cmd+f'
         },
         window: {
           position: 'active-window-center',


### PR DESCRIPTION
## Summary
検索ボックス起動のショートカットキーをsettingsでカスタマイズ可能にする機能を実装しました。

## Changes
- 検索ショートカットキーの設定項目を追加（デフォルト: `Cmd+f`）
- ユーザー設定ファイル `~/.prompt-line/settings.yaml` で変更可能
- 検索ボタンのツールチップに現在のショートカットキーを表示
- ハードコードされた `Cmd+F` から動的設定に変更

### Modified Files
- `src/types/index.ts`: UserSettings型にsearchプロパティ追加
- `src/managers/settings-manager.ts`: デフォルト設定にsearch追加  
- `src/config/app-config.ts`: アプリケーション設定にsearch追加
- `src/renderer/event-handler.ts`: 動的検索ショートカット処理
- `src/renderer/utils/shortcut-formatter.ts`: 検索ボタンツールチップ更新
- テストファイル: shortcuts型のsearchプロパティ追加

## Test plan
- [x] TypeScript型チェック通過
- [x] 全テスト通過（16 test suites, 307 tests）
- [x] ESLint通過
- [x] アプリケーションビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)