### PR TITLE
Fix {args.key} template resolution and add icon documentation

### DIFF
--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -89,6 +89,7 @@ sourcePath: ~/my-project/skills/**/*/SKILL.md
 name: "{frontmatter@name}"
 description: "{frontmatter@description}"
 argumentHint: "{frontmatter@argument-hint}"
+icon: codicon-edit-sparkle
 ```
 
 **Custom search example** — `~/.prompt-line/custom-search/my-notes.yaml`:
@@ -97,6 +98,7 @@ sourcePath: ~/notes/**/*.md
 name: "{basename}"
 description: "{heading}"
 searchPrefix: note
+icon: codicon-note
 ```
 
 **Built-in commands example** — `~/.prompt-line/agent-built-in/my-tool.yaml`:
@@ -108,12 +110,15 @@ commands:
   - name: deploy
     description: Deploy to production
     argument-hint: "[env]"
+    icon: codicon-rocket
 skills:
   - name: test
     description: Run test suite
+    icon: codicon-beaker
 agents:
   - name: reviewer
     description: Code review agent
+    icon: codicon-eye
 ```
 
 ### Managing with a Git repository
@@ -159,6 +164,7 @@ YAML files are copied to `~/.prompt-line/plugins/` and then enabled via `setting
 ```yaml
 name: Tool Name                       # Display name
 color: amber                          # Badge color
+icon: codicon-tools                   # Codicon icon (see Icon section)
 reference: https://example.com/docs   # Single reference URL
 references:                           # Or multiple URLs
   - https://example.com/commands
@@ -168,12 +174,15 @@ commands:
     description: Create a git commit
     argument-hint: "[-m message]"
     color: green                      # Per-item color override
+    icon: codicon-git-commit          # Per-item icon override
 skills:
   - name: batch
     description: Run batch operations
+    icon: codicon-run-all
 agents:
   - name: Explore
     description: Fast codebase exploration
+    icon: codicon-search
 ```
 
 ### agent-skills
@@ -186,6 +195,7 @@ name: "{frontmatter@name}"
 label: global
 description: "{frontmatter@description}"
 argumentHint: "{frontmatter@argument-hint}"
+icon: codicon-edit-sparkle
 ```
 
 Also works with commands:
@@ -193,6 +203,7 @@ Also works with commands:
 sourcePath: ~/.claude/commands/*.md
 name: "{basename}"
 description: "{frontmatter@description}"
+icon: codicon-terminal
 ```
 
 #### Fields
@@ -234,6 +245,7 @@ name: "{basename}(agent)"
 label: global
 description: "{frontmatter@description}"
 displayTime: "{updatedAt}"
+icon: codicon-hubot
 ```
 
 #### Additional fields (custom-search only)
@@ -328,6 +340,19 @@ Badge colors support named colors and hex codes:
 **Named:** grey, darkGrey, slate, stone, red, rose, orange, amber, yellow, lime, green, emerald, teal, cyan, sky, blue, indigo, violet, purple, fuchsia, pink
 
 **Hex:** `#RGB` or `#RRGGBB` (e.g., `#FF6B35`, `#F63`)
+
+## Icon
+
+Set the `icon` field to a [Codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html) class name to display an icon next to the item.
+
+```yaml
+icon: codicon-rocket          # Rocket icon
+icon: codicon-terminal        # Terminal icon
+icon: codicon-edit-sparkle    # Edit sparkle (used for skills)
+icon: codicon-hubot           # Robot icon (used for agents)
+```
+
+Icons can be set at both the entry level (applies to all items) and per-item level (overrides entry-level). Browse all available icons at [Codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html).
 
 ## Hot Reload
 

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -89,6 +89,7 @@ sourcePath: ~/my-project/skills/**/*/SKILL.md
 name: "{frontmatter@name}"
 description: "{frontmatter@description}"
 argumentHint: "{frontmatter@argument-hint}"
