### PR TITLE
feat(settings): change settings shortcut to local-only and remove from config

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -62,8 +62,7 @@ class AppConfigClass {
       close: 'Escape',
       historyNext: 'Ctrl+j',
       historyPrev: 'Ctrl+k',
-      search: 'Cmd+f',
-      settings: 'Cmd+,'
+      search: 'Cmd+f'
     };
 
     const userDataDir = path.join(os.homedir(), '.prompt-line');

--- a/src/handlers/ipc-handlers.ts
+++ b/src/handlers/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, clipboard, IpcMainInvokeEvent, dialog } from 'electron';
+import { ipcMain, clipboard, IpcMainInvokeEvent, dialog, shell } from 'electron';
 import { promises as fs } from 'fs';
 import { exec } from 'child_process';
 import path from 'path';
@@ -98,6 +98,7 @@ class IPCHandlers {
     ipcMain.handle('get-settings', this.handleGetSettings.bind(this));
     ipcMain.handle('update-settings', this.handleUpdateSettings.bind(this));
     ipcMain.handle('reset-settings', this.handleResetSettings.bind(this));
+    ipcMain.handle('open-settings', this.handleOpenSettings.bind(this));
 
     logger.info('IPC handlers set up successfully');
   }
@@ -535,6 +536,19 @@ class IPCHandlers {
     }
   }
 
