### PR TITLE
fix(mentions): resolve Japanese file search issues (Unicode NFC/NFD, IME composition)

### DIFF
--- a/src/handlers/usage-history-handler.ts
+++ b/src/handlers/usage-history-handler.ts
@@ -71,9 +71,14 @@ class UsageHistoryHandler {
     filePaths: string[]
   ): Promise<Record<string, number>> {
     const bonuses: Record<string, number> = {};
+    const manager = getFileUsageHistoryManager();
 
     for (const filePath of filePaths) {
-      bonuses[filePath] = getFileUsageHistoryManager().calculateFileBonus(filePath);
+      try {
+        bonuses[filePath] = manager.calculateFileBonus(filePath);
+      } catch {
+        bonuses[filePath] = 0;
+      }
     }
 
     return bonuses;
@@ -105,8 +110,12 @@ class UsageHistoryHandler {
     const manager = getSymbolUsageHistoryManager();
 
     for (const { filePath, symbolName } of symbols) {
-      const key = manager.createSymbolKey(filePath, symbolName);
-      bonuses[key] = manager.calculateSymbolBonus(filePath, symbolName);
+      try {
+        const key = manager.createSymbolKey(filePath, symbolName);
+        bonuses[key] = manager.calculateSymbolBonus(filePath, symbolName);
+      } catch {
+        // Skip symbols with invalid paths
+      }
     }
 
     return bonuses;

--- a/src/lib/keyword-utils.ts
+++ b/src/lib/keyword-utils.ts
@@ -1,12 +1,16 @@
 /**
  * Split a search query into normalized lowercase keywords.
  * Fast-paths the single-word case to avoid regex overhead.
+ * Supports both ASCII space and full-width space (U+3000) for Japanese input.
  *
  * Shared by both main and renderer processes.
  */
+const WHITESPACE_PATTERN = /[\s\u3000]+/;
+
 export function splitKeywords(query: string): string[] {
-  if (query.indexOf(' ') === -1) {
+  // Fast-path: no whitespace characters at all
+  if (!WHITESPACE_PATTERN.test(query)) {
     return query.length > 0 ? [query] : [];
   }
-  return query.split(/\s+/).filter(k => k.length > 0);
+  return query.split(WHITESPACE_PATTERN).filter(k => k.length > 0);
 }

--- a/src/managers/file-usage-history-manager.ts
+++ b/src/managers/file-usage-history-manager.ts
@@ -36,12 +36,11 @@ class FileUsageHistoryManager extends UsageHistoryManager {
    * Removes leading/trailing slashes and normalizes separators
    */
   normalizeKey(filePath: string): string {
-    // Path traversal detection BEFORE normalization
-    // (path.normalize resolves .. sequences, so check must be done first)
-    if (filePath.includes('..')) {
+    const normalized = path.normalize(filePath);
+    // Check for '..' as an actual path segment (not just a substring in a name)
+    if (normalized.split(path.sep).includes('..')) {
       throw new Error('Path traversal detected');
     }
-    const normalized = path.normalize(filePath);
     return normalized.replace(/^\/+|\/+$/g, '');
   }
 

--- a/src/managers/symbol-usage-history-manager.ts
+++ b/src/managers/symbol-usage-history-manager.ts
@@ -36,12 +36,11 @@ class SymbolUsageHistoryManager extends UsageHistoryManager {
    * Format: {filePath}:{symbolName}
    */
   createSymbolKey(filePath: string, symbolName: string): string {
-    // Path traversal detection BEFORE normalization
-    // (path.normalize resolves .. sequences, so check must be done first)
-    if (filePath.includes('..')) {
+    const normalized = path.normalize(filePath);
+    // Check for '..' as an actual path segment (not just a substring in a name)
+    if (normalized.split(path.sep).includes('..')) {
       throw new Error('Path traversal detected');
     }
-    const normalized = path.normalize(filePath);
     return `${normalized}:${symbolName}`;
   }
 

--- a/src/renderer/history-search/history-search-manager.ts
+++ b/src/renderer/history-search/history-search-manager.ts
@@ -78,6 +78,8 @@ export class HistorySearchManager implements IInitializable {
 
       this.searchInput.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
+          // Skip during IME composition to allow composition cancellation
+          if (e.isComposing) return;
           e.preventDefault();
           e.stopPropagation();
           e.stopImmediatePropagation();

--- a/src/renderer/mention-manager.ts
+++ b/src/renderer/mention-manager.ts
@@ -606,7 +606,6 @@ export class MentionManager implements IInitializable {
     }
 
     const { query, startPos } = result;
-
     // Check if query matches a recently inserted path (prevent re-showing after selection)
     if (this.lastInsertedMentionPath) {
       if (query.trimEnd() === this.lastInsertedMentionPath ||

--- a/src/renderer/mentions/fuzzy-matcher.ts
+++ b/src/renderer/mentions/fuzzy-matcher.ts
@@ -26,7 +26,8 @@ class LowercaseCache {
     const cached = this.cache.get(str);
     if (cached !== undefined) return cached;
 
-    const lower = str.toLowerCase();
+    // Normalize to NFC to handle macOS NFD filenames vs NFC IME input
+    const lower = str.normalize('NFC').toLowerCase();
     this.cache.set(str, lower);
     return lower;
   }
@@ -68,8 +69,8 @@ export function getLowercaseCacheSize(): number {
  * Simple fuzzy matching - checks if pattern appears in text
  */
 export function fuzzyMatch(text: string, pattern: string): boolean {
-  // Simple substring match (case-insensitive)
-  return text.toLowerCase().includes(pattern.toLowerCase());
+  // Simple substring match (case-insensitive, NFC-normalized for macOS compatibility)
+  return text.normalize('NFC').toLowerCase().includes(pattern.normalize('NFC').toLowerCase());
 }
 
 /**

--- a/src/renderer/mentions/managers/event-listener-manager.ts
+++ b/src/renderer/mentions/managers/event-listener-manager.ts
@@ -58,6 +58,9 @@ export class EventListenerManager {
   private pendingInputUpdate: number | null = null;
   private pendingSelectionUpdate: number | null = null;
 
+  // IME composition tracking
+  private isComposing: boolean = false;
+
   // Throttle state for mousemove handler
   private lastMouseMoveTime: number = 0;
   private static readonly MOUSE_MOVE_THROTTLE = 80;
@@ -131,14 +134,18 @@ export class EventListenerManager {
     // Create bound input handler with rAF optimization
     // Skip processing if text hasn't changed to avoid redundant work
     this.boundInputHandler = () => {
+      // Skip during IME composition to avoid filtering with intermediate text
+      // (e.g., hiragana "しすとれ" before katakana conversion "シストレ")
+      if (this.isComposing) return;
+
       // Debounce with rAF - skip if already pending
       if (this.pendingInputUpdate) return;
 
       this.pendingInputUpdate = requestAnimationFrame(() => {
         this.pendingInputUpdate = null;
 
-        // Guard: skip if listeners are suspended
-        if (this.listenersAreSuspended) return;
+        // Guard: skip if listeners are suspended or composing
+        if (this.listenersAreSuspended || this.isComposing) return;
 
         if (!this.textInput) return;
         const currentText = this.textInput.value;
@@ -159,6 +166,31 @@ export class EventListenerManager {
 
     // Listen for input changes to detect @ mentions and update highlights
     this.textInput.addEventListener('input', this.boundInputHandler);
+
+    // Track IME composition state
+    this.textInput.addEventListener('compositionstart', () => {
+      this.isComposing = true;
+    });
+
+    // After IME composition ends, process the confirmed text synchronously.
+    // Using rAF here is unreliable: if the user quickly cycles conversion candidates
+    // (compositionend → compositionstart), the rAF fires after the new compositionstart
+    // and gets skipped by the isComposing guard.
+    this.textInput.addEventListener('compositionend', () => {
+      this.isComposing = false;
+      if (this.listenersAreSuspended || !this.textInput) return;
+
+      // Cancel pending rAF to prevent stale processing
+      if (this.pendingInputUpdate) {
+        cancelAnimationFrame(this.pendingInputUpdate);
+        this.pendingInputUpdate = null;
+      }
+
+      const currentText = this.textInput.value;
+      if (currentText === this.lastText) return;
+      this.lastText = currentText;
+      this.callbacks.checkForFileSearch();
+    });
 
     // Listen for keydown for navigation and backspace handling
     this.textInput.addEventListener('keydown', (e) => {

--- a/src/renderer/mentions/managers/file-filter-manager.ts
+++ b/src/renderer/mentions/managers/file-filter-manager.ts
@@ -168,7 +168,7 @@ export class FileFilterManager {
     }
 
     // Score and filter files
-    const queryLower = query.toLowerCase();
+    const queryLower = query.normalize('NFC').toLowerCase();
     const keywords = splitKeywords(queryLower);
     const scored = files
       .map(file => {
@@ -294,7 +294,7 @@ export class FileFilterManager {
     // Select source files: previous results or all files
     const sourceFiles = canUseIncrementalSearch ? this.lastResults : allFiles;
 
-    const queryLower = query.toLowerCase();
+    const queryLower = query.normalize('NFC').toLowerCase();
     const keywords = splitKeywords(queryLower);
     const seenDirs = new Set<string>();
     const seenDirNames = new Map<string, { path: string; depth: number }>();
@@ -313,40 +313,34 @@ export class FileFilterManager {
       })
       .filter(item => item.score > 0);
 
-    // Find matching directories (by path containing the query)
+    // Find matching directories from:
+    // 1. Explicit directory entries in sourceFiles (isDirectory: true)
+    // 2. Intermediate directories in file paths
     for (const file of sourceFiles) {
 
       const relativePath = getRelativePath(file.path, baseDir);
       const pathParts = relativePath.split('/').filter(p => p);
 
+      // Handle explicit directory entries directly (e.g., Stage 1 top-level directories)
+      if (file.isDirectory && pathParts.length > 0) {
+        const dirPath = pathParts.join('/');
+        const dirName = pathParts[pathParts.length - 1] || '';
+        this.addMatchingDir(dirName, dirPath, pathParts.length, file, keywords, seenDirs, seenDirNames, matchingDirs);
+        continue;
+      }
+
       // Check each directory in the path (except the last part which is the file name)
       for (let i = 0; i < pathParts.length - 1; i++) {
         const dirPath = pathParts.slice(0, i + 1).join('/');
         const dirName = pathParts[i] || '';
+        if (!dirName) continue;
 
-        if (!dirName || seenDirs.has(dirPath)) continue;
-
-        // Check if directory name or path matches all keywords (AND condition)
-        const dirNameLower = dirName.toLowerCase();
-        const dirPathLower = dirPath.toLowerCase();
-        if (keywords.every(kw => dirNameLower.includes(kw) || dirPathLower.includes(kw))) {
-          seenDirs.add(dirPath);
-
-          // Prefer shorter paths (likely the original, not symlink-resolved)
-          const depth = pathParts.length;
-          const existing = seenDirNames.get(dirName);
-          if (existing && existing.depth <= depth) {
-            continue;
-          }
-
-          seenDirNames.set(dirName, { path: dirPath, depth });
-          const virtualDir: FileInfo = {
-            name: dirName,
-            path: baseDir + '/' + dirPath,
-            isDirectory: true
-          };
-          matchingDirs.push(virtualDir);
-        }
+        const virtualDir: FileInfo = {
+          name: dirName,
+          path: baseDir + '/' + dirPath,
+          isDirectory: true
+        };
+        this.addMatchingDir(dirName, dirPath, pathParts.length, virtualDir, keywords, seenDirs, seenDirNames, matchingDirs);
       }
     }
 
@@ -388,6 +382,36 @@ export class FileFilterManager {
 
     // Return truncated results
     return fullResults.slice(0, maxSuggestions);
+  }
+
+  /**
+   * Check if a directory matches all keywords and track it for dedup.
+   * Shared by explicit directory entry handling and intermediate directory detection.
+   */
+  private addMatchingDir(
+    dirName: string,
+    dirPath: string,
+    depth: number,
+    dirEntry: FileInfo,
+    keywords: string[],
+    seenDirs: Set<string>,
+    seenDirNames: Map<string, { path: string; depth: number }>,
+    matchingDirs: FileInfo[]
+  ): void {
+    if (!dirName || seenDirs.has(dirPath)) return;
+
+    const dirNameLower = dirName.normalize('NFC').toLowerCase();
+    const dirPathLower = dirPath.normalize('NFC').toLowerCase();
+    if (!keywords.every(kw => dirNameLower.includes(kw) || dirPathLower.includes(kw))) return;
+
+    seenDirs.add(dirPath);
+
+    // Prefer shorter paths (shallower depth)
+    const existing = seenDirNames.get(dirName);
+    if (existing && existing.depth <= depth) return;
+
+    seenDirNames.set(dirName, { path: dirPath, depth });
+    matchingDirs.push(dirEntry);
   }
 
   /**
@@ -464,7 +488,7 @@ export class FileFilterManager {
     baseDir?: string
   ): SuggestionItem[] {
     const items: SuggestionItem[] = [];
-    const queryLower = query.toLowerCase();
+    const queryLower = query.normalize('NFC').toLowerCase();
     const keywords = splitKeywords(queryLower);
 
     // Add files with scores (including usage bonuses)

--- a/src/renderer/mentions/managers/suggestion-ui-manager.ts
+++ b/src/renderer/mentions/managers/suggestion-ui-manager.ts
@@ -114,6 +114,8 @@ export class SuggestionUIManager {
   // D6: Track last queries to skip redundant buildHighlightCache calls
   private lastHighlightQuery: string = '';
   private lastCodeSearchHighlightQuery: string = '';
+  // Sequence counter to detect stale async showSuggestions completions
+  private showSuggestionsSeq: number = 0;
 
   constructor(textInput: HTMLTextAreaElement, callbacks: SuggestionUICallbacks) {
     this.textInput = textInput;
@@ -273,8 +275,13 @@ export class SuggestionUIManager {
       return;
     }
 
+    // Track this call's sequence number to detect stale async completions.
+    // If a newer showSuggestions call starts while we're awaiting, our results are stale.
+    const seq = ++this.showSuggestionsSeq;
+
     // Check if query matches any searchPrefix for mention type
     const matchesPrefix = await this.callbacks.matchesSearchPrefix?.(query, 'mention') ?? false;
+    if (seq !== this.showSuggestionsSeq) return;
 
     // Adjust currentPath based on query
     if (!matchesPrefix) {
@@ -299,6 +306,7 @@ export class SuggestionUIManager {
     const fileUsageBonusesPromise = this.callbacks.getFileUsageBonuses?.() ?? Promise.resolve({} as Record<string, number>);
 
     const [agents, fileUsageBonuses] = await Promise.all([agentsPromise, fileUsageBonusesPromise]);
+    if (seq !== this.showSuggestionsSeq) return;
     this.callbacks.setFilteredAgents?.(agents);
 
     // Filter files if directory data is available
@@ -313,6 +321,7 @@ export class SuggestionUIManager {
 
     // Get maxSuggestions setting for merged list
     const maxSuggestions = await this.callbacks.getMaxSuggestions?.('mention') ?? 20;
+    if (seq !== this.showSuggestionsSeq) return;
 
     // Strip searchPrefix from query for scoring (e.g., "plan:" → "", "plan:custom" → "custom")
     let scoringQuery = searchTerm;
@@ -326,7 +335,6 @@ export class SuggestionUIManager {
     // Merge files and agents into a single sorted list
     const merged = this.callbacks.mergeSuggestions?.(scoringQuery, maxSuggestions, fileUsageBonuses) ?? [];
     this.callbacks.setMergedSuggestions?.(merged);
-
     this.callbacks.setSelectedIndex?.(0);
     this.callbacks.setIsVisible?.(true);
 
@@ -367,6 +375,11 @@ export class SuggestionUIManager {
    */
   public handleKeyDown(e: KeyboardEvent): boolean {
     if (!this.isVisible) return false;
+
+    // Skip all key handling during IME composition to allow Japanese input
+    if (e.isComposing || this.callbacks.getIsComposing?.()) {
+      return false;
+    }
 
     const totalItems = this.mergedSuggestions.length;
     const currentIndex = this.selectedIndex;
@@ -422,10 +435,6 @@ export class SuggestionUIManager {
   }
 
   private handleEnterKey(e: KeyboardEvent, totalItems: number, currentIndex: number): boolean {
-    if (e.isComposing || this.callbacks.getIsComposing?.()) {
-      return false;
-    }
-
     if (totalItems > 0) {
       e.preventDefault();
       e.stopPropagation();
@@ -449,10 +458,6 @@ export class SuggestionUIManager {
   }
 
   private handleTabKey(e: KeyboardEvent, totalItems: number, currentIndex: number): boolean {
-    if (e.isComposing || this.callbacks.getIsComposing?.()) {
-      return false;
-    }
-
     if (totalItems > 0) {
       e.preventDefault();
       e.stopPropagation();

--- a/tests/integration/file-filter-directory-search.test.ts
+++ b/tests/integration/file-filter-directory-search.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration test for FileFilterManager directory search.
+ * Verifies that directories (especially Japanese-named ones) are found
+ * when searching with a query at root level, even when only Stage 1
+ * (single-level) data is available (no files inside the directory).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { FileFilterManager } from '../../src/renderer/mentions/managers/file-filter-manager';
+import type { DirectoryData } from '../../src/renderer/mentions/types';
+import type { FileInfo } from '../../src/types';
+
+const baseDir = '/test';
+
+function createManager(): FileFilterManager {
+  return new FileFilterManager({
+    getDefaultMaxSuggestions: () => 20,
+  });
+}
+
+// Stage 1 data: only top-level entries (directories have isDirectory: true, no child files)
+const stage1Files: FileInfo[] = [
+  { name: '_archive', path: '/test/_archive', isDirectory: true },
+  { name: 'My Notes', path: '/test/My Notes', isDirectory: true },
+  { name: 'DOCS', path: '/test/DOCS', isDirectory: true },
+  { name: 'プロジェクト', path: '/test/プロジェクト', isDirectory: true },
+  { name: 'ドキュメント', path: '/test/ドキュメント', isDirectory: true },
+  { name: '設計書', path: '/test/設計書', isDirectory: true },
+  { name: 'README.md', path: '/test/README.md', isDirectory: false },
+];
+
+// Stage 2 data: includes files inside directories
+const stage2Files: FileInfo[] = [
+  ...stage1Files,
+  { name: 'main.py', path: '/test/プロジェクト/main.py', isDirectory: false },
+  { name: 'utils.py', path: '/test/プロジェクト/utils.py', isDirectory: false },
+  { name: 'report.xlsx', path: '/test/ドキュメント/report.xlsx', isDirectory: false },
+  { name: 'notes.md', path: '/test/DOCS/notes.md', isDirectory: false },
+];
+
+function makeCachedData(files: FileInfo[]): DirectoryData {
+  return {
+    directory: baseDir,
+    files,
+    timestamp: Date.now(),
+  };
+}
+
+describe('FileFilterManager directory search', () => {
+  let manager: FileFilterManager;
+
+  beforeEach(() => {
+    manager = createManager();
+  });
+
+  describe('Stage 1 data (top-level directories only)', () => {
+    test('empty query shows all top-level entries', () => {
+      const result = manager.filterFiles(makeCachedData(stage1Files), '', '');
+      expect(result).toHaveLength(stage1Files.length);
+    });
+
+    test('Japanese query finds matching directory', () => {
+      const result = manager.filterFiles(makeCachedData(stage1Files), '', 'プロジェクト');
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result.some(f => f.name === 'プロジェクト')).toBe(true);
+    });
+
+    test('partial Japanese query finds matching directory', () => {
+      const result = manager.filterFiles(makeCachedData(stage1Files), '', 'プロジェ');
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result.some(f => f.name === 'プロジェクト')).toBe(true);
+    });
+
+    test('English query finds matching directory', () => {
+      const result = manager.filterFiles(makeCachedData(stage1Files), '', 'DOCS');
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result.some(f => f.name === 'DOCS')).toBe(true);
+    });
+
+    test('case-insensitive English query', () => {
+      const result = manager.filterFiles(makeCachedData(stage1Files), '', 'docs');
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result.some(f => f.name === 'DOCS')).toBe(true);
+    });
+
+    test('non-matching query returns empty', () => {
+      const result = manager.filterFiles(makeCachedData(stage1Files), '', 'zzzzz');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('Stage 2 data (with files inside directories)', () => {
+    test('Japanese query finds directory even with child files', () => {
+      const result = manager.filterFiles(makeCachedData(stage2Files), '', 'プロジェクト');
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result.some(f => f.name === 'プロジェクト' && f.isDirectory)).toBe(true);
+    });
+
+    test('does not duplicate directories found via both explicit entry and path', () => {
+      const result = manager.filterFiles(makeCachedData(stage2Files), '', 'プロジェクト');
+      const dirs = result.filter(f => f.name === 'プロジェクト' && f.isDirectory);
+      expect(dirs).toHaveLength(1);
+    });
+  });
+
+  describe('mixed queries', () => {
+    test('query matching file name finds file', () => {
+      const result = manager.filterFiles(makeCachedData(stage2Files), '', 'README');
+      expect(result.some(f => f.name === 'README.md')).toBe(true);
+    });
+
+    test('query matching both file and directory returns both', () => {
+      const result = manager.filterFiles(makeCachedData(stage2Files), '', 'ドキュメント');
+      expect(result.some(f => f.name === 'ドキュメント' && f.isDirectory)).toBe(true);
+    });
+  });
+});

--- a/tests/integration/scoring/history-search-scoring.test.ts
+++ b/tests/integration/scoring/history-search-scoring.test.ts
@@ -127,6 +127,36 @@ describe('History Search Scoring', () => {
     });
   });
 
+  describe('Japanese text search', () => {
+    test('searches Japanese text', () => {
+      const history: HistoryItem[] = [
+        { text: 'テスト用のコマンド', timestamp: Date.now() - 1000, id: 'jp1' },
+        { text: 'hello world', timestamp: Date.now() - 2000, id: 'en1' },
+        { text: '検索機能のテスト', timestamp: Date.now() - 3000, id: 'jp2' },
+      ];
+
+      const result = filterEngine.filter(history, 'テスト');
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items.map(i => i.id)).toContain('jp1');
+      expect(result.items.map(i => i.id)).toContain('jp2');
+    });
+
+    test('AND search with full-width space separated keywords', () => {
+      const history: HistoryItem[] = [
+        { text: 'テスト 検索 実行', timestamp: Date.now() - 1000, id: 'all-match' },
+        { text: 'テスト のみ', timestamp: Date.now() - 2000, id: 'partial-match' },
+        { text: '関係ないテキスト', timestamp: Date.now() - 3000, id: 'no-match' },
+      ];
+
+      // Full-width space between keywords: AND search
+      const result = filterEngine.filter(history, 'テスト\u3000検索');
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe('all-match');
+    });
+  });
+
   // Tests with real data - skip if no data available
   describe.skip('Real data tests (requires ~/.prompt-line/history.jsonl)', () => {
     let realData: RealTestData | null = null;

--- a/tests/integration/suggestion-ui-stale-check.test.ts
+++ b/tests/integration/suggestion-ui-stale-check.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Integration test for SuggestionUIManager stale async check.
+ * Simulates the IME composition race condition where showSuggestions("")
+ * (from initial "@" trigger) resolves AFTER showSuggestions("プロジェクト")
+ * (from composition input), overwriting filtered results with unfiltered ones.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { SuggestionUIManager } from '../../src/renderer/mentions/managers/suggestion-ui-manager';
+import type { SuggestionItem } from '../../src/renderer/mentions/types';
+import type { FileInfo, AgentItem } from '../../src/types';
+
+// Track what was rendered
+let lastRenderedSuggestions: SuggestionItem[] = [];
+
+// Control async resolution order
+let matchesPrefixResolvers: Array<(value: boolean) => void> = [];
+let maxSuggestionsResolvers: Array<(value: number) => void> = [];
+
+const allFiles: FileInfo[] = [
+  { name: '_archive', path: '/test/_archive', isDirectory: true },
+  { name: 'My Notes', path: '/test/My Notes', isDirectory: true },
+  { name: 'DOCS', path: '/test/DOCS', isDirectory: true },
+  { name: 'プロジェクト', path: '/test/プロジェクト', isDirectory: true },
+  { name: 'ドキュメント', path: '/test/ドキュメント', isDirectory: true },
+  { name: '設計書', path: '/test/設計書', isDirectory: true },
+];
+
+function setupDOM(): { textarea: HTMLTextAreaElement; container: HTMLElement } {
+  // SuggestionUIManager needs these DOM elements
+  const container = document.createElement('div');
+  container.id = 'fileSuggestions';
+  document.body.appendChild(container);
+
+  const textarea = document.createElement('textarea');
+  textarea.id = 'textInput';
+  document.body.appendChild(textarea);
+
+  return { textarea, container };
+}
+
+function createCallbacks() {
+  const state = {
+    filteredFiles: [] as FileInfo[],
+    filteredAgents: [] as AgentItem[],
+    currentPath: '',
+  };
+
+  return {
+    getCachedDirectoryData: () => ({
+      directory: '/test',
+      files: allFiles,
+      timestamp: Date.now(),
+    }),
+    getAtStartPosition: () => 0,
+    adjustCurrentPathToQuery: () => {},
+    filterFiles: (query: string) => {
+      if (!query) return allFiles;
+      const q = query.toLowerCase();
+      return allFiles.filter(f => f.name.toLowerCase().includes(q));
+    },
+    mergeSuggestions: (query: string) => {
+      return state.filteredFiles.map(f => ({
+        type: 'file' as const,
+        file: f,
+        score: query ? 100 : 50,
+      }));
+    },
+    searchAgents: async () => [] as AgentItem[],
+    getFileUsageBonuses: async () => ({} as Record<string, number>),
+    matchesSearchPrefix: async () => {
+      return new Promise<boolean>(resolve => {
+        matchesPrefixResolvers.push(resolve);
+      });
+    },
+    getMaxSuggestions: async () => {
+      return new Promise<number>(resolve => {
+        maxSuggestionsResolvers.push(resolve);
+      });
+    },
+    isIndexBeingBuilt: () => false,
+    showIndexingHint: () => {},
+    showTooltipForSelectedItem: () => {},
+    setFilteredFiles: (f: FileInfo[]) => { state.filteredFiles = f; },
+    setFilteredAgents: (a: AgentItem[]) => { state.filteredAgents = a; },
+    setMergedSuggestions: () => {},
+    setCurrentQuery: () => {},
+    setCurrentPath: (p: string) => { state.currentPath = p; },
+    getCurrentPath: () => state.currentPath,
+    setSelectedIndex: () => {},
+    setIsVisible: () => {},
+    restoreDefaultHint: () => {},
+  };
+}
+
+// Helper to flush microtasks
+async function flushMicrotasks(count = 5) {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('SuggestionUIManager stale async check', () => {
+  let manager: SuggestionUIManager;
+  let textarea: HTMLTextAreaElement;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    matchesPrefixResolvers = [];
+    maxSuggestionsResolvers = [];
+    lastRenderedSuggestions = [];
+
+    const dom = setupDOM();
+    textarea = dom.textarea;
+    container = dom.container;
+
+    manager = new SuggestionUIManager(textarea, createCallbacks());
+
+    // Spy on show() to track rendered suggestions without actual DOM rendering
+    vi.spyOn(manager, 'show').mockImplementation((suggestions) => {
+      lastRenderedSuggestions = [...suggestions];
+    });
+  });
+
+  afterEach(() => {
+    container.remove();
+    textarea.remove();
+    vi.restoreAllMocks();
+  });
+
+  test('stale showSuggestions("") does not overwrite filtered showSuggestions("プロジェクト")', async () => {
+    // Step 1: showSuggestions("") - from "@" trigger
+    const p1 = manager.showSuggestions('');
+    // Step 2: showSuggestions("プロジェクト") - from composition
+    const p2 = manager.showSuggestions('プロジェクト');
+
+    expect(matchesPrefixResolvers).toHaveLength(2);
+
+    // Resolve SECOND first (faster response for filtered query)
+    matchesPrefixResolvers[1]!(false);
+    await flushMicrotasks();
+
+    // Second call should proceed to maxSuggestions
+    expect(maxSuggestionsResolvers).toHaveLength(1);
+    maxSuggestionsResolvers[0]!(20);
+    await flushMicrotasks();
+
+    // Now resolve FIRST (slow empty-query response arriving late)
+    matchesPrefixResolvers[0]!(false);
+    await flushMicrotasks();
+
+    await Promise.allSettled([p1, p2]);
+
+    // CRITICAL: Only "プロジェクト" should be in results, NOT all 6 files
+    expect(lastRenderedSuggestions).toHaveLength(1);
+    expect(lastRenderedSuggestions[0]?.file?.name).toBe('プロジェクト');
+  });
+
+  test('FIFO order: first call bails out, second call renders correctly', async () => {
+    const p1 = manager.showSuggestions('');
+    const p2 = manager.showSuggestions('プロジェクト');
+
+    expect(matchesPrefixResolvers).toHaveLength(2);
+
+    // Resolve in FIFO order
+    matchesPrefixResolvers[0]!(false);
+    await flushMicrotasks();
+
+    // First call should bail (stale: seq=1 !== currentSeq=2)
+    // It should NOT create a maxSuggestions resolver
+    expect(maxSuggestionsResolvers).toHaveLength(0);
+
+    // Resolve second
+    matchesPrefixResolvers[1]!(false);
+    await flushMicrotasks();
+
+    expect(maxSuggestionsResolvers).toHaveLength(1);
+    maxSuggestionsResolvers[0]!(20);
+    await flushMicrotasks();
+
+    await Promise.allSettled([p1, p2]);
+
+    expect(lastRenderedSuggestions).toHaveLength(1);
+    expect(lastRenderedSuggestions[0]?.file?.name).toBe('プロジェクト');
+  });
+
+  test('single call works normally', async () => {
+    const p = manager.showSuggestions('プロジェクト');
+
+    expect(matchesPrefixResolvers).toHaveLength(1);
+    matchesPrefixResolvers[0]!(false);
+    await flushMicrotasks();
+
+    expect(maxSuggestionsResolvers).toHaveLength(1);
+    maxSuggestionsResolvers[0]!(20);
+    await flushMicrotasks();
+
+    await p;
+
+    expect(lastRenderedSuggestions).toHaveLength(1);
+    expect(lastRenderedSuggestions[0]?.file?.name).toBe('プロジェクト');
+  });
+
+  test('many concurrent calls (rapid IME composition) - only latest takes effect', async () => {
+    // Simulate: @ → プ → プロ → プロジェ → プロジェクト
+    const promises = [
+      manager.showSuggestions(''),
+      manager.showSuggestions('プ'),
+      manager.showSuggestions('プロ'),
+      manager.showSuggestions('プロジェ'),
+      manager.showSuggestions('プロジェクト'),
+    ];
+
+    expect(matchesPrefixResolvers).toHaveLength(5);
+
+    // Resolve all in FIFO order
+    for (let i = 0; i < 5; i++) {
+      matchesPrefixResolvers[i]!(false);
+      await flushMicrotasks();
+    }
+
+    // Only the LAST call (seq=5) should proceed to maxSuggestions
+    expect(maxSuggestionsResolvers).toHaveLength(1);
+    maxSuggestionsResolvers[0]!(20);
+    await flushMicrotasks();
+
+    await Promise.allSettled(promises);
+
+    // Only "プロジェクト" directory should match
+    expect(lastRenderedSuggestions).toHaveLength(1);
+    expect(lastRenderedSuggestions[0]?.file?.name).toBe('プロジェクト');
+  });
+
+  test('empty query shows all items when no race condition', async () => {
+    const p = manager.showSuggestions('');
+
+    expect(matchesPrefixResolvers).toHaveLength(1);
+    matchesPrefixResolvers[0]!(false);
+    await flushMicrotasks();
+
+    expect(maxSuggestionsResolvers).toHaveLength(1);
+    maxSuggestionsResolvers[0]!(20);
+    await flushMicrotasks();
+
+    await p;
+
+    // All 6 items should be shown
+    expect(lastRenderedSuggestions).toHaveLength(6);
+  });
+});

--- a/tests/unit/keyword-utils.test.ts
+++ b/tests/unit/keyword-utils.test.ts
@@ -1,0 +1,41 @@
+import { splitKeywords } from '../../src/lib/keyword-utils';
+
+describe('splitKeywords', () => {
+  describe('full-width space (U+3000) support', () => {
+    test('splits on full-width space', () => {
+      expect(splitKeywords('テスト\u3000検索')).toEqual(['テスト', '検索']);
+    });
+
+    test('splits on mixed ASCII and full-width spaces', () => {
+      expect(splitKeywords('テスト 検索\u3000実行')).toEqual(['テスト', '検索', '実行']);
+    });
+
+    test('returns empty array for full-width space only', () => {
+      expect(splitKeywords('\u3000')).toEqual([]);
+    });
+  });
+
+  describe('Japanese text without spaces', () => {
+    test('returns single keyword for Japanese text with no spaces', () => {
+      expect(splitKeywords('テスト')).toEqual(['テスト']);
+    });
+  });
+
+  describe('existing ASCII behavior', () => {
+    test('splits on ASCII space', () => {
+      expect(splitKeywords('hello world')).toEqual(['hello', 'world']);
+    });
+
+    test('returns empty array for empty string', () => {
+      expect(splitKeywords('')).toEqual([]);
+    });
+
+    test('trims leading and trailing spaces', () => {
+      expect(splitKeywords('  hello world  ')).toEqual(['hello', 'world']);
+    });
+
+    test('collapses multiple spaces', () => {
+      expect(splitKeywords('hello   world')).toEqual(['hello', 'world']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix Unicode NFC/NFD mismatch**: macOS stores filenames in NFD (decomposed) form while Japanese IME produces NFC (composed) characters, causing `String.includes()` to fail silently for characters with dakuten (e.g., katakana with voiced marks). Apply `.normalize('NFC')` at key comparison points in `LowercaseCache`, `fuzzyMatch`, `addMatchingDir`, and query generation.
- **Fix IME composition handling**: Skip `input` event processing during IME composition to avoid filtering with intermediate hiragana text. Process confirmed text synchronously in `compositionend` handler (rAF is unreliable due to rapid composition cycling).
- **Fix path traversal detection**: `filePath.includes('..')` matched `..` as substring in filenames (e.g., cloud storage paths with `..` in directory names). Changed to check `..` as an actual path segment after `path.normalize()`.
- **Add per-path error handling**: One invalid path in usage history no longer breaks the entire IPC call.

## Test plan

- [x] Type check passes (`pnpm run typecheck`)
- [x] All 1144 tests pass (`pnpm test`)
- [x] Manual testing: Japanese directory names with dakuten characters are correctly filtered in `@` file search
- [x] Existing tests for keyword-utils, file-filter, stale-check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)