### PR TITLE
docs(readme): add download instructions for pre-built binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,15 @@ Of course, it also works with apps other than Terminal.
 ### System Requirements
 
 - macOS 10.14 or later
-- Node.js 20 or later
-- Xcode Command Line Tools or Xcode (for compiling native tools)
+- Node.js 20 or later (only for building from source)
+- Xcode Command Line Tools or Xcode (only for building from source)
+
+### Download Pre-built Binary (Recommended)
+
+Download the latest `.dmg` file for your system from the [GitHub Releases](https://github.com/nkmr-jp/prompt-line/releases) page:
+
+- **Apple Silicon (M1/M2/M3)**: `Prompt-Line-{version}-arm64.dmg`
+- **Intel**: `Prompt-Line-{version}-x64.dmg`
 
 ### Build from Source
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -49,8 +49,15 @@ Enterを押しても勝手に送信されないので、改行する場合も気
 ### システム要件
 
 - macOS 10.14以降
-- Node.js 20以上
-- Xcodeコマンドラインツール または Xcode（ネイティブツールのコンパイル用）
+- Node.js 20以上（ソースからビルドする場合のみ）
+- Xcodeコマンドラインツール または Xcode（ソースからビルドする場合のみ）
+
+### ビルド済みバイナリのダウンロード（推奨）
+
+[GitHubリリースページ](https://github.com/nkmr-jp/prompt-line/releases)から、ご使用のシステムに合った最新の`.dmg`ファイルをダウンロードしてください：
+
+- **Apple Silicon（M1/M2/M3）**: `Prompt-Line-{version}-arm64.dmg`
+- **Intel**: `Prompt-Line-{version}-x64.dmg`
 
 ### ソースからビルド
 


### PR DESCRIPTION
## Summary

Added download instructions section to both English and Japanese READMEs to guide users to download pre-built binaries from GitHub Releases.

## Changes

- Added "Download Pre-built Binary (Recommended)" section before "Build from Source"
- Included links to GitHub Releases page
- Clarified that Node.js and Xcode are only required for building from source
- Updated both `README.md` and `README_ja.md`

## Purpose

This PR is created to test the Release Please automation. When merged to `main`, Release Please should:

1. Detect the `docs:` conventional commit
2. Create a release PR with updated CHANGELOG.md
3. Bump the patch version (0.19.1 → 0.19.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)