### PR TITLE
fix(plugin): auto-discover local YAML plugins without settings.yaml entries

### DIFF
--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -135,8 +135,10 @@ class CustomSearchHandler {
       const enabledPlugins = this.settingsManager.getPluginSettings();
       const pluginPaths = enabledPlugins.map(p => p.path);
       const pluginCommands = pluginLoader.searchAgentBuiltIn(pluginPaths, query);
-      const legacyCommands = pluginLoader.searchLegacyAgentBuiltIn(this.settingsManager.getAgentBuiltInSettings(), query);
-      const agentBuiltIn = [...pluginCommands, ...legacyCommands];
+      const explicitNames = this.settingsManager.getAgentBuiltInSettings();
+      const legacyCommands = pluginLoader.searchLegacyAgentBuiltIn(explicitNames, query);
+      const localCommands = pluginLoader.searchAllLocalAgentBuiltIn(new Set(explicitNames ?? []), query);
+      const agentBuiltIn = [...pluginCommands, ...legacyCommands, ...localCommands];
 
       // Get user commands from CustomSearchLoader (MD files)
       const items = query
@@ -254,8 +256,10 @@ class CustomSearchHandler {
       const enabledPlugins = this.settingsManager.getPluginSettings();
       const pluginPaths = enabledPlugins.map(p => p.path);
       const pluginCommands = pluginLoader.searchAgentBuiltIn(pluginPaths);
-      const legacyCommands = pluginLoader.searchLegacyAgentBuiltIn(this.settingsManager.getAgentBuiltInSettings());
-      const isBuiltIn = [...pluginCommands, ...legacyCommands].some(cmd => cmd.name === commandName);
+      const explicitBuiltInNames = this.settingsManager.getAgentBuiltInSettings();
+      const legacyCommands = pluginLoader.searchLegacyAgentBuiltIn(explicitBuiltInNames);
+      const localBuiltInCommands = pluginLoader.loadAllLocalAgentBuiltIn(new Set(explicitBuiltInNames ?? []));
+      const isBuiltIn = [...pluginCommands, ...legacyCommands, ...localBuiltInCommands].some(cmd => cmd.name === commandName);
       if (isBuiltIn) {
         return false; // Agent built-in don't have individual files
       }
@@ -284,6 +288,8 @@ class CustomSearchHandler {
       const enabledPlugins = this.settingsManager.getPluginSettings();
       const pluginPaths = enabledPlugins.map(p => p.path);
       const builtInAgents = pluginLoader.searchAgentBuiltInAgents(pluginPaths, query);
+      const explicitAgentNames = new Set(this.settingsManager.getAgentBuiltInSettings() ?? []);
+      builtInAgents.push(...pluginLoader.searchAllLocalAgentBuiltInAgents(explicitAgentNames, query));
 
       // Get mentions (agents) from CustomSearchLoader
       // Always use searchItems to apply searchPrefix filtering, even for empty query

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -83,6 +83,7 @@ interface LoadedPlugin {
  */
 class PluginLoader {
   private cache: Map<string, LoadedPlugin> = new Map();
+  private dirScanCache: Map<string, string[]> = new Map();
   private pluginsDir: string;
 
   constructor() {
@@ -558,8 +559,9 @@ class PluginLoader {
 
       const result = this.readYamlByName(dir, name);
       const items = result ? this.parseAgentBuiltIn(result.parsed as AgentBuiltInYaml, result.filePath) : [];
+      const agentItems = result ? this.parseAgentBuiltInAgents(result.parsed as AgentBuiltInYaml, result.filePath) : [];
 
-      this.cache.set(cacheKey, { pluginPath: cacheKey, type: 'agent-built-in', entries: [], agentBuiltIn: items, agentBuiltInAgents: [] });
+      this.cache.set(cacheKey, { pluginPath: cacheKey, type: 'agent-built-in', entries: [], agentBuiltIn: items, agentBuiltInAgents: agentItems });
       commands.push(...items);
     }
 
@@ -575,10 +577,113 @@ class PluginLoader {
   }
 
   /**
+   * Scan a directory for YAML files and return base names (without extension).
+   * Results are cached per directory and invalidated via clearCache().
+   */
+  private scanYamlFiles(dir: string): string[] {
+    const cached = this.dirScanCache.get(dir);
+    if (cached) return cached;
+
+    try {
+      const files = fs.readdirSync(dir);
+      const names = new Set<string>();
+      for (const file of files) {
+        if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+          names.add(path.basename(file, path.extname(file)));
+        }
+      }
+      const result = Array.from(names);
+      this.dirScanCache.set(dir, result);
+      return result;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Load all YAML entries from a local directory, skipping excluded names.
+   */
+  private loadAllLocalEntries(
+    dir: string,
+    loader: (name: string) => CustomSearchEntry | null,
+    excludeNames?: Set<string>
+  ): CustomSearchEntry[] {
+    const entries: CustomSearchEntry[] = [];
+    for (const name of this.scanYamlFiles(dir)) {
+      if (excludeNames?.has(name)) continue;
+      const entry = loader(name);
+      if (entry) entries.push(entry);
+    }
+    return entries;
+  }
+
+  /**
+   * Auto-load all agent-skills YAML files from ~/.prompt-line/agent-skills/
+   */
+  loadAllLocalAgentSkills(excludeNames?: Set<string>): CustomSearchEntry[] {
+    return this.loadAllLocalEntries(config.paths.agentSkillsDir, n => this.loadAgentSkillFile(n), excludeNames);
+  }
+
+  /**
+   * Auto-load all custom-search YAML files from ~/.prompt-line/custom-search/
+   */
+  loadAllLocalCustomSearch(excludeNames?: Set<string>): CustomSearchEntry[] {
+    return this.loadAllLocalEntries(config.paths.customSearchDir, n => this.loadCustomSearchFile(n), excludeNames);
+  }
+
+  /**
+   * Filter local directory names by excludeNames set.
+   */
+  private getFilteredLocalNames(dir: string, excludeNames?: Set<string>): string[] {
+    const names = this.scanYamlFiles(dir);
+    const filtered = excludeNames ? names.filter(n => !excludeNames.has(n)) : names;
+    return filtered;
+  }
+
+  /**
+   * Auto-load all agent-built-in YAML files from ~/.prompt-line/agent-built-in/
+   */
+  loadAllLocalAgentBuiltIn(excludeNames?: Set<string>): AgentSkillItem[] {
+    const filtered = this.getFilteredLocalNames(config.paths.agentBuiltInDir, excludeNames);
+    if (filtered.length === 0) return [];
+    return this.loadLegacyAgentBuiltIn(filtered);
+  }
+
+  /**
+   * Search local agent-built-in with optional query filter.
+   */
+  searchAllLocalAgentBuiltIn(excludeNames?: Set<string>, query?: string): AgentSkillItem[] {
+    return this.filterByQuery(this.loadAllLocalAgentBuiltIn(excludeNames), query);
+  }
+
+  /**
+   * Auto-load all agent-built-in agents from ~/.prompt-line/agent-built-in/
+   * Delegates to loadLegacyAgentBuiltIn to prime cache, then reads agentBuiltInAgents.
+   */
+  loadAllLocalAgentBuiltInAgents(excludeNames?: Set<string>): AgentItem[] {
+    const filtered = this.getFilteredLocalNames(config.paths.agentBuiltInDir, excludeNames);
+    if (filtered.length === 0) return [];
+    // Prime the cache via loadLegacyAgentBuiltIn, then read agentBuiltInAgents
+    this.loadLegacyAgentBuiltIn(filtered);
+    return filtered.flatMap(name => {
+      const cached = this.cache.get(`legacy-built-in:${name}`);
+      return cached?.agentBuiltInAgents ?? [];
+    });
+  }
+
+  /**
+   * Search local agent-built-in agents with optional query filter.
+   */
+  searchAllLocalAgentBuiltInAgents(excludeNames?: Set<string>, query?: string): AgentItem[] {
+    return this.filterByQuery(this.loadAllLocalAgentBuiltInAgents(excludeNames), query);
+  }
+
+  /**
    * Clear the cache to force reload
    */
   clearCache(): void {
     this.cache.clear();
+    this.dirScanCache.clear();
     logger.debug('Plugin loader cache cleared');
   }
 }

--- a/src/managers/plugin-manager.ts
+++ b/src/managers/plugin-manager.ts
@@ -33,6 +33,7 @@ class PluginManager extends EventEmitter {
     try {
       await Promise.all([
         ensureDir(this.targetDir),
+        ensureDir(config.paths.agentBuiltInDir),
         ensureDir(config.paths.agentSkillsDir),
         ensureDir(config.paths.customSearchDir),
       ]);
@@ -67,7 +68,7 @@ class PluginManager extends EventEmitter {
     // recreated directories when an ignored callback is present, which breaks
     // hot reload after `plugin:install` (it deletes and recreates the target dir).
     // Instead, filter by extension in the event handlers below.
-    this.watcher = chokidar.watch([this.targetDir, config.paths.agentSkillsDir, config.paths.customSearchDir], {
+    this.watcher = chokidar.watch([this.targetDir, config.paths.agentBuiltInDir, config.paths.agentSkillsDir, config.paths.customSearchDir], {
       persistent: true,
       ignoreInitial: true,
       depth: 10,

--- a/src/managers/settings-manager.ts
+++ b/src/managers/settings-manager.ts
@@ -564,10 +564,12 @@ class SettingsManager extends EventEmitter {
     }
 
     // Merge inline/file-based settings entries
+    const explicitAgentSkillNames = new Set<string>();
     const agentSkills = this.currentSettings.agentSkills;
     if (agentSkills && agentSkills.length > 0) {
       for (const item of agentSkills) {
         if (typeof item === 'string') {
+          explicitAgentSkillNames.add(item);
           const entry = pluginLoader.loadAgentSkillFile(item);
           if (entry) entries.push(entry);
         } else {
@@ -576,10 +578,12 @@ class SettingsManager extends EventEmitter {
       }
     }
 
+    const explicitCustomSearchNames = new Set<string>();
     const customSearchMentions = this.currentSettings.customSearch;
     if (customSearchMentions) {
       for (const item of customSearchMentions) {
         if (typeof item === 'string') {
+          explicitCustomSearchNames.add(item);
           const entry = pluginLoader.loadCustomSearchFile(item);
           if (entry) entries.push(entry);
         } else {
@@ -587,6 +591,10 @@ class SettingsManager extends EventEmitter {
         }
       }
     }
+
+    // Auto-discover local YAML files not explicitly listed in settings
+    entries.push(...pluginLoader.loadAllLocalAgentSkills(explicitAgentSkillNames));
+    entries.push(...pluginLoader.loadAllLocalCustomSearch(explicitCustomSearchNames));
 
     return entries;
   }

--- a/tests/unit/settings-manager.test.ts
+++ b/tests/unit/settings-manager.test.ts
@@ -33,6 +33,8 @@ vi.mock('../../src/lib/plugin-loader', () => ({
     loadPluginEntries: vi.fn(() => []),
     loadAgentBuiltIn: vi.fn(() => []),
     searchAgentBuiltIn: vi.fn(() => []),
+    loadAllLocalAgentSkills: vi.fn(() => []),
+    loadAllLocalCustomSearch: vi.fn(() => []),
     clearCache: vi.fn()
   }
 }));


### PR DESCRIPTION
## Summary

- Local plugin directories (`~/.prompt-line/agent-built-in/`, `agent-skills/`, `custom-search/`) now auto-scan for YAML files, matching the documented quick-start behavior in `docs/ja/plugins.md`
- Previously, placing YAML files in these directories had no effect unless explicitly listed in `settings.yaml` — this was a doc/implementation mismatch
- Directory scan results are cached and invalidated on `clearCache()` to avoid repeated `readdirSync` on hot paths (IPC handlers called on every keystroke)

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — all 1249 tests pass
- [x] Verified via CDP: placed `test-local.yaml` in `~/.prompt-line/agent-built-in/` without any `settings.yaml` entry → `test-local-cmd` appeared in agent skills query

🤖 Generated with [Claude Code](https://claude.com/claude-code)