### PR TITLE
docs(readme): improve overview section clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ English |
 Prompt Line is a macOS app developed to improve the prompt input experience in the terminal for CLI-based AI coding agents such as [Claude Code](https://github.com/anthropics/claude-code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [OpenAI Codex CLI](https://github.com/openai/codex), and [Aider](https://github.com/paul-gauthier/aider).
 It addresses UX challenges related to multi-byte character input (e.g., Japanese) by providing a dedicated floating input interface. 
 
-This greatly reduces stress when entering text in the following cases in particular. 
+This is particularly useful in the following scenarios:
 
-1. **Prompt input for CLI-based AI coding agents in the terminal** 
-2. **Chat apps where pressing Enter sends the message at an unintended time** 
-3. **Text editor with slow input response (e.g., large Confluence documents)**
+1. **Prompt input for CLI-based AI coding agents** - Prevents accidental submission with Enter key in terminal environments
+2. **Chat applications** - Avoid sending messages prematurely when you just want to add a line break
+3. **Slow text editors** - Maintain smooth typing experience even with large documents (e.g., Confluence)
 
 
 ## Features

--- a/README_ja.md
+++ b/README_ja.md
@@ -9,11 +9,11 @@
 Prompt Lineは、[Claude Code](https://github.com/anthropics/claude-code)、[Gemini CLI](https://github.com/google-gemini/gemini-cli)、[OpenAI Codex CLI](https://github.com/openai/codex)、[Aider](https://github.com/paul-gauthier/aider) などのCLI型AIコーディングエージェントのターミナルでのプロンプト入力体験を改善することを目的として開発したmacOSアプリです。
 日本語などのマルチバイト文字入力時のUXの課題を専用のフローティング入力インターフェースで解決します。 
 
-特に以下のようなケースでのテキスト入力のストレスを大幅に軽減します。
+特に以下のような場面で効果を発揮します：
 
-1. **ターミナルでのCLI型AIコーディングエージェントへのプロンプト入力**
-2. **Enterを押したら意図しないタイミングで送信されてしまうチャットアプリ**
-3. **入力の重たいテキストエディタ(例：巨大なコンフルエンスのドキュメントなど)**
+1. **CLI型AIコーディングエージェントへの入力** - ターミナル環境でのEnterキーの誤送信を防止
+2. **チャットアプリケーション** - 改行したいだけなのに誤ってメッセージを送信してしまうことを回避
+3. **動作の重いテキストエディタ** - 大きなドキュメント（Confluenceなど）でもスムーズな入力体験を維持
 
 
 ## 特徴


### PR DESCRIPTION
## Summary

Improved the overview section in both English and Japanese READMEs to provide clearer explanations of use cases.

## Changes

- Enhanced wording for better readability
- Added specific details to each scenario:
  - CLI coding agents: Clarified prevention of accidental Enter key submission
  - Chat apps: Explained line break vs. message send issue
  - Slow editors: Specified maintaining smooth typing experience
- Improved consistency between English and Japanese versions

## Purpose

This PR tests the Release Please automation. When merged to `main`, Release Please should:

1. Detect the `docs:` conventional commit
2. Create a release PR with updated CHANGELOG.md
3. Bump the patch version (0.19.1 → 0.19.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)