### PR TITLE
fix(plugin): copy resource files alongside YAML during plugin install

### DIFF
--- a/scripts/plugin-install.ts
+++ b/scripts/plugin-install.ts
@@ -461,7 +461,7 @@ function isValidPluginFolder(relPath: string): boolean {
   return parts.some(part => (VALID_PLUGIN_TYPES as readonly string[]).includes(part));
 }
 
-function copyYamlFiles(
+export function copyYamlFiles(
   sourceDir: string,
   targetDir: string,
   gitCwd: string,
@@ -539,6 +539,14 @@ function copyYamlFiles(
       pluginEntries.push(pluginEntry);
 
       totalFiles++;
+    } else if (isPluginFolder && entry.isFile() && !entry.name.endsWith('.yml') && !entry.name.endsWith('.yaml')) {
+      // Copy non-YAML resource files (scripts, etc.) as-is, preserving permissions
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+      }
+      fs.copyFileSync(sourcePath, targetPath);
+      const stat = fs.statSync(sourcePath);
+      fs.chmodSync(targetPath, stat.mode);
     }
   }
 

--- a/scripts/plugin-install.ts
+++ b/scripts/plugin-install.ts
@@ -546,7 +546,7 @@ export function copyYamlFiles(
       }
       fs.copyFileSync(sourcePath, targetPath);
       const stat = fs.statSync(sourcePath);
-      fs.chmodSync(targetPath, stat.mode);
+      fs.chmodSync(targetPath, stat.mode & 0o777);
     }
   }
 

--- a/tests/unit/plugin-install.test.ts
+++ b/tests/unit/plugin-install.test.ts
@@ -1,0 +1,83 @@
+vi.unmock('path');
+vi.unmock('fs');
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { copyYamlFiles } from '../../scripts/plugin-install';
+
+describe('copyYamlFiles', () => {
+  let tmpDir: string;
+  let sourceDir: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-install-test-'));
+    sourceDir = path.join(tmpDir, 'source');
+    targetDir = path.join(tmpDir, 'target');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createPluginDir(files: Record<string, { content: string; mode?: number }>) {
+    const pluginDir = path.join(sourceDir, 'custom-search');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    for (const [name, { content, mode }] of Object.entries(files)) {
+      const filePath = path.join(pluginDir, name);
+      fs.writeFileSync(filePath, content, 'utf-8');
+      if (mode !== undefined) fs.chmodSync(filePath, mode);
+    }
+    return pluginDir;
+  }
+
+  it('copies non-YAML resource files alongside YAML files in plugin folders', () => {
+    createPluginDir({
+      'ghq.yaml': { content: 'name: test\nsourceCommand: "./ghq-list.sh"\n' },
+      'ghq-list.sh': { content: '#!/bin/bash\nghq list\n', mode: 0o755 },
+    });
+
+    copyYamlFiles(sourceDir, targetDir, '', '', '', sourceDir);
+
+    expect(fs.existsSync(path.join(targetDir, 'custom-search', 'ghq.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, 'custom-search', 'ghq-list.sh'))).toBe(true);
+  });
+
+  it('preserves executable permission on copied resource files', () => {
+    createPluginDir({
+      'test.yaml': { content: 'name: test\nsourceCommand: "./run.sh"\n' },
+      'run.sh': { content: '#!/bin/bash\necho hello\n', mode: 0o755 },
+    });
+
+    copyYamlFiles(sourceDir, targetDir, '', '', '', sourceDir);
+
+    const stat = fs.statSync(path.join(targetDir, 'custom-search', 'run.sh'));
+    // Check owner-execute bit
+    expect(stat.mode & 0o100).toBeTruthy();
+  });
+
+  it('counts only YAML files in totalFiles', () => {
+    createPluginDir({
+      'a.yaml': { content: 'name: a\nsourcePath: ~/test\n' },
+      'b.yaml': { content: 'name: b\nsourcePath: ~/test\n' },
+      'helper.sh': { content: '#!/bin/bash\n', mode: 0o755 },
+    });
+
+    const result = copyYamlFiles(sourceDir, targetDir, '', '', '', sourceDir);
+
+    expect(result.totalFiles).toBe(2);
+  });
+
+  it('does not copy resource files outside valid plugin folders', () => {
+    // Create a non-plugin directory (no valid type like custom-search/agent-skills)
+    const invalidDir = path.join(sourceDir, 'other');
+    fs.mkdirSync(invalidDir, { recursive: true });
+    fs.writeFileSync(path.join(invalidDir, 'script.sh'), '#!/bin/bash\n', 'utf-8');
+    fs.chmodSync(path.join(invalidDir, 'script.sh'), 0o755);
+
+    copyYamlFiles(sourceDir, targetDir, '', '', '', sourceDir);
+
+    expect(fs.existsSync(path.join(targetDir, 'other', 'script.sh'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed plugin installer (`copyYamlFiles()`) to also copy non-YAML resource files (e.g., `.sh` scripts) in valid plugin directories
- Preserves file permissions (executable bit) on copied resource files
- Root cause: `sourceCommand: "./ghq-list.sh"` failed with `No such file or directory` because the installer only copied `.yaml`/`.yml` files, skipping co-located scripts

## Test plan
- [x] All 1270 tests pass (51 test files)
- [x] TypeScript type check passes
- [x] New tests verify resource file copying, permission preservation, and YAML-only counting
- [ ] Re-install plugins (`pnpm run plugin:install github.com/nkmr-jp/prompt-line-plugins`) and verify `@ghq:` search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)