### PR TITLE
feat(history): add appName tracking to history items

### DIFF
--- a/src/handlers/ipc-handlers.ts
+++ b/src/handlers/ipc-handlers.ts
@@ -122,17 +122,27 @@ class IPCHandlers {
       }
 
 
+      // Get previous app info before hiding window
+      const previousApp = await this.getPreviousAppAsync();
+      
+      // Extract app name for history
+      let appName: string | undefined;
+      if (previousApp) {
+        if (typeof previousApp === 'string') {
+          appName = previousApp;
+        } else if (previousApp.name) {
+          appName = previousApp.name;
+        }
+      }
+
       await Promise.all([
-        this.historyManager.addToHistory(text),
+        this.historyManager.addToHistory(text, appName),
         this.draftManager.clearDraft(),
         this.setClipboardAsync(text)
       ]);
 
       const hideWindowPromise = this.windowManager.hideInputWindow();
-      const [, previousApp] = await Promise.all([
-        hideWindowPromise,
-        this.getPreviousAppAsync()
-      ]);
+      await hideWindowPromise;
 
       await sleep(Math.max(config.timing.windowHideDelay, 5));
 

--- a/src/managers/history-manager.ts
+++ b/src/managers/history-manager.ts
@@ -102,7 +102,7 @@ class HistoryManager implements IHistoryManager {
     }
   }
 
-  async addToHistory(text: string): Promise<HistoryItem | null> {
+  async addToHistory(text: string, appName?: string): Promise<HistoryItem | null> {
     try {
       const trimmedText = text.trim();
       if (!trimmedText) {
@@ -115,7 +115,8 @@ class HistoryManager implements IHistoryManager {
       const historyItem: HistoryItem = {
         text: trimmedText,
         timestamp: Date.now(),
-        id: generateId()
+        id: generateId(),
+        ...(appName && { appName })
       };
       
       this.historyData.unshift(historyItem);
@@ -125,6 +126,7 @@ class HistoryManager implements IHistoryManager {
       logger.debug('Added item to history (batch save queued):', { 
         id: historyItem.id, 
         length: trimmedText.length,
+        appName: appName || 'unknown',
         totalItems: this.historyData.length 
       });
       

--- a/src/managers/optimized-history-manager.ts
+++ b/src/managers/optimized-history-manager.ts
@@ -173,7 +173,7 @@ class OptimizedHistoryManager implements IHistoryManager {
     }, 100); // 100ms後に実行
   }
 
-  async addToHistory(text: string): Promise<HistoryItem | null> {
+  async addToHistory(text: string, appName?: string): Promise<HistoryItem | null> {
     try {
       const trimmedText = text.trim();
       if (!trimmedText) {
@@ -188,6 +188,9 @@ class OptimizedHistoryManager implements IHistoryManager {
         const existingItem = this.recentCache.find(item => item.text === trimmedText);
         if (existingItem) {
           existingItem.timestamp = Date.now();
+          if (appName) {
+            existingItem.appName = appName;
+          }
           this.recentCache.unshift(existingItem);
           return existingItem;
         }
@@ -196,7 +199,8 @@ class OptimizedHistoryManager implements IHistoryManager {
       const historyItem: HistoryItem = {
         text: trimmedText,
         timestamp: Date.now(),
-        id: generateId()
+        id: generateId(),
+        ...(appName && { appName })
       };
 
       // キャッシュに追加
@@ -221,6 +225,7 @@ class OptimizedHistoryManager implements IHistoryManager {
       logger.debug('Added item to history:', { 
         id: historyItem.id, 
         length: trimmedText.length,
+        appName: appName || 'unknown',
         cacheSize: this.recentCache.length,
         totalItems: this.totalItemCountCached ? this.totalItemCount : 'not calculated'
       });

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -13,6 +13,7 @@ export interface HistoryItem {
   text: string;
   timestamp: number;
   id: string;
+  appName?: string;
 }
 
 export interface AppInfo {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface HistoryItem {
   text: string;
   timestamp: number;
   id: string;
+  appName?: string;
 }
 
 export interface DraftData {
@@ -135,7 +136,7 @@ export interface ExportData {
 
 export interface IHistoryManager {
   initialize(): Promise<void>;
-  addToHistory(text: string): Promise<HistoryItem | null>;
+  addToHistory(text: string, appName?: string): Promise<HistoryItem | null>;
   getHistory(limit?: number): Promise<HistoryItem[]> | HistoryItem[];
   getHistoryItem(id: string): HistoryItem | null;
   getRecentHistory(limit?: number): HistoryItem[];

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -148,7 +148,7 @@ describe('IPCHandlers', () => {
             const result = await (ipcHandlers as any).handlePasteText(null, 'test text');
 
             expect(result.success).toBe(true);
-            expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith('test text');
+            expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith('test text', 'TestApp');
             expect(mockDraftManager.clearDraft).toHaveBeenCalled();
             expect(clipboard.writeText).toHaveBeenCalledWith('test text');
             expect(mockWindowManager.hideInputWindow).toHaveBeenCalled();
@@ -192,11 +192,13 @@ describe('IPCHandlers', () => {
             mockWindowManager.hideInputWindow.mockResolvedValue();
             mockWindowManager.focusPreviousApp.mockResolvedValue(true);
             pasteWithNativeTool.mockResolvedValue();
+            // Reset getPreviousApp to return the default mock value
+            mockWindowManager.getPreviousApp.mockReturnValue({ name: 'TestApp', bundleId: 'com.test.app' });
 
             await (ipcHandlers as any).handlePasteText(null, 'test text');
 
             expect(mockDraftManager.clearDraft).toHaveBeenCalledTimes(1);
-            expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith('test text');
+            expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith('test text', 'TestApp');
         });
 
         test('should clear draft even when paste fails', async () => {
@@ -204,12 +206,14 @@ describe('IPCHandlers', () => {
             mockWindowManager.hideInputWindow.mockResolvedValue();
             mockWindowManager.focusPreviousApp.mockResolvedValue(true);
             pasteWithNativeTool.mockRejectedValue(new Error('Paste script failed'));
+            // Reset getPreviousApp to return the default mock value
+            mockWindowManager.getPreviousApp.mockReturnValue({ name: 'TestApp', bundleId: 'com.test.app' });
 
             const result = await (ipcHandlers as any).handlePasteText(null, 'test text');
 
             expect(result.success).toBe(false);
             expect(mockDraftManager.clearDraft).toHaveBeenCalledTimes(1);
-            expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith('test text');
+            expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith('test text', 'TestApp');
         });
 
         test('should not clear draft when text is empty', async () => {


### PR DESCRIPTION
## Summary
- Add appName field to HistoryItem interface to track source application
- Update HistoryManager implementations to store app name with paste history
- Modify IPC handlers to extract app name from previous application info

## Changes
- **Types**: Add optional `appName` field to `HistoryItem` interface
- **HistoryManager**: Update `addToHistory` method to accept `appName` parameter
- **OptimizedHistoryManager**: Same updates for optimized implementation
- **IPC Handlers**: Extract app name from previous app info during paste operations
- **Tests**: Update test cases to handle new parameter structure

## Test plan
- [x] All existing tests pass (307/307)
- [x] TypeScript compilation successful
- [x] ESLint checks pass
- [x] Application builds successfully
- [x] New appName field properly stored in history.jsonl

🤖 Generated with [Claude Code](https://claude.ai/code)