### PR TITLE
feat(logging): control DEBUG log output based on environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Development
 ```bash
-npm start          # Run app in production mode
+npm start          # Run app in development mode (with DEBUG logging enabled)
 npm run reset-accessibility  # Reset accessibility permissions for Prompt Line
 ```
+
+**Development vs Production Modes:**
+- **Development Mode** (`npm start`):
+  - Sets `NODE_ENV=development`
+  - Enables DEBUG level logging
+  - Shows detailed debug information in console and log files
+  - Only active when running `npm start` (not in packaged builds)
+
+- **Production Mode** (packaged app):
+  - Built apps always use INFO level logging (DEBUG logs disabled)
+  - Determined by `app.isPackaged` status
+  - Provides cleaner logs for end users
 
 ### Testing
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Prompt Line is a macOS app developed to improve the prompt input experience in the terminal for CLI-based AI coding agents such as Claude Code, OpenAI Codex CLI, and Aider.",
   "main": "dist/main.js",
   "scripts": {
-    "start": "npm run compile && electron .",
+    "start": "NODE_ENV=development npm run compile && NODE_ENV=development electron .",
     "compile": "tsc && npm run build:renderer && cd native && make install && cp -r ../src/native-tools ../dist/",
     "build:renderer": "vite build && cp src/renderer/input.html dist/renderer/input.html && cp -r src/renderer/styles dist/renderer/",
     "typecheck": "tsc --noEmit",
-    "build": "npm run compile && electron-builder --mac --publish=never",
+    "build": "NODE_ENV=production npm run compile && NODE_ENV=production electron-builder --mac --publish=never",
     "clean": "rm -rf dist/mac* dist/*.dmg dist/*.zip dist/*.blockmap",
     "clean:cache": "rm -rf node_modules/.cache ~/Library/Caches/electron-builder ~/Library/Caches/electron",
     "clean:full": "npm run clean && npm run clean:cache && rm -rf dist/",

--- a/src/config/CLAUDE.md
+++ b/src/config/CLAUDE.md
@@ -93,13 +93,37 @@ platform: {
 
 **Logging System:**
 ```typescript
+// Determine log level based on environment and packaging status
+let logLevel: LogLevel = 'info'; // Default to info
+
+// Only enable debug logging in development mode when not packaged
+try {
+  const electron = require('electron');
+  const app = electron.app;
+
+  if (process.env.NODE_ENV === 'development' && !app?.isPackaged) {
+    logLevel = 'debug';
+  }
+} catch {
+  // Electron not available (e.g., in tests), use NODE_ENV only
+  if (process.env.NODE_ENV === 'development') {
+    logLevel = 'debug';
+  }
+}
+
 logging: {
-  level: (process.env.NODE_ENV === 'development' ? 'debug' : 'info') as LogLevel,
+  level: logLevel,                   // DEBUG in dev mode, INFO in production/packaged
   enableFileLogging: true,
   maxLogFileSize: 5 * 1024 * 1024,  // 5MB
   maxLogFiles: 3                     // Rotation limit
 }
 ```
+- **Intelligent Log Level Selection**:
+  - Development mode (`npm start`): Uses DEBUG level when `NODE_ENV=development` and app is not packaged
+  - Production/Packaged mode: Always uses INFO level (DEBUG logs disabled)
+  - Test mode: Falls back to NODE_ENV check when Electron is unavailable
+- **Dual Condition Check**: Requires both `NODE_ENV=development` AND `!app.isPackaged` for DEBUG logging
+- **Safe Fallback**: Uses try-catch to handle cases where Electron app object is unavailable
 
 ## Key Responsibilities
 

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -115,8 +115,26 @@ class AppConfigClass {
       isLinux: process.platform === 'linux'
     };
 
+    // Determine log level based on environment and packaging status
+    let logLevel: LogLevel = 'info'; // Default to info
+
+    // Only enable debug logging in development mode when not packaged
+    try {
+      const electron = require('electron');
+      const app = electron.app;
+
+      if (process.env.NODE_ENV === 'development' && !app?.isPackaged) {
+        logLevel = 'debug';
+      }
+    } catch {
+      // Electron not available (e.g., in tests), use NODE_ENV only
+      if (process.env.NODE_ENV === 'development') {
+        logLevel = 'debug';
+      }
+    }
+
     this.logging = {
-      level: (process.env.NODE_ENV === 'development' ? 'debug' : 'info') as LogLevel,
+      level: logLevel,
       enableFileLogging: true,
       maxLogFileSize: 5 * 1024 * 1024,
       maxLogFiles: 3


### PR DESCRIPTION
## Summary
- Implemented environment-based DEBUG log control
- DEBUG logs are now only shown during development (`npm start`)
- Production/packaged builds only show INFO level logs

## Changes
- Updated `package.json`:
  - `npm start`: Sets `NODE_ENV=development` (enables DEBUG logs)
  - `npm run build`: Sets `NODE_ENV=production` (INFO logs only)
- Modified `src/config/app-config.ts`:
  - Added intelligent log level detection
  - Requires both `NODE_ENV=development` AND `!app.isPackaged` for DEBUG logging
  - Packaged apps always use INFO level
- Updated documentation:
  - `CLAUDE.md`: Added Development vs Production modes explanation
  - `src/config/CLAUDE.md`: Documented log level control implementation

## Test plan
- [x] All tests pass (`npm test`)
- [x] TypeScript type checking passes (`npm run typecheck`)
- [ ] Manual verification: Run `npm start` and verify DEBUG logs appear
- [ ] Manual verification: Build and run packaged app, verify only INFO logs appear

## Related
Ref: TOOLS-497

🤖 Generated with [Claude Code](https://claude.com/claude-code)