### PR TITLE
feat(ui): implement dynamic shortcut display from settings

### DIFF
--- a/src/renderer/input.html
+++ b/src/renderer/input.html
@@ -39,7 +39,7 @@
             
             <div class="history-section">
                 <div class="history-header">
-                    <div class="history-title">History <span id="historyShortcuts" style="font-size: 10px; color: rgba(255, 255, 255, 0.4); font-weight: normal;"><kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">jk</kbd></span></div>
+                    <div class="history-title">History <span id="historyShortcuts" style="font-size: 10px; color: rgba(255, 255, 255, 0.4); font-weight: normal;"><kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">j</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">k</kbd></span></div>
                     
                     <!-- Search overlay moved inside history-header -->
                     <div class="search-overlay" id="searchOverlay">

--- a/src/renderer/utils/shortcut-formatter.ts
+++ b/src/renderer/utils/shortcut-formatter.ts
@@ -43,11 +43,19 @@ export function updateShortcutsDisplay(
     const historyNext = shortcuts.historyNext || 'Ctrl+j';
     const historyPrev = shortcuts.historyPrev || 'Ctrl+k';
     
-    // Extract key parts (e.g., "Ctrl+j" -> "j", "Ctrl+k" -> "k")
-    const nextKey = historyNext.split('+').pop() || 'j';
-    const prevKey = historyPrev.split('+').pop() || 'k';
+    // Format the shortcuts properly
+    const formattedNext = formatShortcut(historyNext);
+    const formattedPrev = formatShortcut(historyPrev);
     
-    historyShortcutsEl.innerHTML = `<kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">${nextKey}</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">${prevKey}</kbd>`;
+    // Extract modifier and key parts for both shortcuts
+    const nextParts = formattedNext.split('+');
+    const prevParts = formattedPrev.split('+');
+    
+    const nextModifier = nextParts.slice(0, -1).join('+');
+    const nextKey = nextParts[nextParts.length - 1];
+    const prevKey = prevParts[prevParts.length - 1];
+    
+    historyShortcutsEl.innerHTML = `<kbd style="font-size: 9px; padding: 1px 4px;">${nextModifier}</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">${nextKey}</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">${prevKey}</kbd>`;
   }
 
   // Update search button tooltip

--- a/tests/unit/utils/shortcut-formatter.test.ts
+++ b/tests/unit/utils/shortcut-formatter.test.ts
@@ -176,6 +176,6 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, historyShortcutsEl, shortcuts);
 
-    expect(historyShortcutsEl.innerHTML).toBe('<kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">j</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">k</kbd>');
+    expect(historyShortcutsEl.innerHTML).toBe('<kbd style="font-size: 9px; padding: 1px 4px;">⌘+⇧</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">j</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">k</kbd>');
   });
 });


### PR DESCRIPTION
## Summary
- Improve shortcut display to properly use dynamic values from settings.yaml
- Fix history navigation shortcut formatting to support complex modifier combinations
- Update HTML template for better shortcut display consistency

## Changes
- **shortcut-formatter.ts**: Enhanced to handle any modifier key combination (Cmd+Shift, Ctrl+Alt, etc.)
- **input.html**: Fixed history shortcut display format from "jk" to "j/k"
- **Tests**: Updated to match new dynamic formatting behavior

## Test plan
- [x] All existing tests pass
- [x] Shortcut formatter tests updated and passing
- [x] Manual testing shows shortcuts from settings.yaml are correctly displayed
- [x] Complex modifier combinations (e.g., Cmd+Shift+j) display correctly as ⌘+⇧+j

🤖 Generated with [Claude Code](https://claude.ai/code)