### PR TITLE
fix(mentions): suppress Building Index and hint for non-capable apps

### DIFF
--- a/src/renderer/directory-data-handler.ts
+++ b/src/renderer/directory-data-handler.ts
@@ -22,6 +22,7 @@ export interface MentionManagerCallbacks {
   getMentionManager: () => {
     setFileSearchEnabled: (enabled: boolean) => void;
     setSymbolSearchEnabled: (enabled: boolean) => void;
+    setDirectoryDetectionCapable: (capable: boolean) => void;
     preloadSearchPrefixesCache: () => void;
     handleCachedDirectoryData: (data: DirectoryInfo) => void;
     updateCache: (data: DirectoryInfo) => void;
@@ -110,6 +111,9 @@ export class DirectoryDataHandler {
 
       // Update file search enabled state in MentionManager
       fileSearchManager?.setFileSearchEnabled(data.fileSearchEnabled ?? false);
+
+      // Update directory detection capability based on source app
+      fileSearchManager?.setDirectoryDetectionCapable(this.isDirectoryDetectionCapable(data.sourceApp));
 
       // Update symbol search enabled state in MentionManager (disabled when rg is not available)
       fileSearchManager?.setSymbolSearchEnabled(data.symbolSearchEnabled ?? true);

--- a/src/renderer/mention-manager.ts
+++ b/src/renderer/mention-manager.ts
@@ -268,6 +268,13 @@ export class MentionManager implements IInitializable {
     return this.state.symbolSearchEnabled;
   }
 
+  /**
+   * Set whether the source app supports directory detection
+   */
+  public setDirectoryDetectionCapable(capable: boolean): void {
+    this.state.directoryDetectionCapable = capable;
+  }
+
 
   // ============================================
   // State Update Helpers
@@ -521,6 +528,10 @@ export class MentionManager implements IInitializable {
    * Returns true if directory data is not yet available or is from draft fallback with no files
    */
   private isIndexBeingBuilt(): boolean {
+    // Non-capable apps never have index building (no directory detection)
+    if (!this.state.directoryDetectionCapable) {
+      return false;
+    }
     // Delegate to DirectoryCacheManager
     return this.directoryCacheManager?.isIndexBeingBuilt() ?? true;
   }
@@ -529,6 +540,10 @@ export class MentionManager implements IInitializable {
    * Show hint that file index is being built
    */
   private showIndexingHint(): void {
+    // Don't show "Building Index" for non-capable apps (no directory detection)
+    if (!this.state.directoryDetectionCapable) {
+      return;
+    }
     // Don't show "Building Index" if there's a more important hint (e.g., fd not installed)
     if (this.directoryCacheManager?.getHint()) {
       return;

--- a/src/renderer/mentions/managers/mention-state.ts
+++ b/src/renderer/mentions/managers/mention-state.ts
@@ -34,6 +34,7 @@ export class MentionState {
   isVisible: boolean = false;
   fileSearchEnabled: boolean = false;
   symbolSearchEnabled: boolean = true;  // Default true, disabled when rg is not available
+  directoryDetectionCapable: boolean = false;  // Whether source app supports directory detection
 
   // Filtered results
   filteredFiles: FileInfo[] = [];


### PR DESCRIPTION
## Summary
- Suppress "Building file index..." message when typing `@` in apps that don't support directory detection (e.g., Safari, Finder)
- Keep default hint text unchanged for non-capable apps instead of overwriting it with indexing status

## Changes
- Added `directoryDetectionCapable` flag to `MentionState`
- `DirectoryDataHandler` now passes directory detection capability to `MentionManager` on window shown
- `isIndexBeingBuilt()` returns `false` for non-capable apps
- `showIndexingHint()` early-returns for non-capable apps

## Test plan
- [x] TypeScript type check passes
- [x] All 1119 tests pass
- [ ] Open Prompt Line from a non-capable app (e.g., Safari) → type `@` → verify no "Building file index..." message
- [ ] Open Prompt Line from a capable app (e.g., Terminal, VSCode) → type `@` → verify "Building file index..." still appears when index is building

🤖 Generated with [Claude Code](https://claude.com/claude-code)