### PR TITLE
feat(file-cache): add file list caching for @mention file search

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -90,6 +90,12 @@ class AppConfigClass {
       },
       get directoryFile() {
         return path.join(userDataDir, 'directory.json');
+      },
+      get cacheDir() {
+        return path.join(userDataDir, 'cache');
+      },
+      get fileListsCacheDir() {
+        return path.join(userDataDir, 'cache', 'file-lists');
       }
     };
 

--- a/src/managers/file-cache-manager.ts
+++ b/src/managers/file-cache-manager.ts
@@ -1,0 +1,517 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { createReadStream, createWriteStream } from 'fs';
+import { createInterface } from 'readline';
+import config from '../config/app-config';
+import { logger } from '../utils/utils';
+import type {
+  FileInfo,
+  FileCacheMetadata,
+  CachedDirectoryData,
+  GlobalCacheMetadata,
+  FileCacheStats,
+  CachedFileEntry
+} from '../types';
+
+class FileCacheManager {
+  private cacheDir: string;
+  private globalMetadataPath: string;
+  private static readonly CACHE_VERSION = '1.0';
+  private static readonly DEFAULT_TTL_SECONDS = 3600; // 1 hour
+  private static readonly MAX_RECENT_DIRECTORIES = 10;
+
+  constructor() {
+    this.cacheDir = path.join(config.paths.userDataDir, 'cache', 'file-lists');
+    this.globalMetadataPath = path.join(this.cacheDir, 'global-metadata.json');
+  }
+
+  /**
+   * Initialize cache directory structure
+   */
+  async initialize(): Promise<void> {
+    try {
+      await fs.mkdir(this.cacheDir, { recursive: true });
+      logger.debug('File cache manager initialized');
+    } catch (error) {
+      logger.error('Failed to initialize file cache manager:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Encode directory path for cache directory name
+   * Claude projects style: / -> -
+   * Example: /Users/nkmr/ghq -> -Users-nkmr-ghq
+   */
+  encodeDirectoryPath(directory: string): string {
+    return directory.replace(/\//g, '-');
+  }
+
+  /**
+   * Get cache directory path for a specific directory
+   */
+  getCachePath(directory: string): string {
+    const encoded = this.encodeDirectoryPath(directory);
+    return path.join(this.cacheDir, encoded);
+  }
+
+  /**
+   * Load cache for a directory (returns immediately if exists)
+   * Returns null if cache doesn't exist or is invalid
+   */
+  async loadCache(directory: string): Promise<CachedDirectoryData | null> {
+    try {
+      const cachePath = this.getCachePath(directory);
+      const metadataPath = path.join(cachePath, 'metadata.json');
+      const filesPath = path.join(cachePath, 'files.jsonl');
+
+      // Check if both metadata and files exist
+      try {
+        await fs.access(metadataPath);
+        await fs.access(filesPath);
+      } catch {
+        logger.debug('Cache not found for directory:', directory);
+        return null;
+      }
+
+      // Read metadata
+      const metadataContent = await fs.readFile(metadataPath, 'utf8');
+      const metadata = JSON.parse(metadataContent) as FileCacheMetadata;
+
+      // Read files from JSONL
+      const entries = await this.readJsonlFile(filesPath);
+      const files = entries.map(entry => this.cacheEntryToFileInfo(entry));
+
+      logger.debug(`Loaded cache for directory: ${directory} (${files.length} files)`);
+
+      return {
+        directory,
+        files,
+        metadata
+      };
+    } catch (error) {
+      logger.error('Failed to load cache:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Save cache for a directory (background operation)
+   * This should be called asynchronously after file search completes
+   */
+  async saveCache(
+    directory: string,
+    files: FileInfo[],
+    options?: {
+      searchMode?: 'quick' | 'recursive';
+      usedFd?: boolean;
+      gitignoreRespected?: boolean;
+    }
+  ): Promise<void> {
+    try {
+      const cachePath = this.getCachePath(directory);
+      const metadataPath = path.join(cachePath, 'metadata.json');
+      const filesPath = path.join(cachePath, 'files.jsonl');
+
+      // Create cache directory
+      await fs.mkdir(cachePath, { recursive: true });
+
+      // Prepare metadata
+      const now = new Date().toISOString();
+      const metadata: FileCacheMetadata = {
+        version: FileCacheManager.CACHE_VERSION,
+        directory,
+        createdAt: now,
+        updatedAt: now,
+        fileCount: files.length,
+        ttlSeconds: FileCacheManager.DEFAULT_TTL_SECONDS,
+        ...(options?.searchMode && { searchMode: options.searchMode }),
+        ...(options?.usedFd !== undefined && { usedFd: options.usedFd }),
+        ...(options?.gitignoreRespected !== undefined && {
+          gitignoreRespected: options.gitignoreRespected
+        })
+      };
+
+      // Write metadata
+      await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2));
+
+      // Convert files to cache entries and write JSONL
+      const entries = files.map(file => this.fileInfoToCacheEntry(file));
+      await this.writeJsonlFile(filesPath, entries);
+
+      // Update global metadata
+      await this.setLastUsedDirectory(directory);
+
+      logger.debug(`Saved cache for directory: ${directory} (${files.length} files)`);
+    } catch (error) {
+      logger.error('Failed to save cache:', error);
+      // Don't throw - cache save failure shouldn't break file search
+    }
+  }
+
+  /**
+   * Check if cache is valid (within TTL)
+   */
+  isCacheValid(metadata: FileCacheMetadata, ttlSeconds?: number): boolean {
+    const ttl = ttlSeconds ?? metadata.ttlSeconds ?? FileCacheManager.DEFAULT_TTL_SECONDS;
+    const updatedAt = new Date(metadata.updatedAt).getTime();
+    const now = Date.now();
+    const ageMs = now - updatedAt;
+    const isValid = ageMs < ttl * 1000;
+
+    logger.debug(`Cache validity check: age=${ageMs}ms, ttl=${ttl}s, valid=${isValid}`);
+
+    return isValid;
+  }
+
+  /**
+   * Update cache timestamp only (when no file changes detected)
+   * This extends the cache TTL without rewriting files
+   */
+  async updateCacheTimestamp(directory: string): Promise<void> {
+    try {
+      const cachePath = this.getCachePath(directory);
+      const metadataPath = path.join(cachePath, 'metadata.json');
+
+      // Read existing metadata
+      const metadataContent = await fs.readFile(metadataPath, 'utf8');
+      const metadata = JSON.parse(metadataContent) as FileCacheMetadata;
+
+      // Update only the updatedAt field
+      metadata.updatedAt = new Date().toISOString();
+
+      // Write back
+      await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2));
+
+      logger.debug(`Updated cache timestamp for directory: ${directory}`);
+    } catch (error) {
+      logger.error('Failed to update cache timestamp:', error);
+      // Don't throw - timestamp update failure shouldn't break operations
+    }
+  }
+
+  /**
+   * Get last used directory from global metadata
+   */
+  async getLastUsedDirectory(): Promise<string | null> {
+    try {
+      const content = await fs.readFile(this.globalMetadataPath, 'utf8');
+      const metadata = JSON.parse(content) as GlobalCacheMetadata;
+      return metadata.lastUsedDirectory;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        logger.debug('Global metadata not found');
+        return null;
+      }
+      logger.error('Failed to read global metadata:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Set last used directory in global metadata
+   */
+  async setLastUsedDirectory(directory: string): Promise<void> {
+    try {
+      let metadata: GlobalCacheMetadata;
+
+      try {
+        const content = await fs.readFile(this.globalMetadataPath, 'utf8');
+        metadata = JSON.parse(content) as GlobalCacheMetadata;
+      } catch {
+        // Create new metadata if not exists
+        metadata = {
+          version: FileCacheManager.CACHE_VERSION,
+          lastUsedDirectory: null,
+          lastUsedAt: null,
+          recentDirectories: []
+        };
+      }
+
+      const now = new Date().toISOString();
+
+      // Update last used
+      metadata.lastUsedDirectory = directory;
+      metadata.lastUsedAt = now;
+
+      // Update recent directories list
+      // Remove if already exists
+      metadata.recentDirectories = metadata.recentDirectories.filter(
+        item => item.directory !== directory
+      );
+
+      // Add to front
+      metadata.recentDirectories.unshift({
+        directory,
+        lastUsedAt: now
+      });
+
+      // Limit to MAX_RECENT_DIRECTORIES
+      metadata.recentDirectories = metadata.recentDirectories.slice(
+        0,
+        FileCacheManager.MAX_RECENT_DIRECTORIES
+      );
+
+      // Write back
+      await fs.writeFile(
+        this.globalMetadataPath,
+        JSON.stringify(metadata, null, 2)
+      );
+
+      logger.debug(`Updated global metadata with directory: ${directory}`);
+    } catch (error) {
+      logger.error('Failed to update global metadata:', error);
+      // Don't throw - metadata update failure shouldn't break operations
+    }
+  }
+
+  /**
+   * Clear cache for a specific directory
+   */
+  async clearCache(directory: string): Promise<void> {
+    try {
+      const cachePath = this.getCachePath(directory);
+
+      // Remove cache directory recursively
+      await fs.rm(cachePath, { recursive: true, force: true });
+
+      logger.info(`Cleared cache for directory: ${directory}`);
+    } catch (error) {
+      logger.error('Failed to clear cache:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Clear all caches
+   */
+  async clearAllCaches(): Promise<void> {
+    try {
+      // Read all cache directories
+      const entries = await fs.readdir(this.cacheDir, { withFileTypes: true });
+
+      // Remove all directories except global-metadata.json
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const cachePath = path.join(this.cacheDir, entry.name);
+          await fs.rm(cachePath, { recursive: true, force: true });
+        }
+      }
+
+      // Also remove global metadata
+      await fs.rm(this.globalMetadataPath, { force: true });
+
+      logger.info('Cleared all caches');
+    } catch (error) {
+      logger.error('Failed to clear all caches:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get cache statistics
+   */
+  async getCacheStats(): Promise<FileCacheStats> {
+    try {
+      const entries = await fs.readdir(this.cacheDir, { withFileTypes: true });
+
+      let totalCaches = 0;
+      let totalFiles = 0;
+      let oldestCache: string | null = null;
+      let newestCache: string | null = null;
+      let totalSizeBytes = 0;
+      let oldestTimestamp = Number.MAX_SAFE_INTEGER;
+      let newestTimestamp = 0;
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+
+        const metadataPath = path.join(this.cacheDir, entry.name, 'metadata.json');
+
+        try {
+          const content = await fs.readFile(metadataPath, 'utf8');
+          const metadata = JSON.parse(content) as FileCacheMetadata;
+
+          totalCaches++;
+          totalFiles += metadata.fileCount;
+
+          const timestamp = new Date(metadata.updatedAt).getTime();
+          if (timestamp < oldestTimestamp) {
+            oldestTimestamp = timestamp;
+            oldestCache = metadata.directory;
+          }
+          if (timestamp > newestTimestamp) {
+            newestTimestamp = timestamp;
+            newestCache = metadata.directory;
+          }
+
+          // Calculate directory size
+          const filesPath = path.join(this.cacheDir, entry.name, 'files.jsonl');
+          const stats = await fs.stat(filesPath);
+          totalSizeBytes += stats.size;
+        } catch {
+          // Skip invalid cache entries
+          continue;
+        }
+      }
+
+      return {
+        totalCaches,
+        totalFiles,
+        oldestCache,
+        newestCache,
+        totalSizeBytes
+      };
+    } catch (error) {
+      logger.error('Failed to get cache stats:', error);
+      return {
+        totalCaches: 0,
+        totalFiles: 0,
+        oldestCache: null,
+        newestCache: null,
+        totalSizeBytes: 0
+      };
+    }
+  }
+
+  /**
+   * Cleanup old caches (for periodic maintenance)
+   * Removes caches older than maxAgeDays
+   */
+  async cleanupOldCaches(maxAgeDays: number): Promise<void> {
+    try {
+      const entries = await fs.readdir(this.cacheDir, { withFileTypes: true });
+      const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+      const now = Date.now();
+      let removedCount = 0;
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+
+        const metadataPath = path.join(this.cacheDir, entry.name, 'metadata.json');
+
+        try {
+          const content = await fs.readFile(metadataPath, 'utf8');
+          const metadata = JSON.parse(content) as FileCacheMetadata;
+
+          const timestamp = new Date(metadata.updatedAt).getTime();
+          const age = now - timestamp;
+
+          if (age > maxAgeMs) {
+            const cachePath = path.join(this.cacheDir, entry.name);
+            await fs.rm(cachePath, { recursive: true, force: true });
+            removedCount++;
+            logger.debug(`Removed old cache: ${metadata.directory}`);
+          }
+        } catch {
+          // Skip invalid cache entries
+          continue;
+        }
+      }
+
+      logger.info(`Cleanup completed: removed ${removedCount} old caches`);
+    } catch (error) {
+      logger.error('Failed to cleanup old caches:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Convert FileInfo to CachedFileEntry for storage
+   * Uses compact format to reduce file size
+   */
+  private fileInfoToCacheEntry(file: FileInfo): CachedFileEntry {
+    const entry: CachedFileEntry = {
+      path: file.path,
+      name: file.name,
+      type: file.isDirectory ? 'directory' : 'file'
+    };
+
+    if (file.size !== undefined) {
+      entry.size = file.size;
+    }
+
+    if (file.modifiedAt) {
+      entry.mtime = new Date(file.modifiedAt).getTime();
+    }
+
+    return entry;
+  }
+
+  /**
+   * Convert CachedFileEntry to FileInfo for use
+   */
+  private cacheEntryToFileInfo(entry: CachedFileEntry): FileInfo {
+    const fileInfo: FileInfo = {
+      path: entry.path,
+      name: entry.name,
+      isDirectory: entry.type === 'directory'
+    };
+
+    if (entry.size !== undefined) {
+      fileInfo.size = entry.size;
+    }
+
+    if (entry.mtime !== undefined) {
+      fileInfo.modifiedAt = new Date(entry.mtime).toISOString();
+    }
+
+    return fileInfo;
+  }
+
+  /**
+   * Read JSONL file as stream for memory efficiency
+   */
+  private async readJsonlFile(filePath: string): Promise<CachedFileEntry[]> {
+    return new Promise((resolve, reject) => {
+      const entries: CachedFileEntry[] = [];
+      const fileStream = createReadStream(filePath);
+      const rl = createInterface({
+        input: fileStream,
+        crlfDelay: Infinity
+      });
+
+      rl.on('line', (line) => {
+        try {
+          if (line.trim()) {
+            const entry = JSON.parse(line) as CachedFileEntry;
+            entries.push(entry);
+          }
+        } catch {
+          logger.warn('Invalid JSONL line in cache file:', line);
+        }
+      });
+
+      rl.on('close', () => {
+        resolve(entries);
+      });
+
+      rl.on('error', (error) => {
+        reject(error);
+      });
+    });
+  }
+
+  /**
+   * Write JSONL file as stream for memory efficiency
+   */
+  private async writeJsonlFile(
+    filePath: string,
+    entries: CachedFileEntry[]
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const writeStream = createWriteStream(filePath);
+
+      writeStream.on('error', reject);
+      writeStream.on('finish', resolve);
+
+      for (const entry of entries) {
+        writeStream.write(JSON.stringify(entry) + '\n');
+      }
+
+      writeStream.end();
+    });
+  }
+}
+
+export default FileCacheManager;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -395,12 +395,14 @@ export class PromptLineRenderer {
       // Reset draggable state when window is shown (new session)
       this.domManager.setDraggable(false);
 
-      // Cache directory data for file search (Stage 1 or draft fallback)
+      // Cache directory data for file search (from cache, Stage 1, or draft fallback)
       if (data.directoryData) {
         console.debug('[Renderer] caching directory data for file search', {
-          fromDraft: data.directoryData.fromDraft
+          fromDraft: data.directoryData.fromDraft,
+          fromCache: data.directoryData.fromCache,
+          cacheAge: data.directoryData.cacheAge
         });
-        this.fileSearchManager?.cacheDirectoryData(data.directoryData);
+        this.fileSearchManager?.handleCachedDirectoryData(data.directoryData);
 
         // Update hint text with formatted directory path
         if (data.directoryData.directory) {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -56,6 +56,9 @@ export interface DirectoryInfo {
   directoryChanged?: boolean;  // true if directory changed from previous (draft) directory
   previousDirectory?: string;  // previous directory (from draft) for comparison
   fromDraft?: boolean;         // true if this data is from draft fallback (not actual detection)
+  // Cache related fields
+  fromCache?: boolean;         // true if data was loaded from disk cache
+  cacheAge?: number;           // milliseconds since cache was updated
 }
 
 export interface WindowData {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,8 @@ export interface PathsConfig {
   logFile: string;
   imagesDir: string;
   directoryFile: string;
+  cacheDir: string;             // Cache root directory
+  fileListsCacheDir: string;    // File lists cache directory
 }
 
 export interface HistoryConfig {
@@ -251,6 +253,9 @@ export interface DirectoryInfo {
   directoryChanged?: boolean;  // true if directory changed from previous (draft) directory
   previousDirectory?: string;  // previous directory (from draft) for comparison
   fromDraft?: boolean;         // true if this data is from draft fallback (not actual detection)
+  // Cache related fields
+  fromCache?: boolean;         // true if data was loaded from cache
+  cacheAge?: number;           // milliseconds since cache was updated
 }
 
 // File search settings configuration
@@ -281,5 +286,58 @@ export interface DirectoryData {
   partial?: boolean;          // true for Stage 1 (quick), false for Stage 2 (recursive)
   searchMode?: 'quick' | 'recursive';
   usedFd?: boolean;           // true if fd command was used
+}
+
+// ============================================================================
+// File Cache Related Types
+// ============================================================================
+
+// Cache metadata for a cached directory
+export interface FileCacheMetadata {
+  version: string;
+  directory: string;
+  createdAt: string;
+  updatedAt: string;
+  fileCount: number;
+  searchMode?: 'quick' | 'recursive';
+  usedFd?: boolean;
+  gitignoreRespected?: boolean;
+  ttlSeconds?: number;
+}
+
+// Cached directory data returned from FileCacheManager
+export interface CachedDirectoryData {
+  directory: string;
+  files: FileInfo[];
+  metadata: FileCacheMetadata;
+}
+
+// Cache entry stored in files.jsonl
+export interface CachedFileEntry {
+  path: string;
+  name: string;
+  type: 'file' | 'directory';
+  size?: number;
+  mtime?: number;
+}
+
+// Global cache metadata for tracking recent directories
+export interface GlobalCacheMetadata {
+  version: string;
+  lastUsedDirectory: string | null;
+  lastUsedAt: string | null;
+  recentDirectories: Array<{
+    directory: string;
+    lastUsedAt: string;
+  }>;
+}
+
+// Cache statistics
+export interface FileCacheStats {
+  totalCaches: number;
+  totalFiles: number;
+  oldestCache: string | null;
+  newestCache: string | null;
+  totalSizeBytes: number;
 }
 

--- a/tests/unit/file-cache-manager.test.ts
+++ b/tests/unit/file-cache-manager.test.ts
@@ -1,0 +1,532 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import type { FileInfo } from '../../src/types';
+
+// Mock the config module FIRST (must be before imports that use it)
+jest.mock('../../src/config/app-config', () => {
+  const mockUserDataDir = '/test/.prompt-line';
+  return {
+    __esModule: true,
+    default: {
+      paths: {
+        userDataDir: mockUserDataDir,
+        cacheDir: `${mockUserDataDir}/cache`,
+        fileListsCacheDir: `${mockUserDataDir}/cache/file-lists`
+      }
+    }
+  };
+});
+
+// Mock fs promises module
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: jest.fn(),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    access: jest.fn(),
+    readdir: jest.fn(),
+    stat: jest.fn(),
+    rm: jest.fn()
+  },
+  createReadStream: jest.fn(),
+  createWriteStream: jest.fn()
+}));
+
+// Mock the utils module
+jest.mock('../../src/utils/utils', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+// Mock readline module
+jest.mock('readline', () => ({
+  createInterface: jest.fn()
+}));
+
+// Import after mocks
+import FileCacheManager from '../../src/managers/file-cache-manager';
+import { promises as fs } from 'fs';
+
+const mockedFs = jest.mocked(fs);
+
+describe('FileCacheManager', () => {
+  let cacheManager: FileCacheManager;
+
+  beforeEach(() => {
+    cacheManager = new FileCacheManager();
+    jest.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    test('should create cache directory on initialize', async () => {
+      mockedFs.mkdir.mockResolvedValue(undefined as any);
+
+      await cacheManager.initialize();
+
+      expect(mockedFs.mkdir).toHaveBeenCalledWith(
+        '/test/.prompt-line/cache/file-lists',
+        { recursive: true }
+      );
+    });
+
+    test('should handle initialization errors', async () => {
+      mockedFs.mkdir.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(cacheManager.initialize()).rejects.toThrow('Permission denied');
+    });
+  });
+
+  describe('encodeDirectoryPath', () => {
+    test('should encode directory path by replacing / with -', () => {
+      const input = '/Users/nkmr/ghq/github.com/nkmr-jp/prompt-line';
+      const expected = '-Users-nkmr-ghq-github.com-nkmr-jp-prompt-line';
+
+      const result = cacheManager.encodeDirectoryPath(input);
+
+      expect(result).toBe(expected);
+    });
+
+    test('should handle root directory', () => {
+      const input = '/';
+      const expected = '-';
+
+      const result = cacheManager.encodeDirectoryPath(input);
+
+      expect(result).toBe(expected);
+    });
+
+    test('should handle relative paths', () => {
+      const input = 'relative/path';
+      const expected = 'relative-path';
+
+      const result = cacheManager.encodeDirectoryPath(input);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('getCachePath', () => {
+    test('should return correct cache path', () => {
+      const directory = '/Users/nkmr/project';
+      const expected = '/test/.prompt-line/cache/file-lists/-Users-nkmr-project';
+
+      const result = cacheManager.getCachePath(directory);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('loadCache', () => {
+    test('should return null if cache does not exist', async () => {
+      mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await cacheManager.loadCache('/test/dir');
+
+      expect(result).toBeNull();
+    });
+
+    test('should return null if metadata is invalid', async () => {
+      mockedFs.access.mockResolvedValue(undefined as any);
+      mockedFs.readFile.mockRejectedValue(new Error('Invalid JSON'));
+
+      const result = await cacheManager.loadCache('/test/dir');
+
+      expect(result).toBeNull();
+    });
+
+    test('should load valid cache with files', async () => {
+      const directory = '/test/dir';
+      const metadata = {
+        version: '1.0',
+        directory,
+        createdAt: '2025-12-01T00:00:00.000Z',
+        updatedAt: '2025-12-01T00:00:00.000Z',
+        fileCount: 2,
+        searchMode: 'recursive' as const,
+        usedFd: true,
+        gitignoreRespected: true,
+        ttlSeconds: 3600
+      };
+
+      mockedFs.access.mockResolvedValue(undefined as any);
+      mockedFs.readFile.mockResolvedValue(JSON.stringify(metadata) as any);
+
+      // Mock readline for JSONL reading
+      const mockRl = {
+        on: jest.fn((event: string, handler: Function) => {
+          if (event === 'line') {
+            handler('{"path":"file1.ts","name":"file1.ts","type":"file","size":100,"mtime":1700000000000}');
+            handler('{"path":"file2.ts","name":"file2.ts","type":"file","size":200,"mtime":1700000001000}');
+          } else if (event === 'close') {
+            handler();
+          }
+          return mockRl;
+        })
+      };
+
+      const { createInterface } = await import('readline');
+      (createInterface as jest.Mock).mockReturnValue(mockRl);
+
+      const result = await cacheManager.loadCache(directory);
+
+      expect(result).not.toBeNull();
+      expect(result?.directory).toBe(directory);
+      expect(result?.files).toHaveLength(2);
+      expect(result?.metadata.fileCount).toBe(2);
+    });
+  });
+
+  describe('saveCache', () => {
+    test('should save cache with files and metadata', async () => {
+      const directory = '/test/dir';
+      const files: FileInfo[] = [
+        {
+          path: 'file1.ts',
+          name: 'file1.ts',
+          isDirectory: false,
+          size: 100,
+          modifiedAt: '2025-12-01T00:00:00.000Z'
+        },
+        {
+          path: 'file2.ts',
+          name: 'file2.ts',
+          isDirectory: false,
+          size: 200,
+          modifiedAt: '2025-12-01T00:01:00.000Z'
+        }
+      ];
+
+      mockedFs.mkdir.mockResolvedValue(undefined as any);
+      mockedFs.writeFile.mockResolvedValue(undefined as any);
+
+      // Mock createWriteStream
+      const mockWriteStream = {
+        write: jest.fn(),
+        end: jest.fn(),
+        on: jest.fn((event: string, handler: Function) => {
+          if (event === 'finish') {
+            handler();
+          }
+          return mockWriteStream;
+        })
+      };
+      const { createWriteStream } = await import('fs');
+      (createWriteStream as jest.Mock).mockReturnValue(mockWriteStream);
+
+      await cacheManager.saveCache(directory, files, {
+        searchMode: 'recursive',
+        usedFd: true,
+        gitignoreRespected: true
+      });
+
+      expect(mockedFs.mkdir).toHaveBeenCalled();
+      expect(mockedFs.writeFile).toHaveBeenCalled();
+      expect(mockWriteStream.write).toHaveBeenCalledTimes(2);
+      expect(mockWriteStream.end).toHaveBeenCalled();
+    });
+
+    test('should not throw on save error', async () => {
+      mockedFs.mkdir.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(
+        cacheManager.saveCache('/test/dir', [])
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('isCacheValid', () => {
+    test('should return true for fresh cache', () => {
+      const metadata = {
+        version: '1.0',
+        directory: '/test',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        fileCount: 0,
+        ttlSeconds: 3600
+      };
+
+      const result = cacheManager.isCacheValid(metadata);
+
+      expect(result).toBe(true);
+    });
+
+    test('should return false for expired cache', () => {
+      const oldDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+      const metadata = {
+        version: '1.0',
+        directory: '/test',
+        createdAt: oldDate.toISOString(),
+        updatedAt: oldDate.toISOString(),
+        fileCount: 0,
+        ttlSeconds: 3600 // 1 hour
+      };
+
+      const result = cacheManager.isCacheValid(metadata);
+
+      expect(result).toBe(false);
+    });
+
+    test('should use custom TTL if provided', () => {
+      const oldDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+      const metadata = {
+        version: '1.0',
+        directory: '/test',
+        createdAt: oldDate.toISOString(),
+        updatedAt: oldDate.toISOString(),
+        fileCount: 0,
+        ttlSeconds: 3600 // 1 hour (should be overridden)
+      };
+
+      // Use custom TTL of 3 hours
+      const result = cacheManager.isCacheValid(metadata, 10800);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('updateCacheTimestamp', () => {
+    test('should update only the timestamp field', async () => {
+      const metadata = {
+        version: '1.0',
+        directory: '/test',
+        createdAt: '2025-12-01T00:00:00.000Z',
+        updatedAt: '2025-12-01T00:00:00.000Z',
+        fileCount: 100,
+        ttlSeconds: 3600
+      };
+
+      mockedFs.readFile.mockResolvedValue(JSON.stringify(metadata) as any);
+      mockedFs.writeFile.mockResolvedValue(undefined as any);
+
+      await cacheManager.updateCacheTimestamp('/test');
+
+      expect(mockedFs.writeFile).toHaveBeenCalled();
+      const writtenData = (mockedFs.writeFile as jest.Mock).mock.calls[0]?.[1] as string;
+      const updatedMetadata = JSON.parse(writtenData);
+
+      expect(updatedMetadata.createdAt).toBe(metadata.createdAt);
+      expect(updatedMetadata.fileCount).toBe(metadata.fileCount);
+      expect(new Date(updatedMetadata.updatedAt).getTime()).toBeGreaterThan(
+        new Date(metadata.updatedAt).getTime()
+      );
+    });
+
+    test('should not throw on update error', async () => {
+      mockedFs.readFile.mockRejectedValue(new Error('Not found'));
+
+      await expect(
+        cacheManager.updateCacheTimestamp('/test')
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('global metadata management', () => {
+    test('should return null if global metadata does not exist', async () => {
+      mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await cacheManager.getLastUsedDirectory();
+
+      expect(result).toBeNull();
+    });
+
+    test('should return last used directory', async () => {
+      const globalMetadata = {
+        version: '1.0',
+        lastUsedDirectory: '/test/dir',
+        lastUsedAt: '2025-12-01T00:00:00.000Z',
+        recentDirectories: []
+      };
+
+      mockedFs.readFile.mockResolvedValue(JSON.stringify(globalMetadata) as any);
+
+      const result = await cacheManager.getLastUsedDirectory();
+
+      expect(result).toBe('/test/dir');
+    });
+
+    test('should update global metadata with new directory', async () => {
+      const existingMetadata = {
+        version: '1.0',
+        lastUsedDirectory: '/old/dir',
+        lastUsedAt: '2025-12-01T00:00:00.000Z',
+        recentDirectories: [
+          {
+            directory: '/old/dir',
+            lastUsedAt: '2025-12-01T00:00:00.000Z'
+          }
+        ]
+      };
+
+      mockedFs.readFile.mockResolvedValue(JSON.stringify(existingMetadata) as any);
+      mockedFs.writeFile.mockResolvedValue(undefined as any);
+
+      await cacheManager.setLastUsedDirectory('/new/dir');
+
+      expect(mockedFs.writeFile).toHaveBeenCalled();
+      const writtenData = (mockedFs.writeFile as jest.Mock).mock.calls[0]?.[1] as string;
+      const updatedMetadata = JSON.parse(writtenData);
+
+      expect(updatedMetadata.lastUsedDirectory).toBe('/new/dir');
+      expect(updatedMetadata.recentDirectories).toHaveLength(2);
+      expect(updatedMetadata.recentDirectories[0].directory).toBe('/new/dir');
+    });
+
+    test('should limit recent directories to MAX_RECENT_DIRECTORIES', async () => {
+      const recentDirs = Array.from({ length: 12 }, (_, i) => ({
+        directory: `/dir${i}`,
+        lastUsedAt: new Date().toISOString()
+      }));
+
+      const existingMetadata = {
+        version: '1.0',
+        lastUsedDirectory: '/dir0',
+        lastUsedAt: new Date().toISOString(),
+        recentDirectories: recentDirs
+      };
+
+      mockedFs.readFile.mockResolvedValue(JSON.stringify(existingMetadata) as any);
+      mockedFs.writeFile.mockResolvedValue(undefined as any);
+
+      await cacheManager.setLastUsedDirectory('/new/dir');
+
+      const writtenData = (mockedFs.writeFile as jest.Mock).mock.calls[0]?.[1] as string;
+      const updatedMetadata = JSON.parse(writtenData);
+
+      expect(updatedMetadata.recentDirectories).toHaveLength(10); // MAX_RECENT_DIRECTORIES
+    });
+  });
+
+  describe('clearCache', () => {
+    test('should remove cache directory', async () => {
+      mockedFs.rm.mockResolvedValue(undefined as any);
+
+      await cacheManager.clearCache('/test/dir');
+
+      expect(mockedFs.rm).toHaveBeenCalledWith(
+        expect.stringContaining('-test-dir'),
+        { recursive: true, force: true }
+      );
+    });
+
+    test('should throw on error', async () => {
+      mockedFs.rm.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(cacheManager.clearCache('/test/dir')).rejects.toThrow('Permission denied');
+    });
+  });
+
+  describe('clearAllCaches', () => {
+    test('should remove all cache directories', async () => {
+      const mockEntries = [
+        { name: 'cache1', isDirectory: () => true },
+        { name: 'cache2', isDirectory: () => true },
+        { name: 'global-metadata.json', isDirectory: () => false }
+      ];
+
+      mockedFs.readdir.mockResolvedValue(mockEntries as any);
+      mockedFs.rm.mockResolvedValue(undefined as any);
+
+      await cacheManager.clearAllCaches();
+
+      expect(mockedFs.rm).toHaveBeenCalledTimes(3); // 2 directories + global metadata
+    });
+  });
+
+  describe('getCacheStats', () => {
+    test('should return stats for all caches', async () => {
+      const mockEntries = [
+        { name: 'cache1', isDirectory: () => true },
+        { name: 'cache2', isDirectory: () => true }
+      ];
+
+      const metadata1 = {
+        version: '1.0',
+        directory: '/dir1',
+        createdAt: '2025-12-01T00:00:00.000Z',
+        updatedAt: '2025-12-01T01:00:00.000Z',
+        fileCount: 100,
+        ttlSeconds: 3600
+      };
+
+      const metadata2 = {
+        version: '1.0',
+        directory: '/dir2',
+        createdAt: '2025-12-01T02:00:00.000Z',
+        updatedAt: '2025-12-01T03:00:00.000Z',
+        fileCount: 200,
+        ttlSeconds: 3600
+      };
+
+      mockedFs.readdir.mockResolvedValue(mockEntries as any);
+      mockedFs.readFile
+        .mockResolvedValueOnce(JSON.stringify(metadata1) as any)
+        .mockResolvedValueOnce(JSON.stringify(metadata2) as any);
+      mockedFs.stat
+        .mockResolvedValueOnce({ size: 1000 } as any)
+        .mockResolvedValueOnce({ size: 2000 } as any);
+
+      const stats = await cacheManager.getCacheStats();
+
+      expect(stats.totalCaches).toBe(2);
+      expect(stats.totalFiles).toBe(300);
+      expect(stats.totalSizeBytes).toBe(3000);
+      expect(stats.oldestCache).toBe('/dir1');
+      expect(stats.newestCache).toBe('/dir2');
+    });
+
+    test('should return zero stats on error', async () => {
+      mockedFs.readdir.mockRejectedValue(new Error('Not found'));
+
+      const stats = await cacheManager.getCacheStats();
+
+      expect(stats.totalCaches).toBe(0);
+      expect(stats.totalFiles).toBe(0);
+      expect(stats.totalSizeBytes).toBe(0);
+      expect(stats.oldestCache).toBeNull();
+      expect(stats.newestCache).toBeNull();
+    });
+  });
+
+  describe('cleanupOldCaches', () => {
+    test('should remove caches older than maxAgeDays', async () => {
+      const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago
+      const recentDate = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000); // 1 day ago
+
+      const mockEntries = [
+        { name: 'old-cache', isDirectory: () => true },
+        { name: 'recent-cache', isDirectory: () => true }
+      ];
+
+      const oldMetadata = {
+        version: '1.0',
+        directory: '/old',
+        createdAt: oldDate.toISOString(),
+        updatedAt: oldDate.toISOString(),
+        fileCount: 100,
+        ttlSeconds: 3600
+      };
+
+      const recentMetadata = {
+        version: '1.0',
+        directory: '/recent',
+        createdAt: recentDate.toISOString(),
+        updatedAt: recentDate.toISOString(),
+        fileCount: 100,
+        ttlSeconds: 3600
+      };
+
+      mockedFs.readdir.mockResolvedValue(mockEntries as any);
+      mockedFs.readFile
+        .mockResolvedValueOnce(JSON.stringify(oldMetadata) as any)
+        .mockResolvedValueOnce(JSON.stringify(recentMetadata) as any);
+      mockedFs.rm.mockResolvedValue(undefined as any);
+
+      await cacheManager.cleanupOldCaches(7); // 7 days
+
+      expect(mockedFs.rm).toHaveBeenCalledTimes(1); // Only old cache removed
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add JSONL-based file list caching for @mention file search to improve performance
- Implement FileCacheManager with streaming read/write for memory efficiency
- Integrate cache loading in WindowManager for instant file search availability on window show
- Support configurable cache TTL (default 1 hour) and automatic cleanup of old caches

## Changes

### New Files
- `src/managers/file-cache-manager.ts` - Core caching functionality with JSONL streaming
- `tests/unit/file-cache-manager.test.ts` - Comprehensive test coverage (26 tests)

### Modified Files
- `src/managers/window-manager.ts` - Integrate cache loading and background updates with diff detection
- `src/renderer/file-search-manager.ts` - Handle cached directory data with status tracking
- `src/renderer/renderer.ts` - Use `handleCachedDirectoryData` instead of deprecated method
- `src/renderer/types.ts` - Add cache-related fields to DirectoryInfo
- `src/types/index.ts` - Add cache types (FileCacheMetadata, CachedDirectoryData, etc.)
- `src/config/app-config.ts` - Add cache directory paths

## Test plan

- [x] All 432 tests passing
- [x] TypeScript compilation successful
- [x] ESLint passing
- [ ] Manual test: Verify file search works with cached data on window show
- [ ] Manual test: Verify cache is updated in background when directory changes
- [ ] Manual test: Verify old caches are cleaned up after TTL expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)