### PR TITLE
fix(file-search): apply excludePatterns during include pattern searches

### DIFF
--- a/native/directory-detector.swift
+++ b/native/directory-detector.swift
@@ -1173,14 +1173,14 @@ class DirectoryDetector {
             args.append(String(depth))
         }
 
-        // Exclude patterns (only for normal search, not include patterns)
-        if includePattern == nil {
-            for exclude in excludePatterns {
-                args.append("--exclude")
-                args.append(exclude)
-            }
+        // Exclude patterns (always apply user-specified excludes)
+        for exclude in excludePatterns {
+            args.append("--exclude")
+            args.append(exclude)
+        }
 
-            // Add default excludes
+        // Add default excludes only for normal search (not include patterns)
+        if includePattern == nil {
             for exclude in DEFAULT_EXCLUDES {
                 args.append("--exclude")
                 args.append(exclude)
@@ -1587,7 +1587,7 @@ class DirectoryDetector {
                         fdPath: fdPath,
                         directory: directory,
                         respectGitignore: false,  // Ignore .gitignore for include patterns
-                        excludePatterns: [],      // No excludes for include patterns
+                        excludePatterns: settings.excludePatterns,  // Apply user-specified excludes
                         includePattern: pattern,
                         includeHidden: true,      // Allow hidden files in include patterns
                         maxDepth: settings.maxDepth,


### PR DESCRIPTION
## Summary
- Fixed excludePatterns being ignored during include pattern searches
- Files like `.DS_Store` were appearing in search results even when explicitly excluded in settings
- Now user-specified excludePatterns are applied unconditionally in fd searches

## Changes
- Pass `settings.excludePatterns` to `executeFdSearch()` in `getFileListRecursive()`
- Apply user-specified excludePatterns unconditionally in `executeFdSearch()`
- Keep DEFAULT_EXCLUDES only for normal searches (not include patterns)

## Test plan
- [ ] Configure excludePatterns in settings.yml (e.g., `.DS_Store`)
- [ ] Configure includePatterns that would normally include those files
- [ ] Verify excluded files no longer appear in file search results
- [ ] Verify include patterns still work correctly for non-excluded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)