### PR TITLE
feat(file-search): add frontmatter popup on agent hover

### DIFF
--- a/src/managers/agent-loader.ts
+++ b/src/managers/agent-loader.ts
@@ -152,15 +152,23 @@ class AgentLoader {
     try {
       const content = await fs.readFile(filePath, 'utf8');
       const description = this.extractDescription(content);
+      const frontmatter = this.extractFrontmatter(content);
 
       // Agent name is the filename without .md extension
       const name = fileName.replace(/\.md$/, '');
 
-      return {
+      const result: AgentItem = {
         name,
         description: description || '',
         filePath
       };
+
+      // Only add frontmatter if it exists
+      if (frontmatter) {
+        result.frontmatter = frontmatter;
+      }
+
+      return result;
     } catch (error) {
       logger.warn('Failed to parse agent file', { filePath, error });
       return null;
@@ -197,6 +205,20 @@ class AgentLoader {
     }
 
     return description;
+  }
+
+  /**
+   * Extract full frontmatter content for popup display
+   * Returns the raw frontmatter text between --- markers
+   */
+  private extractFrontmatter(content: string): string {
+    // Match YAML frontmatter between --- markers
+    const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch || !frontmatterMatch[1]) {
+      return '';
+    }
+
+    return frontmatterMatch[1].trim();
   }
 
   /**

--- a/src/renderer/styles/components/file-suggestions.css
+++ b/src/renderer/styles/components/file-suggestions.css
@@ -163,3 +163,40 @@
 .file-suggestions::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover, #666);
 }
+
+/* Frontmatter Popup Styles */
+.frontmatter-popup {
+  position: fixed;
+  background: #1a1a1a; /* Darker than menu for contrast */
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 8px 10px;
+  max-height: 150px;
+  overflow-y: auto;
+  z-index: 101; /* Above suggestions container */
+  font-family: 'SF Mono', 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-secondary, #aaa);
+  white-space: pre-wrap;
+  word-break: break-word;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-sizing: border-box;
+}
+
+.frontmatter-popup::-webkit-scrollbar {
+  width: 4px;
+}
+
+.frontmatter-popup::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.frontmatter-popup::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb, #555);
+  border-radius: 4px;
+}
+
+.frontmatter-popup::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover, #666);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,6 +214,7 @@ export interface AgentItem {
   name: string;
   description: string;
   filePath: string;
+  frontmatter?: string;  // Front Matter 全文（ポップアップ表示用）
 }
 
 export interface FileInfo {


### PR DESCRIPTION
## Summary
- Add frontmatter popup display when hovering over agent items in file search dropdown
- Extract and store full frontmatter content from agent .md files for popup display
- Support adaptive positioning: shows above item when insufficient space below
- Enable mouse wheel and keyboard (arrow keys) scrolling within the popup

## Test plan
- [ ] Open file search with `@` and hover over an agent item with frontmatter
- [ ] Verify popup appears near the hovered item with frontmatter content
- [ ] Test popup positioning when window is at bottom of screen (should appear above)
- [ ] Test mouse wheel scrolling when popup is visible
- [ ] Test arrow key scrolling when popup is visible
- [ ] Verify popup disappears when mouse moves away from item

🤖 Generated with [Claude Code](https://claude.com/claude-code)