+icon: codicon-edit-sparkle
 ```
 
 **カスタム検索の例** — `~/.prompt-line/custom-search/my-notes.yaml`:
@@ -97,6 +98,7 @@ sourcePath: ~/notes/**/*.md
 name: "{basename}"
 description: "{heading}"
 searchPrefix: note
+icon: codicon-note
 ```
 
 **組み込みコマンドの例** — `~/.prompt-line/agent-built-in/my-tool.yaml`:
@@ -108,12 +110,15 @@ commands:
   - name: deploy
     description: 本番環境にデプロイ
     argument-hint: "[env]"
+    icon: codicon-rocket
 skills:
   - name: test
     description: テストスイートを実行
+    icon: codicon-beaker
 agents:
   - name: reviewer
     description: コードレビューエージェント
+    icon: codicon-eye
 ```
 
 ### Gitリポジトリで管理
@@ -159,6 +164,7 @@ YAMLファイルは `~/.prompt-line/plugins/` にコピーされ、`settings.yam
 ```yaml
 name: ツール名                         # 表示名
 color: amber                          # バッジカラー
+icon: codicon-tools                   # Codiconアイコン（アイコンの項を参照）
 reference: https://example.com/docs   # 参照URL（単一）
 references:                           # または複数URL
   - https://example.com/commands
@@ -168,12 +174,15 @@ commands:
     description: gitコミットを作成
     argument-hint: "[-m message]"
     color: green                      # アイテム個別のカラー上書き
+    icon: codicon-git-commit          # アイテム個別のアイコン上書き
 skills:
   - name: batch
     description: バッチ操作を実行
+    icon: codicon-run-all
 agents:
   - name: Explore
     description: 高速コードベース探索
+    icon: codicon-search
 ```
 
 ### agent-skills
@@ -186,6 +195,7 @@ name: "{frontmatter@name}"
 label: global
 description: "{frontmatter@description}"
 argumentHint: "{frontmatter@argument-hint}"
+icon: codicon-edit-sparkle
 ```
 
 コマンドにも対応：
@@ -193,6 +203,7 @@ argumentHint: "{frontmatter@argument-hint}"
 sourcePath: ~/.claude/commands/*.md
 name: "{basename}"
 description: "{frontmatter@description}"
+icon: codicon-terminal
 ```
 
 #### フィールド
@@ -234,6 +245,7 @@ name: "{basename}(agent)"
 label: global
 description: "{frontmatter@description}"
 displayTime: "{updatedAt}"
+icon: codicon-hubot
 ```
 
 #### 追加フィールド（custom-search専用）
@@ -328,6 +340,19 @@ sourcePath: "~/.claude/teams/**/config.json@. | select(.active)"  # JSON + jq
 **名前付き：** grey, darkGrey, slate, stone, red, rose, orange, amber, yellow, lime, green, emerald, teal, cyan, sky, blue, indigo, violet, purple, fuchsia, pink
 
 **16進コード：** `#RGB` または `#RRGGBB`（例: `#FF6B35`, `#F63`）
+
+## アイコン
+
+`icon` フィールドに [Codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html) のクラス名を指定すると、アイテムの横にアイコンが表示されます。
+
+```yaml
+icon: codicon-rocket          # ロケットアイコン
+icon: codicon-terminal        # ターミナルアイコン
+icon: codicon-edit-sparkle    # 編集スパークル（スキル向け）
+icon: codicon-hubot           # ロボットアイコン（エージェント向け）
+```
+
+アイコンはエントリレベル（全アイテムに適用）とアイテム個別レベル（エントリレベルを上書き）の両方で設定できます。利用可能なアイコン一覧は [Codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html) を参照してください。
 
 ## ホットリロード
 

--- a/src/lib/template-resolver.ts
+++ b/src/lib/template-resolver.ts
@@ -11,6 +11,7 @@
  * - {heading}: 最初の # heading のテキスト
  * - {json@path}: JSONデータの値参照（ドット記法・配列インデックス対応）
  * - {json:N@path}: 親要素のJSONデータ参照（N=1: 直接の親、N=2: 2つ上の親）
