### PR TITLE
fix(agent-skill): fix tooltip stuck on first item during navigation

### DIFF
--- a/src/renderer/agent-skill-manager.ts
+++ b/src/renderer/agent-skill-manager.ts
@@ -583,6 +583,7 @@ export class AgentSkillManager implements IInitializable {
       item.className = 'agent-skill-suggestion-item';
       if (index === this.selectedIndex) {
         item.classList.add('selected');
+        this.selectedSkillElement = item;
       }
       item.dataset.index = index.toString();
 


### PR DESCRIPTION
## Summary
- Fix selection highlight and tooltip position staying on the first item when navigating through slash command suggestions with arrow keys
- Root cause: the D5 performance optimization (commit 0cc6389) changed `updateSelection()` to use a tracked element reference instead of iterating all items, but `renderSuggestions()` did not save the initially selected element to `selectedSkillElement`
- This caused the previous selection to never be cleared, resulting in multiple items highlighted and the tooltip always anchored to the first item

## Test plan
- [x] TypeScript type check passes
- [x] All 1119 tests pass
- [ ] Manual: type `/` to open slash command suggestions, press ArrowDown/ArrowUp to navigate — verify only one item is highlighted at a time
- [ ] Manual: enable auto-show tooltip (Ctrl+i), navigate through items — verify tooltip follows the selected item

🤖 Generated with [Claude Code](https://claude.com/claude-code)