### PR TITLE
feat(tray): add version display and release notes link to tray menu

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, globalShortcut, Tray, Menu, nativeImage } from 'electron';
+import { app, globalShortcut, Tray, Menu, nativeImage, shell } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
@@ -168,6 +168,17 @@ class PromptLineApp {
           label: 'Hide Window',
           click: async () => {
             await this.hideInputWindow();
+          }
+        },
+        { type: 'separator' },
+        {
+          label: `Version ${config.app.version}`,
+          enabled: false
+        },
+        {
+          label: 'Release Notes',
+          click: () => {
+            shell.openExternal('https://github.com/nkmr-jp/prompt-line/blob/main/CHANGELOG.md');
           }
         },
         { type: 'separator' },


### PR DESCRIPTION
## Summary
- Add current version display (Version 0.1.0) as disabled menu item in tray
- Add "Release Notes" menu item linking to GitHub CHANGELOG.md for checking latest updates
- Import shell module from electron for external link handling

## Test plan
- [x] Run TypeScript type checking (`npm run typecheck`)
- [x] Run all tests (`npm test`)
- [x] Verify pre-commit hooks pass
- [x] Manual testing: Right-click tray icon to verify new menu items appear
- [x] Manual testing: Click "Release Notes" to verify external link opens correctly

🤖 Generated with [Claude Code](https://claude.ai/code)