### PR TITLE
fix(file-search): preserve normal backspace behavior with Shift and text selection

### DIFF
--- a/src/renderer/file-search-manager.ts
+++ b/src/renderer/file-search-manager.ts
@@ -589,6 +589,9 @@ export class FileSearchManager {
       if (this.isVisible) {
         this.handleKeyDown(e);
       } else if (e.key === 'Backspace') {
+        // Don't override Shift+Backspace or when text is selected
+        if (e.shiftKey) return;
+        if (this.textInput && this.textInput.selectionStart !== this.textInput.selectionEnd) return;
         // Handle backspace to delete entire @path if cursor is at the end of one
         this.handleBackspaceForAtPath(e);
       } else if (e.key === 'Enter' && e.ctrlKey) {

--- a/src/renderer/file-search/file-search-manager.ts
+++ b/src/renderer/file-search/file-search-manager.ts
@@ -655,6 +655,10 @@ export class FileSearchManager {
       e.preventDefault();
       this.hideSuggestions();
     } else if (e.key === 'Backspace') {
+      // Don't override Shift+Backspace or when text is selected
+      if (e.shiftKey) return;
+      if (this.textInput && this.textInput.selectionStart !== this.textInput.selectionEnd) return;
+
       // Navigate up directory when backspace on empty query with path
       if (this.currentQuery === '' && this.currentPath) {
         e.preventDefault();

--- a/src/renderer/file-search/highlighter.ts
+++ b/src/renderer/file-search/highlighter.ts
@@ -481,6 +481,10 @@ export class FileSearchHighlighter {
   /**
    * Handle backspace key to delete entire @path if cursor is at the end
    * Uses replaceRangeWithUndo for native Undo/Redo support
+   *
+   * Note: Does not override normal backspace behavior when:
+   * - Shift key is pressed (Shift+Backspace)
+   * - Text is selected (let browser delete selection normally)
    */
   public handleBackspaceForAtPath(
     e: KeyboardEvent,
@@ -488,6 +492,17 @@ export class FileSearchHighlighter {
     getTextContent: () => string,
     setCursorPosition: (pos: number) => void
   ): void {
+    // Don't override Shift+Backspace (let it behave as normal backspace)
+    if (e.shiftKey) {
+      return;
+    }
+
+    // Don't override when text is selected (let browser delete selection normally)
+    const textInput = this.getTextInput();
+    if (textInput && textInput.selectionStart !== textInput.selectionEnd) {
+      return;
+    }
+
     const cursorPos = getCursorPosition();
     const atPath = this.findAtPathAtCursor(cursorPos);
 


### PR DESCRIPTION
## Summary
- Fix backspace key behavior in @path file search to preserve normal behavior when:
  - Shift+Backspace is pressed (let it behave as normal backspace)
  - Text is selected (let browser delete selection normally)

## Changes
- `src/renderer/file-search/highlighter.ts`: Added early return conditions in `handleBackspaceForAtPath`
- `src/renderer/file-search/file-search-manager.ts`: Added early return conditions in `handleKeyDown`
- `src/renderer/file-search-manager.ts`: Added early return conditions in keydown event handler

## Test plan
- [ ] Type `@path/to/file` and position cursor at the end
- [ ] Press Backspace → Should delete entire @path (existing behavior)
- [ ] Select some text and press Backspace → Should delete only selected text (fixed)
- [ ] Press Shift+Backspace → Should delete single character (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)