### PR TITLE
ci: update Node.js version to 22 for semantic-release compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Update Node.js version from 20 to 22 in CI workflows
- Required for semantic-release which now requires Node.js ^22.14.0 or >= 24.10.0

## Changes
- `.github/workflows/release.yml`: Node.js 20 → 22
- `.github/workflows/ci.yml`: Node.js 20 → 22

## Test plan
- [ ] CI workflow passes with Node.js 22
- [ ] Release workflow executes semantic-release successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)