+ * - {args.key}: テンプレート引数（例: args: { open: "iTerm" } → {args.open} = "iTerm"）
  * - {content}: ファイルの全コンテンツ
  * - {filepath}: ファイルの絶対パス
  *
@@ -34,6 +35,8 @@ export interface TemplateContext {
   content?: string;
   jsonData?: Record<string, unknown>;
   parentJsonDataStack?: Record<string, unknown>[];
+  /** テンプレート引数（{args.key} として解決される） */
+  args?: Record<string, string>;
 }
 
 /**
@@ -127,6 +130,13 @@ export function resolveTemplate(
       const stack = context.parentJsonDataStack!;
       if (index < 0 || index >= stack.length) return '';
       return t(resolveJsonPath(stack[index]!, jsonPath));
+    });
+  }
+
+  // Replace {args.key}
+  if (context.args) {
+    result = result.replace(/\{args\.([^}]+)\}/g, (_, key: string) => {
+      return t(context.args![key] ?? '');
     });
   }
 

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -953,7 +953,7 @@ class CustomSearchLoader extends EventEmitter {
       const jsonData = isJsonFile ? parseJsonContent(content) : undefined;
       const hasValues = Object.keys(values).length > 0;
       const basePath = splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir());
-      const context = { basename, frontmatter, prefix, dirname, filePath, basePath, heading, content, ...(hasValues && { values }), ...(jsonData && { jsonData }) };
+      const context = { basename, frontmatter, prefix, dirname, filePath, basePath, heading, content, ...(hasValues && { values }), ...(jsonData && { jsonData }), ...(entry.args && { args: entry.args }) };
 
       const item: CustomSearchItem = {
         name: resolveTemplate(entry.name, context),
@@ -1096,7 +1096,7 @@ class CustomSearchLoader extends EventEmitter {
     values?: Record<string, string>
   ): CustomSearchItem | null {
     const basePath = entry.sourcePath ? splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir()) : '';
-    const context = { basename, frontmatter: {}, prefix, dirname, filePath, basePath, heading, line: trimmed, content, ...(values && { values }) };
+    const context = { basename, frontmatter: {}, prefix, dirname, filePath, basePath, heading, line: trimmed, content, ...(values && { values }), ...(entry.args && { args: entry.args }) };
     const item: CustomSearchItem = {
       name: resolveTemplate(entry.name, context),
       description: resolveTemplate(entry.description, context),
@@ -1380,7 +1380,7 @@ class CustomSearchLoader extends EventEmitter {
     content?: string
   ): CustomSearchItem | null {
     const basePath = entry.sourcePath ? splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir()) : '';
-    const context = { basename, frontmatter: {}, prefix: '', dirname, filePath, basePath, heading: '', jsonData: elementData, ...(parentJsonDataStack && { parentJsonDataStack }), ...(content !== undefined && { content }) };
+    const context = { basename, frontmatter: {}, prefix: '', dirname, filePath, basePath, heading: '', jsonData: elementData, ...(parentJsonDataStack && { parentJsonDataStack }), ...(content !== undefined && { content }), ...(entry.args && { args: entry.args }) };
     const item: CustomSearchItem = {
       name: resolveTemplate(entry.name, context),
       description: resolveTemplate(entry.description, context),


### PR DESCRIPTION
## Summary
- **Fix `{args.open}` template variable not being resolved** in custom search commands — the `args` field was loaded from plugin YAML but never passed to the template context, and the resolver had no `{args.key}` handler
- **Add icon (`codicon`) documentation** to plugin guide (EN/JA) with examples in all YAML samples and a dedicated Icon section linking to the Codicon reference

## Test plan
- [x] TypeScript type check passes
- [x] All 1231 tests pass
- [ ] Verify `{args.open}` resolves correctly in a custom search plugin with `args: { open: iTerm }`
- [ ] Confirm icon field renders in plugin YAML samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)