### PR TITLE
docs: add DeepWiki badge to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [English](README.md) | [日本語](README_ja.md)
 
 # 🧑‍💻 Prompt Line
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nkmr-jp/prompt-line)
 
 macOS floating text input tool that enables quick text entry across any application.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,6 +1,7 @@
 [English](README.md) | [日本語](README_ja.md)
 
 # 🧑‍💻 Prompt Line
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nkmr-jp/prompt-line)
 
 macOS用フローティングテキスト入力ツール。あらゆるアプリケーションで素早くテキスト入力が可能です。
 


### PR DESCRIPTION
## Summary
- Added DeepWiki AI code search badge to README files for enhanced documentation accessibility

## Test plan
- [x] Verified badge displays correctly in README
- [x] Confirmed link functionality to DeepWiki search

🤖 Generated with [Claude Code](https://claude.ai/code)