### PR TITLE
fix(directory-detector): resolve shell CWD to project root for IDE terminals

### DIFF
--- a/native/directory-detector/ProcessTree.swift
+++ b/native/directory-detector/ProcessTree.swift
@@ -306,10 +306,11 @@ extension DirectoryDetector {
 
                 let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
 
-                // Check each shell, prefer non-home directories
+                // Check each shell, prefer non-home directories, resolve to project root
                 for shellPid in shellPids.prefix(5) {
                     if let cwd = getCwdFromPid(shellPid), cwd != homeDir {
-                        return (cwd, shellPid)
+                        let dir = findProjectRoot(cwd) ?? cwd
+                        return (dir, shellPid)
                     }
                 }
 
@@ -384,10 +385,11 @@ extension DirectoryDetector {
 
             let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
 
-            // Step 4: Check CWD of each IDE shell, prefer non-home directories
+            // Step 4: Check CWD of each IDE shell, prefer non-home directories, resolve to project root
             for shellPid in ideShells.prefix(5) {
                 if let cwd = getCwdFromPid(shellPid), cwd != homeDir {
-                    return (cwd, shellPid)
+                    let dir = findProjectRoot(cwd) ?? cwd
+                    return (dir, shellPid)
                 }
             }
 
@@ -479,10 +481,11 @@ extension DirectoryDetector {
 
                 let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
 
-                // Check each shell, prefer non-home directories
+                // Check each shell, prefer non-home directories, resolve to project root
                 for shellPid in shellPids.prefix(5) {
                     if let cwd = getCwdFromPid(shellPid), cwd != homeDir {
-                        return (cwd, shellPid)
+                        let dir = findProjectRoot(cwd) ?? cwd
+                        return (dir, shellPid)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Add `findProjectRoot()` to resolve shell CWD to the nearest project root by checking `.idea/` and `.git/` markers in a single upward traversal
- Update all IDE terminal detection methods to return the project root instead of raw shell CWD, fixing incorrect file search scoping when `cd`-ing in IDE terminals
- Improve project name hint matching by comparing against the project root basename instead of any path component

### Affected IDEs
- **JetBrains** (GoLand, IntelliJ, WebStorm, PyCharm, etc.) — `getIDETerminalDirectoryFast`
- **VSCode / Cursor / Windsurf / Kiro / OpenCode** — `getElectronIDETerminalDirectory`
- **Antigravity** (tmux-based) — `getTmuxTerminalDirectory`
- **Fallback path** — `getElectronIDETerminalDirectoryFallback`

### Problem
When using IDE terminals, `cd` to a subdirectory or unrelated path caused file search (`@` mentions) to scope to the wrong directory. The root cause was that detection methods returned the shell's raw CWD instead of the project root.

### Solution
Traverse parent directories from the shell CWD looking for `.idea/` (JetBrains marker) or `.git/` at each level, returning the closest match as the project root. Falls back to the raw CWD if no marker is found.

## Test plan
- [x] `pnpm test` — all 1119 tests pass
- [x] `cd native && make install` — native tool builds successfully
- [ ] Manual: Open GoLand with multiple projects, verify correct project root is detected
- [ ] Manual: `cd /tmp` in IDE terminal, verify project root is still returned
- [ ] Manual: `cd` to a subdirectory, verify project root (not subdirectory) is returned
- [ ] Manual: Open VSCode/Cursor, verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)