### PR TITLE
feat(plugin): use YAML file directory as cwd for sourceCommand/runCommand

### DIFF
--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -299,6 +299,24 @@ args:
 - Output format: plain text (one item per line) or JSONL (one JSON per line)
 - Auto-detected from first line of output
 
+**Custom scripts:**
+
+`sourceCommand` and `runCommand` are executed with the YAML file's directory as the working directory (`cwd`). You can place scripts alongside the plugin YAML and reference them with relative paths.
+
+```yaml
+sourceCommand: "./search.sh"
+name: "{line}"
+searchPrefix: mydata
+runCommand: "./open.sh {line}"
+```
+
+```
+~/.prompt-line/plugins/my-plugin/custom-search/
+  ├── my-search.yaml    # sourceCommand: "./search.sh"
+  ├── search.sh         # cwd = this directory when executed
+  └── open.sh
+```
+
 ---
 
 ## Template Variables

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -299,6 +299,24 @@ args:
 - 出力フォーマット: プレーンテキスト（1行1アイテム）またはJSONL（1行1JSON）
 - 出力の最初の行から自動判別
 
+**カスタムスクリプト：**
+
+`sourceCommand` や `runCommand` はYAMLファイルのディレクトリを作業ディレクトリ（`cwd`）として実行されます。プラグインYAMLと同じフォルダにスクリプトを配置し、相対パスで参照できます。
+
+```yaml
+sourceCommand: "./search.sh"
+name: "{line}"
+searchPrefix: mydata
+runCommand: "./open.sh {line}"
+```
+
+```
+~/.prompt-line/plugins/my-plugin/custom-search/
+  ├── my-search.yaml    # sourceCommand: "./search.sh"
+  ├── search.sh         # cwd = このディレクトリで実行
+  └── open.sh
+```
+
 ---
 
 ## テンプレート変数

--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -541,9 +541,9 @@ class CustomSearchHandler {
         this.customSearchLoader.getItems('mention'),
         this.customSearchLoader.getItems('command'),
       ]);
