### PR TITLE
fix(deps): update js-yaml to 4.1.1 and enforce via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2016,16 +2016,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2038,20 +2028,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -2105,13 +2081,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -7495,20 +7464,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {

--- a/package.json
+++ b/package.json
@@ -159,5 +159,8 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.1"
+  },
+  "overrides": {
+    "js-yaml": "^4.1.1"
   }
 }


### PR DESCRIPTION
## Summary

- Update direct dependency js-yaml from 4.1.0 to 4.1.1 to fix Prototype Pollution vulnerability (CVE-2025-64718)
- Add npm overrides to enforce js-yaml 4.1.1 across all dependencies, removing outdated 3.14.1 from transitive dependencies
- Reduce security vulnerabilities from 21 to 3

## Details

### Direct Dependency Update (Commit e366778)
- Updated `js-yaml` from `^4.1.0` to `^4.1.1` in dependencies
- Resolves CVE-2025-64718 (GHSA-mh29-5h37-fv8m) - Prototype Pollution vulnerability
- Addresses Dependabot alert #11

### Transitive Dependency Fix (Commit 4862547)
- Added `overrides` field to package.json to enforce js-yaml ^4.1.1
- Removed js-yaml 3.14.1 (from 2020) that was pulled in by @istanbuljs/load-nyc-config
- Dependency chain: jest → @jest/transform → babel-plugin-istanbul → @istanbuljs/load-nyc-config → js-yaml 3.14.1

### Security Impact
- **Before**: 21 vulnerabilities (2 low, 19 moderate)
- **After**: 3 vulnerabilities (2 low, 1 moderate)
- **Removed packages**: 4 (including old js-yaml and its dependencies)

## Test Plan

- [x] All tests passing (16 test suites, 335 tests)
- [x] TypeScript compilation successful
- [x] Vite renderer build successful
- [x] Native tools (Swift) compilation successful
- [x] Verify js-yaml 3.14.1 removed from package-lock.json
- [x] Verify all js-yaml references point to 4.1.1

## References

- Dependabot Alert: https://github.com/nkmr-jp/prompt-line/security/dependabot/11
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-64718
- GHSA: https://github.com/nodeca/js-yaml/security/advisories/GHSA-mh29-5h37-fv8m

🤖 Generated with [Claude Code](https://claude.com/claude-code)