### PR TITLE
chore: add build cleanup scripts and troubleshooting guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ npm run pre-push   # Run all pre-push checks (lint + typecheck + test)
 
 # Additional build commands
 npm run build:renderer  # Vite build for renderer process
-npm run clean      # Removes build artifacts
+npm run clean      # Removes build artifacts (DMG, zip files, etc.)
+npm run clean:cache     # Clears build caches (node_modules/.cache, electron caches)
+npm run clean:full      # Full cleanup (build artifacts + caches + dist directory)
 npm run release    # Semantic release process
 npm run prepare    # Husky setup
 ```
@@ -268,6 +270,89 @@ The window supports multiple positioning modes with dynamic configuration:
 - **Explicit permissions**: Requires user accessibility permissions with guided setup
 - **Local data only**: All data stored locally, no network requests
 - **JSON communication**: Structured data exchange prevents parsing attacks
+
+## Common Build Issues and Troubleshooting
+
+### Build Failures
+
+#### electron-builder ENOENT Error
+If you encounter an error like `ENOENT: no such file or directory, rename '...Electron' -> '...Prompt Line'`:
+
+**Root Cause:** Corrupted electron-builder cache or incomplete Electron binary download.
+
+**Solution:**
+```bash
+# Full cleanup and rebuild
+npm run clean:full
+npm install
+npm run build
+```
+
+**Quick Fix (cache only):**
+```bash
+npm run clean:cache
+npm run build
+```
+
+#### TypeScript Compilation Errors
+If `tsc` command is not found or TypeScript compilation fails:
+
+**Solution:**
+```bash
+# Reinstall dependencies
+npm install
+npm run build
+```
+
+#### Native Tools Compilation Errors
+If Swift compilation fails for native tools:
+
+**Common Issues:**
+- Xcode Command Line Tools not installed
+- Incompatible macOS SDK version
+
+**Solution:**
+```bash
+# Install Xcode Command Line Tools
+xcode-select --install
+
+# Verify installation
+xcode-select -p
+```
+
+### Performance Issues
+
+#### Slow Build Times
+- Use `npm run compile` instead of full `npm run build` for faster development iterations
+- Native tools are cached after first compilation
+- Consider using SSD for faster I/O operations
+
+#### Large Distribution Size
+- DMG files are ~100-110MB per architecture (expected size)
+- App bundle contains full Electron framework
+- Use `npm run clean` to remove old build artifacts
+
+### Cleanup Commands Reference
+
+| Command | Purpose | When to Use |
+|---------|---------|-------------|
+| `npm run clean` | Remove build artifacts only | After each build to clean up DMG/zip files |
+| `npm run clean:cache` | Clear build caches | When experiencing cache-related build issues |
+| `npm run clean:full` | Complete cleanup | Before fresh build or when troubleshooting build errors |
+
+### Build Process Verification
+
+To verify a successful build:
+```bash
+# Check generated files
+ls -lh dist/*.dmg
+
+# Verify app bundles exist
+ls -la dist/mac*/Prompt\ Line.app
+
+# Check native tools
+ls -la dist/mac*/Prompt\ Line.app/Contents/Resources/app.asar.unpacked/dist/native-tools/
+```
 
 ## Investigation and Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "typecheck": "tsc --noEmit",
     "build": "npm run compile && electron-builder --mac --publish=never",
     "clean": "rm -rf dist/mac* dist/*.dmg dist/*.zip dist/*.blockmap",
+    "clean:cache": "rm -rf node_modules/.cache ~/Library/Caches/electron-builder ~/Library/Caches/electron",
+    "clean:full": "npm run clean && npm run clean:cache && rm -rf dist/",
     "release": "semantic-release",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- Add comprehensive cleanup commands for build artifacts and caches
- Add detailed troubleshooting guide for common build issues
- Document electron-builder ENOENT error resolution

## Changes

### package.json
- Add `npm run clean:cache` - Clear electron-builder and node caches
- Add `npm run clean:full` - Complete cleanup (artifacts + caches + dist)

### CLAUDE.md
- Add "Common Build Issues and Troubleshooting" section
- Document electron-builder ENOENT error solution
- Add TypeScript compilation error troubleshooting
- Add Native Tools compilation error troubleshooting
- Include performance optimization tips
- Add cleanup commands reference table
- Add build verification commands

## Problem Solved
This PR resolves recurring build cache issues encountered during electron-builder packaging, where corrupted caches cause ENOENT errors when renaming Electron binaries.

## Test Plan
- [x] Build succeeds with `npm run build`
- [x] `npm run clean:cache` clears all relevant caches
- [x] `npm run clean:full` performs complete cleanup
- [x] Documentation is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)