### PR TITLE
fix(deps): add missing glob dependency for production build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
+        "glob": "^13.0.0",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {
@@ -943,6 +944,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@electron/asar/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@electron/fuses": {
       "version": "1.8.0",
       "dev": true,
@@ -1783,7 +1808,6 @@
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -1791,7 +1815,6 @@
     },
     "node_modules/@isaacs/brace-expansion": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -7760,19 +7783,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "dev": true,
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
         "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": "20 || >=22"
@@ -8539,6 +8557,8 @@
     },
     "node_modules/jackspeak": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10208,7 +10228,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.1.1",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
@@ -10230,7 +10249,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -13164,7 +13182,6 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -13179,7 +13196,6 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "11.2.4",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   },
   "dependencies": {
     "chokidar": "^5.0.0",
+    "glob": "^13.0.0",
     "js-yaml": "^4.1.1"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- Add `glob` package to dependencies to fix "Cannot find module 'glob'" error in production builds
- The `glob` module is used in `prefix-resolver.ts` but was not listed in package.json
- Development builds worked because glob was present in node_modules, but production builds failed as electron-builder only bundles packages listed in dependencies

## Test plan
- [x] Run `npm run build` successfully
- [x] Launch built application without JavaScript errors
- [ ] Verify slash commands work correctly (uses glob via prefix-resolver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)