### PR TITLE
fix(ci): Enable CHANGELOG.md auto-update in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           force-bump-patch-version: true
+          changelog-file: CHANGELOG.md
+          update-file: package.json,package-lock.json,CHANGELOG.md


### PR DESCRIPTION
## Summary

Fixes the issue where CHANGELOG.md was not being automatically updated and committed during releases.

### Problem

After migrating to go-semantic-release in PR #181, the changelog content was being generated and used in GitHub Release notes, but the CHANGELOG.md file in the repository was not being updated.

**Root Cause:**
- The go-semantic-release GitHub Action was writing to a temporary file (`.generated-go-semantic-release-changelog.md`)
- The `update-file` parameter was not configured, so no files were committed back to the repository

### Solution

Added two parameters to the release workflow:
- `changelog-file: CHANGELOG.md` - Explicitly specify the output file
- `update-file: package.json,package-lock.json,CHANGELOG.md` - Enable automatic commits for these files

### Changes

- Modified `.github/workflows/release.yml` to add `changelog-file` and `update-file` parameters

### Expected Behavior

After this fix, each release will automatically:
1. Generate CHANGELOG.md content with emojis
2. Update CHANGELOG.md by prepending new release notes
3. Commit the changes with message: `chore(release): x.x.x [skip ci]`
4. Update package.json and package-lock.json versions

### Test Plan

- [x] Workflow configuration updated
- [x] Parameters validated against go-semantic-release/action documentation
- [ ] Next release will verify CHANGELOG.md is committed automatically

### Related

- Fixes the issue discovered after PR #181 (v0.19.0 release)
- Release v0.19.0: https://github.com/nkmr-jp/prompt-line/releases/tag/v0.19.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)