+  private async handleOpenSettings(_event: IpcMainInvokeEvent): Promise<IPCResult> {
+    try {
+      const settingsFilePath = this.settingsManager.getSettingsFilePath();
+      logger.info('Opening settings file:', settingsFilePath);
+      
+      await shell.openPath(settingsFilePath);
+      return { success: true };
+    } catch (error) {
+      logger.error('Failed to open settings file:', error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
   removeAllHandlers(): void {
     const handlers = [
       'paste-text',
@@ -554,7 +568,8 @@ class IPCHandlers {
       'paste-image',
       'get-settings',
       'update-settings',
-      'reset-settings'
+      'reset-settings',
+      'open-settings'
     ];
 
     handlers.forEach(handler => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,14 +99,9 @@ class PromptLineApp {
     try {
       const settings = this.settingsManager?.getSettings();
       const mainShortcut = settings?.shortcuts.main || config.shortcuts.main;
-      const settingsShortcut = settings?.shortcuts.settings || config.shortcuts.settings;
       
       const mainRegistered = globalShortcut.register(mainShortcut, async () => {
         await this.showInputWindow();
-      });
-
-      const settingsRegistered = globalShortcut.register(settingsShortcut, async () => {
-        await this.openSettingsFile();
       });
 
       if (mainRegistered) {
@@ -114,13 +109,6 @@ class PromptLineApp {
       } else {
         logger.error('Failed to register global shortcut:', mainShortcut);
         throw new Error(`Failed to register shortcut: ${mainShortcut}`);
-      }
-
-      if (settingsRegistered) {
-        logger.info('Settings shortcut registered:', settingsShortcut);
-      } else {
-        logger.error('Failed to register settings shortcut:', settingsShortcut);
-        throw new Error(`Failed to register settings shortcut: ${settingsShortcut}`);
       }
     } catch (error) {
       logger.error('Error registering shortcuts:', error);

--- a/src/managers/settings-manager.ts
+++ b/src/managers/settings-manager.ts
@@ -20,8 +20,7 @@ class SettingsManager {
         close: 'Escape',
         historyNext: 'Ctrl+j',
         historyPrev: 'Ctrl+k',
-        search: 'Cmd+f',
-        settings: 'Cmd+,'
+        search: 'Cmd+f'
       },
       window: {
         position: 'active-text-field',
@@ -130,10 +129,6 @@ shortcuts:
   # Shortcut to enable search mode in history
   # Used to filter paste history items
   search: ${settings.shortcuts.search}
-  
-  # Shortcut to open settings file for editing
-  # Opens the settings.yaml file in the default editor
-  settings: ${settings.shortcuts.settings}
 
 # Window appearance and positioning configuration
 window:

--- a/src/renderer/event-handler.ts
+++ b/src/renderer/event-handler.ts
@@ -177,6 +177,19 @@ export class EventHandler {
         }
       }
 
+      // Handle Cmd+, for opening settings (local shortcut only when window is active)
+      if (e.key === ',' && e.metaKey) {
+        e.preventDefault();
+        
+        try {
+          await ipcRenderer.invoke('open-settings');
+          console.log('Settings file opened');
+        } catch (error) {
+          console.error('Failed to open settings:', error);
+        }
+        return;
+      }
+
       // Image paste is handled by PromptLineRenderer to avoid duplication
     } catch (error) {
       console.error('Error handling keydown:', error);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,7 +84,6 @@ export interface ShortcutsConfig {
   historyNext: string;
   historyPrev: string;
   search: string;
-  settings: string;
 }
 
 export interface PathsConfig {
@@ -169,7 +168,6 @@ export interface UserSettings {
     historyNext: string;
     historyPrev: string;
     search: string;
-    settings: string;
   };
   window: {
     position: StartupPosition;

--- a/tests/integration/app-integration.test.ts
+++ b/tests/integration/app-integration.test.ts
@@ -79,7 +79,7 @@ describe('DOM Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -113,7 +113,7 @@ describe('DOM Integration Tests', () => {
 
         test('should handle empty history', () => {
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -136,7 +136,7 @@ describe('DOM Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 
@@ -158,7 +158,7 @@ describe('DOM Integration Tests', () => {
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Cmd+Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 600, height: 300 }
             };
 

--- a/tests/integration/error-handling.test.ts
+++ b/tests/integration/error-handling.test.ts
@@ -107,7 +107,7 @@ describe('Error Handling Integration Tests', () => {
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -223,7 +223,7 @@ more broken content: }}}
 
             // Test partial settings
             const partialSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             } as any;
 
@@ -253,7 +253,7 @@ window:
             }));
 
             const invalidSettings = {
-                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Shift+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 'not_a_number', height: 400 }
             } as any;
 
@@ -334,7 +334,7 @@ window:
 
             // Simulate disk space issues by testing with very large settings objects
             const hugeSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 },
                 // Add large data to simulate memory pressure
                 largeData: new Array(1000).fill('large_data_item')
@@ -360,7 +360,7 @@ window:
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -390,7 +390,7 @@ window:
             }));
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -435,7 +435,7 @@ window:
             ];
 
             const settings: UserSettings = {
-                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                 window: { position: 'cursor', width: 800, height: 400 }
             };
 
@@ -514,7 +514,7 @@ window:
             // Rapidly re-render with different settings
             for (let i = 1; i <= 20; i++) {
                 const settings: UserSettings = {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                     window: { position: 'cursor', width: 800 + i * 10, height: 400 }
                 };
 
@@ -551,7 +551,7 @@ window:
             
             for (const width of stressWidths) {
                 const settings: UserSettings = {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f', settings: 'Cmd+,' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'Ctrl+j', historyPrev: 'Ctrl+k', search: 'Cmd+f' },
                     window: { position: 'cursor', width: width, height: 400 }
                 };
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -430,7 +430,7 @@ describe('IPCHandlers', () => {
             const windowData = {
                 history: [{ text: 'test', timestamp: Date.now(), id: 'test-1' }],
                 settings: {
-                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'ArrowDown', historyPrev: 'ArrowUp', search: 'Cmd+f', settings: 'Cmd+,' },
+                    shortcuts: { main: 'Cmd+Space', paste: 'Enter', close: 'Escape', historyNext: 'ArrowDown', historyPrev: 'ArrowUp', search: 'Cmd+f' },
                     window: { position: 'cursor' as const, width: 800, height: 400 }
                 }
             };
@@ -496,7 +496,7 @@ describe('IPCHandlers', () => {
             ipcHandlers.removeAllHandlers();
 
             // Should be called for each handler (including new settings handlers)
-            expect(ipcMain.removeAllListeners).toHaveBeenCalledTimes(18);
+            expect(ipcMain.removeAllListeners).toHaveBeenCalledTimes(19);
             expect(logger.info).toHaveBeenCalledWith('All IPC handlers removed');
         });
     });

--- a/tests/unit/settings-manager.test.ts
+++ b/tests/unit/settings-manager.test.ts
@@ -120,8 +120,7 @@ window:
           close: 'Escape',
           historyNext: 'Ctrl+j',
           historyPrev: 'Ctrl+k',
-          search: 'Cmd+f',
-          settings: 'Cmd+,'
+          search: 'Cmd+f'
         },
         window: {
           position: 'active-text-field',
@@ -139,8 +138,7 @@ window:
           close: 'Escape',
           historyNext: 'Ctrl+j',
           historyPrev: 'Ctrl+k',
-          search: 'Cmd+f',
-          settings: 'Cmd+,'
+          search: 'Cmd+f'
         }
       };
 
@@ -216,8 +214,7 @@ window:
           close: 'Escape',
           historyNext: 'Ctrl+j',
           historyPrev: 'Ctrl+k',
-          search: 'Cmd+f',
-          settings: 'Cmd+,'
+          search: 'Cmd+f'
         },
         window: {
           position: 'active-text-field',
@@ -254,4 +251,5 @@ window:
       await expect(settingsManager.init()).rejects.toThrow('Permission denied');
     });
   });
+
 });


### PR DESCRIPTION
## Summary
- Remove global settings shortcut registration (Cmd+,) and make it local-only when the window is active
- Remove settings shortcut from default configuration and user settings
- Add new IPC handler for opening settings file
- Update all related tests and type definitions

## Changes
- **Settings shortcut behavior**: Changed from global to local-only (Cmd+, works only when app window is focused)
- **Configuration cleanup**: Removed settings shortcut from default config and user settings schema
- **IPC enhancement**: Added `open-settings` IPC handler to handle settings file opening
- **Type safety**: Updated TypeScript interfaces to reflect removed settings shortcut
- **Test coverage**: Updated all tests to match new configuration structure

## Benefits
- Reduces global shortcut conflicts with other applications
- Maintains settings access when the app is active
- Cleaner configuration with fewer global shortcuts
- Better user experience with context-aware shortcuts

## Test plan
- [x] All existing tests pass with updated configuration
- [x] Settings can still be opened with Cmd+, when app window is focused
- [x] No global shortcut conflicts with other applications
- [x] IPC handler correctly opens settings file

🤖 Generated with [Claude Code](https://claude.ai/code)