### PR TITLE
fix: resolve CSP inline style violation and improve image naming

### DIFF
--- a/src/handlers/ipc-handlers.ts
+++ b/src/handlers/ipc-handlers.ts
@@ -428,8 +428,15 @@ class IPCHandlers {
         logger.error('Failed to create images directory:', error);
       }
 
-      const timestamp = Date.now();
-      const filename = `image-${timestamp}.png`;
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, '0');
+      const day = String(now.getDate()).padStart(2, '0');
+      const hours = String(now.getHours()).padStart(2, '0');
+      const minutes = String(now.getMinutes()).padStart(2, '0');
+      const seconds = String(now.getSeconds()).padStart(2, '0');
+      
+      const filename = `${year}${month}${day}_${hours}${minutes}${seconds}.png`;
       const filepath = path.join(imagesDir, filename);
       
       // Normalize and validate path to prevent path traversal

--- a/src/renderer/styles/layout/history-section.css
+++ b/src/renderer/styles/layout/history-section.css
@@ -54,7 +54,8 @@
     font-weight: normal;
 }
 
-.history-shortcuts kbd {
+.history-shortcuts kbd,
+.history-kbd {
     font-size: 9px;
     padding: 1px 4px;
 }

--- a/src/renderer/utils/shortcut-formatter.ts
+++ b/src/renderer/utils/shortcut-formatter.ts
@@ -55,7 +55,7 @@ export function updateShortcutsDisplay(
     const nextKey = nextParts[nextParts.length - 1];
     const prevKey = prevParts[prevParts.length - 1];
     
-    historyShortcutsEl.innerHTML = `<kbd style="font-size: 9px; padding: 1px 4px;">${nextModifier}</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">${nextKey}</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">${prevKey}</kbd>`;
+    historyShortcutsEl.innerHTML = `<kbd class="history-kbd">${nextModifier}</kbd>+<kbd class="history-kbd">${nextKey}</kbd>/<kbd class="history-kbd">${prevKey}</kbd>`;
   }
 
   // Update search button tooltip

--- a/tests/unit/utils/shortcut-formatter.test.ts
+++ b/tests/unit/utils/shortcut-formatter.test.ts
@@ -100,7 +100,7 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, historyShortcutsEl, shortcuts);
 
-    expect(historyShortcutsEl.innerHTML).toBe('<kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">j</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">k</kbd>');
+    expect(historyShortcutsEl.innerHTML).toBe('<kbd class="history-kbd">Ctrl</kbd>+<kbd class="history-kbd">j</kbd>/<kbd class="history-kbd">k</kbd>');
   });
 
   test('should use default history shortcuts when not provided', () => {
@@ -111,7 +111,7 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, historyShortcutsEl, shortcuts);
 
-    expect(historyShortcutsEl.innerHTML).toBe('<kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">j</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">k</kbd>');
+    expect(historyShortcutsEl.innerHTML).toBe('<kbd class="history-kbd">Ctrl</kbd>+<kbd class="history-kbd">j</kbd>/<kbd class="history-kbd">k</kbd>');
   });
 
   test('should handle complex paste shortcuts', () => {
@@ -163,7 +163,7 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(null, historyShortcutsEl, shortcuts);
 
-    expect(historyShortcutsEl.innerHTML).toBe('<kbd style="font-size: 9px; padding: 1px 4px;">Ctrl</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">Down</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">Up</kbd>');
+    expect(historyShortcutsEl.innerHTML).toBe('<kbd class="history-kbd">Ctrl</kbd>+<kbd class="history-kbd">Down</kbd>/<kbd class="history-kbd">Up</kbd>');
   });
 
   test('should extract key from complex shortcuts', () => {
@@ -176,6 +176,6 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, historyShortcutsEl, shortcuts);
 
-    expect(historyShortcutsEl.innerHTML).toBe('<kbd style="font-size: 9px; padding: 1px 4px;">⌘+⇧</kbd>+<kbd style="font-size: 9px; padding: 1px 4px;">j</kbd>/<kbd style="font-size: 9px; padding: 1px 4px;">k</kbd>');
+    expect(historyShortcutsEl.innerHTML).toBe('<kbd class="history-kbd">⌘+⇧</kbd>+<kbd class="history-kbd">j</kbd>/<kbd class="history-kbd">k</kbd>');
   });
 });


### PR DESCRIPTION
## Summary
- Fixed CSP inline style violation in history keyboard shortcuts by replacing inline styles with CSS classes
- Improved image naming format from `image-{timestamp}.png` to `YYYYMMDD_HHMMSS.png` for better readability and sorting
- Updated tests to match the new CSS class-based approach

## Changes Made
1. **CSP Compliance**: Replaced inline styles with `.history-kbd` CSS class in `shortcut-formatter.ts`
2. **Image Naming**: Changed timestamp format in `ipc-handlers.ts` to use human-readable date format
3. **Test Updates**: Updated `shortcut-formatter.test.ts` to match new CSS class expectations

## Test Plan
- [x] All existing tests pass
- [x] CSS styles are properly applied via external stylesheet
- [x] Image naming follows new format pattern
- [x] No CSP violations occur during keyboard shortcut display

🤖 Generated with [Claude Code](https://claude.ai/code)