### PR TITLE
feat(settings): add Cmd+, shortcut and tray menu to open settings file

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -62,7 +62,8 @@ class AppConfigClass {
       close: 'Escape',
       historyNext: 'Ctrl+j',
       historyPrev: 'Ctrl+k',
-      search: 'Cmd+f'
+      search: 'Cmd+f',
+      settings: 'Cmd+,'
     };
 
     const userDataDir = path.join(os.homedir(), '.prompt-line');

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,21 +98,49 @@ class PromptLineApp {
   private registerShortcuts(): void {
     try {
       const settings = this.settingsManager?.getSettings();
-      const shortcut = settings?.shortcuts.main || config.shortcuts.main;
+      const mainShortcut = settings?.shortcuts.main || config.shortcuts.main;
+      const settingsShortcut = settings?.shortcuts.settings || config.shortcuts.settings;
       
-      const registered = globalShortcut.register(shortcut, async () => {
+      const mainRegistered = globalShortcut.register(mainShortcut, async () => {
         await this.showInputWindow();
       });
 
-      if (registered) {
-        logger.info('Global shortcut registered:', shortcut);
+      const settingsRegistered = globalShortcut.register(settingsShortcut, async () => {
+        await this.openSettingsFile();
+      });
+
+      if (mainRegistered) {
+        logger.info('Global shortcut registered:', mainShortcut);
       } else {
-        logger.error('Failed to register global shortcut:', shortcut);
-        throw new Error(`Failed to register shortcut: ${shortcut}`);
+        logger.error('Failed to register global shortcut:', mainShortcut);
+        throw new Error(`Failed to register shortcut: ${mainShortcut}`);
+      }
+
+      if (settingsRegistered) {
+        logger.info('Settings shortcut registered:', settingsShortcut);
+      } else {
+        logger.error('Failed to register settings shortcut:', settingsShortcut);
+        throw new Error(`Failed to register settings shortcut: ${settingsShortcut}`);
       }
     } catch (error) {
       logger.error('Error registering shortcuts:', error);
       throw error;
+    }
+  }
+
+  private async openSettingsFile(): Promise<void> {
+    try {
+      if (!this.settingsManager) {
+        logger.warn('Settings manager not initialized');
+        return;
+      }
+
+      const settingsFilePath = this.settingsManager.getSettingsFilePath();
+      logger.info('Opening settings file:', settingsFilePath);
+      
+      await shell.openPath(settingsFilePath);
+    } catch (error) {
+      logger.error('Failed to open settings file:', error);
     }
   }
 
@@ -168,6 +196,13 @@ class PromptLineApp {
           label: 'Hide Window',
           click: async () => {
             await this.hideInputWindow();
+          }
+        },
+        { type: 'separator' },
+        {
+          label: 'Settings',
+          click: async () => {
+            await this.openSettingsFile();
           }
         },
         { type: 'separator' },

--- a/src/managers/settings-manager.ts
+++ b/src/managers/settings-manager.ts
@@ -20,7 +20,8 @@ class SettingsManager {
         close: 'Escape',
         historyNext: 'Ctrl+j',
         historyPrev: 'Ctrl+k',
-        search: 'Cmd+f'
+        search: 'Cmd+f',
+        settings: 'Cmd+,'
       },
       window: {
         position: 'active-text-field',
@@ -129,6 +130,10 @@ shortcuts:
   # Shortcut to enable search mode in history
   # Used to filter paste history items
   search: ${settings.shortcuts.search}
+  
+  # Shortcut to open settings file for editing
+  # Opens the settings.yaml file in the default editor
+  settings: ${settings.shortcuts.settings}
 
 # Window appearance and positioning configuration
 window:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,7 @@ export interface ShortcutsConfig {
   historyNext: string;
   historyPrev: string;
   search: string;
+  settings: string;
 }
 
 export interface PathsConfig {
@@ -168,6 +169,7 @@ export interface UserSettings {
     historyNext: string;
     historyPrev: string;
     search: string;
+    settings: string;
   };
   window: {
     position: StartupPosition;

--- a/tests/integration/app-integration.test.ts
+++ b/tests/integration/app-integration.test.ts
@@ -79,7 +79,7 @@ describe('DOM Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -113,7 +113,7 @@ describe('DOM Integration Tests', () => {
 
         test('should handle empty history', () => {
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -136,7 +136,7 @@ describe('DOM Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -158,7 +158,7 @@ describe('DOM Integration Tests', () => {
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 

--- a/tests/integration/error-handling.test.ts
+++ b/tests/integration/error-handling.test.ts
@@ -107,7 +107,7 @@ describe('Error Handling Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -223,7 +223,7 @@ more broken content: }}}
 
             // Test partial settings
             const partialSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 800, height: 400 }
             } as any;
 
@@ -253,7 +253,7 @@ window:
             }));
 
             const invalidSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 'not_a_number', height: 400 }
             } as any;
 
@@ -334,7 +334,7 @@ window:
 
             // Simulate disk space issues by testing with very large settings objects
             const hugeSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 800, height: 400 },
                 // Add large data to simulate memory pressure
                 largeData: new Array(1000).fill('large_data_item')
@@ -360,7 +360,7 @@ window:
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -390,7 +390,7 @@ window:
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -435,7 +435,7 @@ window:
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -514,7 +514,7 @@ window:
             // Rapidly re-render with different settings
             for (let i = 1; i <= 20; i++) {
                 const settings: UserSettings = {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                     window: { position: 'cursor', width: 800 + i * 10, height: 400 }
                 };
 
@@ -551,7 +551,7 @@ window:
             
             for (const width of stressWidths) {
                 const settings: UserSettings = {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
                     window: { position: 'cursor', width: width, height: 400 }
                 };
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -430,7 +430,7 @@ describe('IPCHandlers', () => {
             const windowData = {
                 history: [{ text: 'test', timestamp: Date.now(), id: 'test-1' }],
                 settings: {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'ArrowDown', historyPrev: 'ArrowUp', search: 'Cmd+f' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'ArrowDown', historyPrev: 'ArrowUp', search: 'Cmd+f', settings: 'Cmd+,' },
                     window: { position: 'cursor' as const, width: 800, height: 400 }
                 }
             };

--- a/tests/unit/settings-manager.test.ts
+++ b/tests/unit/settings-manager.test.ts
@@ -120,7 +120,8 @@ window:
           close: 'Escape',
           historyNext: 'Ctrl+j',
           historyPrev: 'Ctrl+k',
-          search: 'Cmd+f'
+          search: 'Cmd+f',
+          settings: 'Cmd+,'
         },
         window: {
           position: 'active-text-field',
@@ -138,7 +139,8 @@ window:
           close: 'Escape',
           historyNext: 'Ctrl+j',
           historyPrev: 'Ctrl+k',
-          search: 'Cmd+f'
+          search: 'Cmd+f',
+          settings: 'Cmd+,'
         }
       };
 
@@ -214,7 +216,8 @@ window:
           close: 'Escape',
           historyNext: 'Ctrl+j',
           historyPrev: 'Ctrl+k',
-          search: 'Cmd+f'
+          search: 'Cmd+f',
+          settings: 'Cmd+,'
         },
         window: {
           position: 'active-text-field',


### PR DESCRIPTION
## Summary
- Add Cmd+, keyboard shortcut to open settings.yaml file in default editor
- Add Settings menu item to system tray for easy access
- Enhance user experience with convenient settings access

## Implementation Details
- **New Shortcut**: Added `settings: 'Cmd+,'` to shortcuts configuration
- **Global Registration**: Register Cmd+, shortcut in main process to call `openSettingsFile()`
- **Tray Integration**: Add Settings menu item between Hide Window and Version sections
- **Cross-platform**: Uses `shell.openPath()` for reliable file opening across platforms
- **Type Safety**: Updated TypeScript interfaces for proper type checking

## Technical Changes
- Updated `ShortcutsConfig` and `UserSettings` interfaces to include settings shortcut
- Modified `app-config.ts` and `settings-manager.ts` to include default Cmd+, shortcut
- Enhanced `main.ts` with settings shortcut registration and tray menu item
- Updated all test fixtures to maintain compatibility with new shortcut structure

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] All unit tests pass (307 tests)
- [x] Integration tests updated and passing
- [x] Build process completes successfully
- [x] Settings shortcut properly registered in main process
- [x] Tray menu includes Settings option

🤖 Generated with [Claude Code](https://claude.ai/code)