-      const isAuthorized = mentionItems.some(item => item.runCommand === command)
-        || commandItems.some(item => item.runCommand === command);
-      if (!isAuthorized) {
+      const allItems = [...mentionItems, ...commandItems];
+      const authorizedItem = allItems.find(item => item.runCommand === command);
+      if (!authorizedItem) {
         logger.warn('Unauthorized command execution attempt blocked', { commandLength: command.length });
         return { success: false, error: 'Command not authorized' };
       }
@@ -552,6 +552,7 @@ class CustomSearchHandler {
       const { stdout, stderr } = await execAsync(command, {
         timeout: 30000,
         env: getEnhancedEnv(this.settingsManager.getAdditionalPaths()),
+        ...(authorizedItem.sourceDir && { cwd: authorizedItem.sourceDir }),
       });
 
       const output = (stdout || '').trimEnd();

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -200,7 +200,7 @@ class PluginLoader {
       plugin.agentBuiltIn = this.parseAgentBuiltIn(yamlData, filePath);
       plugin.agentBuiltInAgents = this.parseAgentBuiltInAgents(yamlData, filePath);
     } else {
-      const entry = this.parsePluginEntry(parsed as PluginEntryYaml, type, overrides);
+      const entry = this.parsePluginEntry(parsed as PluginEntryYaml, type, filePath, overrides);
       if (entry) {
         plugin.entries = [entry];
       }
@@ -217,6 +217,7 @@ class PluginLoader {
   private parsePluginEntry(
     yamlData: PluginEntryYaml,
     type: PluginType,
+    filePath?: string,
     overrides?: { searchPrefix?: string; args?: Record<string, string> }
   ): CustomSearchEntry | null {
     if (!yamlData.name || (!yamlData.sourcePath && !yamlData.sourceCommand)) {
@@ -231,6 +232,9 @@ class PluginLoader {
       description: (yamlData.description || '').replace(/\n+/g, ' ').trim(),
       sourcePath: yamlData.sourcePath || '',
     };
+
+    // Set sourceDir from YAML file path (for sourceCommand/runCommand cwd)
+    if (filePath) entry.sourceDir = path.dirname(filePath);
 
     // Copy source/run fields
     if (yamlData.sourceCommand !== undefined) entry.sourceCommand = yamlData.sourceCommand;
@@ -524,7 +528,7 @@ class PluginLoader {
     if (cached) return cached.entries[0] ?? null;
 
     const result = this.readYamlByName(dir, name);
-    const entry = result ? this.parsePluginEntry(result.parsed as PluginEntryYaml, type) : null;
+    const entry = result ? this.parsePluginEntry(result.parsed as PluginEntryYaml, type, result.filePath) : null;
     const basePath = path.join(dir, name);
 
     // Cache both hits and misses to avoid repeated I/O for invalid names

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -589,7 +589,7 @@ class CustomSearchLoader extends EventEmitter {
     const results = await Promise.all(
       this.config.map(async (entry) => {
         const sourceId = entry.sourceCommand
-          ? `sourceCommand:${entry.sourceCommand}`
+          ? `sourceCommand:${entry.sourceCommand}${entry.sourceDir ? ':' + entry.sourceDir : ''}`
           : entry.sourcePath;
         try {
           const { items, watchableFiles, watchGlobs } = entry.sourceCommand
@@ -698,7 +698,7 @@ class CustomSearchLoader extends EventEmitter {
   private async loadCommandEntry(
     entry: CustomSearchEntry
   ): Promise<{ items: CustomSearchItem[]; watchableFiles: string[]; watchGlobs: string[] }> {
-    const sourceId = `sourceCommand:${entry.sourceCommand}`;
+    const sourceId = `sourceCommand:${entry.sourceCommand}${entry.sourceDir ? ':' + entry.sourceDir : ''}`;
     const cached = this.commandCache.get(sourceId);
 
     let items: CustomSearchItem[];

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -769,6 +769,7 @@ class CustomSearchLoader extends EventEmitter {
       const { stdout } = await execAsync(entry.sourceCommand!, {
         timeout: CustomSearchLoader.COMMAND_SOURCE_TIMEOUT,
         env: getEnhancedEnv(this.settings?.additionalPaths),
+        ...(entry.sourceDir && { cwd: entry.sourceDir }),
       });
 
       const output = stdout.trimEnd();
@@ -1054,6 +1055,9 @@ class CustomSearchLoader extends EventEmitter {
       // final string, so JSON.stringify output (including object keys) is also quoted.
       const resolvedCommand = resolveTemplate(entry.runCommand, context, shellQuote);
       if (resolvedCommand) item.runCommand = resolvedCommand;
+    }
+    if (entry.sourceDir) {
+      item.sourceDir = entry.sourceDir;
     }
   }
 

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -513,6 +513,8 @@ export interface CustomSearchEntry {
   sourceCommand?: string;
   /** オプション: テンプレート引数（例: { open: "iTerm" } → {args.open} で参照可能） */
   args?: Record<string, string>;
+  /** オプション: sourceCommand/runCommand 実行時の作業ディレクトリ（YAMLファイルのディレクトリパス） */
+  sourceDir?: string;
 }
 
 /**
@@ -553,6 +555,8 @@ export interface CustomSearchItem {
   triggers?: string[];
   /** テンプレート解決済みのコマンド文字列（Ctrl+Enter で実行） */
   runCommand?: string;
+  /** sourceCommand/runCommand 実行時の作業ディレクトリ（YAMLファイルのディレクトリパス） */
+  sourceDir?: string;
 }
 
 export interface AgentSkillItem {

--- a/tests/unit/custom-search-loader.test.ts
+++ b/tests/unit/custom-search-loader.test.ts
@@ -2981,5 +2981,105 @@ Content`;
       expect(calls.some(c => c.options?.cwd === '/plugin-a')).toBe(true);
       expect(calls.some(c => c.options?.cwd === '/plugin-b')).toBe(true);
     });
+
+    test('should execute multiple sourceCommand entries in parallel with correct cwd', async () => {
+      const config: CustomSearchEntry[] = [
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './alpha.sh', sourceDir: '/plugins/alpha', searchPrefix: 'a',
+        },
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './beta.sh', sourceDir: '/plugins/beta', searchPrefix: 'b',
+        },
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: 'ghq list', searchPrefix: 'ghq',
+        },
+      ];
+
+      const loader = new CustomSearchLoader(config);
+      await loader.getItems('mention');
+
+      // All three commands should have been executed
+      expect(execCalls).toHaveLength(3);
+      expect(execCalls.find(c => c.command === './alpha.sh')!.options.cwd).toBe('/plugins/alpha');
+      expect(execCalls.find(c => c.command === './beta.sh')!.options.cwd).toBe('/plugins/beta');
+      expect(execCalls.find(c => c.command === 'ghq list')!.options).not.toHaveProperty('cwd');
+    });
+
+    test('should isolate errors: one failed sourceCommand should not affect others', async () => {
+      vi.mocked(exec).mockImplementation(((cmd: string, optsOrCb: any, cb?: any) => {
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
+        const options = typeof optsOrCb === 'object' ? optsOrCb : {};
+        execCalls.push({ command: cmd, options });
+        if (cmd === './failing.sh') {
+          // Simulate command failure
+          if (callback) callback(new Error('script not found'), '', 'No such file or directory');
+        } else {
+          if (callback) callback(null, 'result1\nresult2', '');
+        }
+      }) as any);
+
+      const config: CustomSearchEntry[] = [
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './success.sh', sourceDir: '/plugins/good', searchPrefix: 'good',
+        },
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './failing.sh', sourceDir: '/plugins/bad', searchPrefix: 'bad',
+        },
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './another.sh', sourceDir: '/plugins/also-good', searchPrefix: 'ok',
+        },
+      ];
+
+      const loader = new CustomSearchLoader(config);
+      // Should not throw despite one command failing
+      await expect(loader.getItems('mention')).resolves.toBeDefined();
+
+      // All three commands should have been attempted
+      expect(execCalls).toHaveLength(3);
+      expect(execCalls.find(c => c.command === './success.sh')).toBeDefined();
+      expect(execCalls.find(c => c.command === './failing.sh')).toBeDefined();
+      expect(execCalls.find(c => c.command === './another.sh')).toBeDefined();
+    });
+
+    test('should isolate timeout: one timed-out command should not block others', async () => {
+      vi.mocked(exec).mockImplementation(((cmd: string, optsOrCb: any, cb?: any) => {
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
+        const options = typeof optsOrCb === 'object' ? optsOrCb : {};
+        execCalls.push({ command: cmd, options });
+        if (cmd === './slow.sh') {
+          // Simulate SIGTERM timeout
+          const err = new Error('Command timed out') as Error & { signal?: string };
+          err.signal = 'SIGTERM';
+          if (callback) callback(err, '', '');
+        } else {
+          if (callback) callback(null, 'fast-result', '');
+        }
+      }) as any);
+
+      const config: CustomSearchEntry[] = [
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './fast.sh', sourceDir: '/plugins/fast', searchPrefix: 'fast',
+        },
+        {
+          name: '{line}', type: 'mention', description: '', sourcePath: '',
+          sourceCommand: './slow.sh', sourceDir: '/plugins/slow', searchPrefix: 'slow',
+        },
+      ];
+
+      const loader = new CustomSearchLoader(config);
+      await expect(loader.getItems('mention')).resolves.toBeDefined();
+
+      // Both commands should have been attempted
+      expect(execCalls).toHaveLength(2);
+      expect(execCalls.find(c => c.command === './fast.sh')).toBeDefined();
+      expect(execCalls.find(c => c.command === './slow.sh')).toBeDefined();
+    });
   });
 });

--- a/tests/unit/custom-search-loader.test.ts
+++ b/tests/unit/custom-search-loader.test.ts
@@ -1,5 +1,18 @@
+// Override child_process.exec to support 3-arg form (command, options, callback)
+// needed by promisify(exec) in custom-search-loader's sourceCommand handling
+const execCalls: Array<{ command: string; options: any }> = [];
+vi.mock('child_process', () => ({
+  exec: vi.fn((cmd: string, optsOrCb: any, cb?: any) => {
+    const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
+    const options = typeof optsOrCb === 'object' ? optsOrCb : {};
+    execCalls.push({ command: cmd, options });
+    if (callback) callback(null, 'line1\nline2', '');
+  })
+}));
+
 import CustomSearchLoader from '../../src/managers/custom-search-loader';
 import { promises as fs } from 'fs';
+import { exec } from 'child_process';
 import chokidarModule from 'chokidar';
 import type { CustomSearchEntry } from '../../src/types';
 
@@ -2881,6 +2894,92 @@ Content`;
       await loader.getItems('command');
 
       await expect(loader.stopWatching()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('sourceCommand with sourceDir (cwd)', () => {
+    const defaultExecImpl = ((cmd: string, optsOrCb: any, cb?: any) => {
+      const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
+      const options = typeof optsOrCb === 'object' ? optsOrCb : {};
+      execCalls.push({ command: cmd, options });
+      if (callback) callback(null, 'line1\nline2', '');
+    }) as any;
+
+    beforeEach(() => {
+      execCalls.length = 0;
+      vi.mocked(exec).mockImplementation(defaultExecImpl);
+    });
+
+    test('should pass sourceDir as cwd to execAsync', async () => {
+      const config: CustomSearchEntry[] = [
+        {
+          name: '{line}',
+          type: 'mention',
+          description: '',
+          sourcePath: '',
+          sourceCommand: './search.sh',
+          sourceDir: '/path/to/plugin/dir',
+          searchPrefix: 'test',
+        },
+      ];
+      const loader = new CustomSearchLoader(config);
+      await loader.getItems('mention');
+
+      // Verify cwd was passed to exec
+      const call = execCalls.find(c => c.command === './search.sh');
+      expect(call).toBeDefined();
+      expect(call!.options.cwd).toBe('/path/to/plugin/dir');
+    });
+
+    test('should not pass cwd when sourceDir is undefined', async () => {
+      const config: CustomSearchEntry[] = [
+        {
+          name: '{line}',
+          type: 'mention',
+          description: '',
+          sourcePath: '',
+          sourceCommand: 'echo hello',
+          searchPrefix: 'test',
+        },
+      ];
+      const loader = new CustomSearchLoader(config);
+      await loader.searchItems('mention', 'test:');
+
+      const call = execCalls.find(c => c.command === 'echo hello');
+      expect(call).toBeDefined();
+      expect(call!.options).not.toHaveProperty('cwd');
+    });
+
+    test('should use different cache keys for same command with different sourceDir', async () => {
+      const config: CustomSearchEntry[] = [
+        {
+          name: '{line}',
+          type: 'mention',
+          description: '',
+          sourcePath: '',
+          sourceCommand: './search.sh',
+          sourceDir: '/plugin-a',
+          searchPrefix: 'a',
+        },
+        {
+          name: '{line}',
+          type: 'mention',
+          description: '',
+          sourcePath: '',
+          sourceCommand: './search.sh',
+          sourceDir: '/plugin-b',
+          searchPrefix: 'b',
+        },
+      ];
+
+      const loader = new CustomSearchLoader(config);
+      await loader.getItems('mention');
+
+      // Both entries should trigger separate exec calls (different cache keys)
+      const calls = execCalls.filter(c => c.command === './search.sh');
+      expect(calls).toHaveLength(2);
+      expect(calls.some(c => c.options?.cwd === '/plugin-a')).toBe(true);
+      expect(calls.some(c => c.options?.cwd === '/plugin-b')).toBe(true);
     });
   });
 });

--- a/tests/unit/plugin-loader.test.ts
+++ b/tests/unit/plugin-loader.test.ts
@@ -243,4 +243,60 @@ commands:
       expect(entries[0].args).toEqual({ key1: 'value1', key2: 'value2' });
     });
   });
+
+  describe('sourceDir', () => {
+    test('should set sourceDir from YAML file path for plugin entries', () => {
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        makePluginYaml({ name: 'test', sourceCommand: 'echo hello' })
+      );
+
+      const entries = loader.loadPluginEntries([{ path: `${SKILLS_PATH}/test` }]);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].sourceDir).toBe('/tmp/test-plugins/github.com/user/repo/agent-skills');
+    });
+
+    test('should set sourceDir for custom-search plugin entries', () => {
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        makePluginYaml({ name: '{line}', sourceCommand: './search.sh', searchPrefix: 'test' })
+      );
+
+      const entries = loader.loadPluginEntries([{ path: 'github.com/user/repo/custom-search/my-search' }]);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].sourceDir).toBe('/tmp/test-plugins/github.com/user/repo/custom-search');
+    });
+
+    test('should set sourceDir for standalone custom-search files', () => {
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        makePluginYaml({ name: '{line}', sourceCommand: './script.sh', searchPrefix: 'standalone' })
+      );
+
+      const entry = loader.loadCustomSearchFile('my-standalone');
+
+      expect(entry).not.toBeNull();
+      expect(entry!.sourceDir).toBe('/tmp/test-custom-search');
+    });
+
+    test('should set sourceDir for standalone agent-skills files', () => {
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        makePluginYaml({ name: 'my-skill', sourceCommand: './run.sh' })
+      );
+
+      const entry = loader.loadAgentSkillFile('my-skill');
+
+      expect(entry).not.toBeNull();
+      expect(entry!.sourceDir).toBe('/tmp/test-agent-skills');
+    });
+
+    test('should not set sourceDir for entries without filePath', () => {
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(makePluginYaml());
+
+      const entries = loader.loadPluginEntries([{ path: `${SKILLS_PATH}/test` }]);
+
+      // sourceDir IS set because plugin entries always have a filePath
+      expect(entries).toHaveLength(1);
+      expect(entries[0].sourceDir).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Added `sourceDir` field to `CustomSearchEntry` and `CustomSearchItem` to track the YAML file's directory path
- `sourceCommand` and `runCommand` now execute with the YAML file's directory as `cwd`, enabling relative path references to co-located scripts
- Works for both plugin-based (`~/.prompt-line/plugins/...`) and standalone (`~/.prompt-line/custom-search/...`) YAML entries
- `sourceDir` is not exposed to the renderer process — `cwd` is resolved server-side from the allowlist-matched item for security

## Example
```yaml
# ~/.prompt-line/plugins/my-plugin/custom-search/my-search.yaml
sourceCommand: "./search.sh"    # Runs with cwd = this YAML's directory
name: "{line}"
searchPrefix: mydata
runCommand: "./open.sh {line}"  # Also uses the same cwd
```

## Changed files
- `src/types/window.ts` — `sourceDir?: string` on `CustomSearchEntry` and `CustomSearchItem`
- `src/lib/plugin-loader.ts` — Set `sourceDir = path.dirname(filePath)` during YAML parsing
- `src/managers/custom-search-loader.ts` — Pass `cwd` to `execAsync` for `sourceCommand`; propagate `sourceDir` to items
- `src/handlers/custom-search-handler.ts` — Use `sourceDir` as `cwd` for `runCommand` execution (resolved from allowlist match)
- `docs/en/plugins.md`, `docs/ja/plugins.md` — Added custom scripts documentation

## Test plan
- [x] TypeScript type check passes
- [x] All 1254 tests pass (50 test files)
- [x] Manual test: standalone custom-search with `./ghq-repos.sh` — 194 items loaded
- [x] Manual test: plugin repo custom-search with `./recent-projects.sh` — 21 items loaded
- [x] Verified via CDP screenshot that `@repo:` and `@rp:` suggestions display correctly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)