### PR TITLE
feat(template): add {projectdir} template variable

### DIFF
--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -334,7 +334,7 @@ runCommand: "./open.sh {line}"
 | `{dirname}` | Parent directory name | |
 | `{dirname:N}` | N levels up directory | `{dirname:2}` |
 | `{pathdir:N}` | Nth directory from sourcePath base | e.g., `sourcePath: ~/a/b/*/file.md` → base=`~/a/b`, `{pathdir:1}`=first dir after base |
-| `{projectdir}` | Current project directory (detected CWD) | e.g., `git -C {projectdir} log` |
+| `{projectdir}` | Current project directory (detected CWD). Remains unresolved if no directory is detected — plugin should handle this case | e.g., `git -C {projectdir} log` |
 | `{latest}` | Most recently modified dir | |
 | `{updatedAt}` | File modification time | |
 | `{args.key}` | Value from `args` field | `{args.open}` |

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -334,7 +334,7 @@ runCommand: "./open.sh {line}"
 | `{dirname}` | Parent directory name | |
 | `{dirname:N}` | N levels up directory | `{dirname:2}` |
 | `{pathdir:N}` | Nth directory from sourcePath base | e.g., `sourcePath: ~/a/b/*/file.md` → base=`~/a/b`, `{pathdir:1}`=first dir after base |
-| `{projectdir}` | Current project directory (detected CWD). Remains unresolved if no directory is detected — plugin should handle this case | e.g., `git -C {projectdir} log` |
+| `{projectdir}` | Current project directory (detected CWD) | e.g., `git -C {projectdir} log` |
 | `{latest}` | Most recently modified dir | |
 | `{updatedAt}` | File modification time | |
 | `{args.key}` | Value from `args` field | `{args.open}` |

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -334,6 +334,7 @@ runCommand: "./open.sh {line}"
 | `{dirname}` | Parent directory name | |
 | `{dirname:N}` | N levels up directory | `{dirname:2}` |
 | `{pathdir:N}` | Nth directory from sourcePath base | e.g., `sourcePath: ~/a/b/*/file.md` → base=`~/a/b`, `{pathdir:1}`=first dir after base |
+| `{projectdir}` | Current project directory (detected CWD) | e.g., `git -C {projectdir} log` |
 | `{latest}` | Most recently modified dir | |
 | `{updatedAt}` | File modification time | |
 | `{args.key}` | Value from `args` field | `{args.open}` |

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -334,7 +334,7 @@ runCommand: "./open.sh {line}"
 | `{dirname}` | 親ディレクトリ名 | |
 | `{dirname:N}` | N階層上のディレクトリ | `{dirname:2}` |
 | `{pathdir:N}` | sourcePathのベースからN番目のディレクトリ | 例: `sourcePath: ~/a/b/*/file.md` → ベース=`~/a/b`、`{pathdir:1}`=ベース直下のディレクトリ |
-| `{projectdir}` | 現在のプロジェクトディレクトリ（検出されたCWD）。未検出時は未解決のまま残る — プラグイン側でハンドリングが必要 | 例: `git -C {projectdir} log` |
+| `{projectdir}` | 現在のプロジェクトディレクトリ（検出されたCWD） | 例: `git -C {projectdir} log` |
 | `{latest}` | 最新の更新ディレクトリ | |
 | `{updatedAt}` | ファイル更新日時 | |
 | `{args.key}` | `args`フィールドの値 | `{args.open}` |

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -334,7 +334,7 @@ runCommand: "./open.sh {line}"
 | `{dirname}` | 親ディレクトリ名 | |
 | `{dirname:N}` | N階層上のディレクトリ | `{dirname:2}` |
 | `{pathdir:N}` | sourcePathのベースからN番目のディレクトリ | 例: `sourcePath: ~/a/b/*/file.md` → ベース=`~/a/b`、`{pathdir:1}`=ベース直下のディレクトリ |
-| `{projectdir}` | 現在のプロジェクトディレクトリ（検出されたCWD） | 例: `git -C {projectdir} log` |
+| `{projectdir}` | 現在のプロジェクトディレクトリ（検出されたCWD）。未検出時は未解決のまま残る — プラグイン側でハンドリングが必要 | 例: `git -C {projectdir} log` |
 | `{latest}` | 最新の更新ディレクトリ | |
 | `{updatedAt}` | ファイル更新日時 | |
 | `{args.key}` | `args`フィールドの値 | `{args.open}` |

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -334,6 +334,7 @@ runCommand: "./open.sh {line}"
 | `{dirname}` | 親ディレクトリ名 | |
 | `{dirname:N}` | N階層上のディレクトリ | `{dirname:2}` |
 | `{pathdir:N}` | sourcePathのベースからN番目のディレクトリ | 例: `sourcePath: ~/a/b/*/file.md` → ベース=`~/a/b`、`{pathdir:1}`=ベース直下のディレクトリ |
+| `{projectdir}` | 現在のプロジェクトディレクトリ（検出されたCWD） | 例: `git -C {projectdir} log` |
 | `{latest}` | 最新の更新ディレクトリ | |
 | `{updatedAt}` | ファイル更新日時 | |
 | `{args.key}` | `args`フィールドの値 | `{args.open}` |

--- a/src/config/settings-yaml-generator.ts
+++ b/src/config/settings-yaml-generator.ts
@@ -299,6 +299,7 @@ function buildAgentSkillsHeader(): string {
     '#   {dirname}: Parent directory name',
     '#   {dirname:N}: N levels up directory name (e.g., {dirname:2} = grandparent)',
     '#   {pathdir:N}: N-th directory from path downward (e.g., path/a/b/file.md → {pathdir:1} = a)',
+    '#   {projectdir}: Current project directory (detected CWD from active window)',
     '#   {latest}: In pattern, matches only the most recently modified directory at that position',
     'agentSkills:'
   ].join('\n') + '\n';
@@ -378,6 +379,7 @@ function buildCustomSearchHeader(): string {
 #   {dirname}           — Parent directory name
 #   {dirname:N}         — N levels up directory name (e.g., {dirname:2} = grandparent)
 #   {pathdir:N}         — N-th directory from path downward (e.g., path/a/b/file.md → {pathdir:1} = a)
+#   {projectdir}        — Current project directory (detected CWD from active window)
 #   {latest}            — In pattern, matches only the most recently modified directory at that position
 #
 # Pattern examples:

--- a/src/handlers/ipc-handlers.ts
+++ b/src/handlers/ipc-handlers.ts
@@ -69,6 +69,8 @@ class IPCHandlers {
     );
     this.windowHandler = new WindowHandler(windowManager);
     this.systemHandler = new SystemHandler(settingsManager);
+    // Connect DirectoryManager to CustomSearchLoader for {projectdir} template variable
+    customSearchLoader.setProjectdirGetter(() => directoryManager.getDirectory());
     this.customSearchHandler = new CustomSearchHandler(
       customSearchLoader,
       settingsManager,

--- a/src/lib/template-resolver.ts
+++ b/src/lib/template-resolver.ts
@@ -14,6 +14,7 @@
  * - {args.key}: テンプレート引数（例: args: { open: "iTerm" } → {args.open} = "iTerm"）
  * - {content}: ファイルの全コンテンツ
  * - {filepath}: ファイルの絶対パス
+ * - {projectdir}: 現在のプロジェクトディレクトリ（DirectoryManagerのCWD）
  *
  * フォールバック構文:
  * - テンプレート全体で `|` を使うと、左側が空文字の場合に右側にフォールバック
@@ -37,6 +38,8 @@ export interface TemplateContext {
   parentJsonDataStack?: Record<string, unknown>[];
   /** テンプレート引数（{args.key} として解決される） */
   args?: Record<string, string>;
+  /** 現在のプロジェクトディレクトリ（{projectdir} として解決される） */
+  projectdir?: string;
 }
 
 /**
@@ -116,6 +119,11 @@ export function resolveTemplate(
   // Replace {filepath}
   if (context.filePath) {
     result = result.replace(/\{filepath\}/g, t(context.filePath));
+  }
+
+  // Replace {projectdir}
+  if (context.projectdir !== undefined) {
+    result = result.replace(/\{projectdir\}/g, t(context.projectdir));
   }
 
   // Replace {frontmatter@fieldName}

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -82,6 +82,7 @@ class CustomSearchLoader extends EventEmitter {
   private watchedPaths: Set<string> = new Set();
   private static readonly FILE_RELOAD_DEBOUNCE_MS = 300;
   private fileReloadTimer: ReturnType<typeof setTimeout> | null = null;
+  private projectdirGetter: (() => string | null) | null = null;
 
   constructor(
     config?: CustomSearchEntry[],
@@ -91,6 +92,19 @@ class CustomSearchLoader extends EventEmitter {
     // Use default config if config is undefined or empty array
     this.config = (config && config.length > 0) ? config : getDefaultCustomSearchConfig();
     this.settings = settings;
+  }
+
+  /**
+   * Set the getter function for the current project directory.
+   * Used to resolve {projectdir} template variable.
+   */
+  setProjectdirGetter(getter: () => string | null): void {
+    this.projectdirGetter = getter;
+  }
+
+  /** Get the current project directory or empty string */
+  private getProjectdir(): string {
+    return this.projectdirGetter?.() ?? '';
   }
 
   /**
@@ -766,7 +780,9 @@ class CustomSearchLoader extends EventEmitter {
     sourceId: string
   ): Promise<CustomSearchItem[]> {
     try {
-      const { stdout } = await execAsync(entry.sourceCommand!, {
+      const projectdir = this.getProjectdir();
+      const resolvedCommand = resolveTemplate(entry.sourceCommand!, { basename: '', frontmatter: {}, ...(projectdir && { projectdir }) }, shellQuote);
+      const { stdout } = await execAsync(resolvedCommand, {
         timeout: CustomSearchLoader.COMMAND_SOURCE_TIMEOUT,
         env: getEnhancedEnv(this.settings?.additionalPaths),
         ...(entry.sourceDir && { cwd: entry.sourceDir }),
@@ -985,7 +1001,8 @@ class CustomSearchLoader extends EventEmitter {
       const jsonData = isJsonFile ? parseJsonContent(content) : undefined;
       const hasValues = Object.keys(values).length > 0;
       const basePath = splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir());
-      const context = { basename, frontmatter, prefix, dirname, filePath, basePath, heading, content, ...(hasValues && { values }), ...(jsonData && { jsonData }), ...(entry.args && { args: entry.args }) };
+      const projectdir = this.getProjectdir();
+      const context = { basename, frontmatter, prefix, dirname, filePath, basePath, heading, content, ...(hasValues && { values }), ...(jsonData && { jsonData }), ...(entry.args && { args: entry.args }), ...(projectdir && { projectdir }) };
 
       const item: CustomSearchItem = {
         name: resolveTemplate(entry.name, context),
@@ -1131,7 +1148,8 @@ class CustomSearchLoader extends EventEmitter {
     values?: Record<string, string>
   ): CustomSearchItem | null {
     const basePath = entry.sourcePath ? splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir()) : '';
-    const context = { basename, frontmatter: {}, prefix, dirname, filePath, basePath, heading, line: trimmed, content, ...(values && { values }), ...(entry.args && { args: entry.args }) };
+    const projectdir = this.getProjectdir();
+    const context = { basename, frontmatter: {}, prefix, dirname, filePath, basePath, heading, line: trimmed, content, ...(values && { values }), ...(entry.args && { args: entry.args }), ...(projectdir && { projectdir }) };
     const item: CustomSearchItem = {
       name: resolveTemplate(entry.name, context),
       description: resolveTemplate(entry.description, context),
@@ -1415,7 +1433,8 @@ class CustomSearchLoader extends EventEmitter {
     content?: string
   ): CustomSearchItem | null {
     const basePath = entry.sourcePath ? splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir()) : '';
-    const context = { basename, frontmatter: {}, prefix: '', dirname, filePath, basePath, heading: '', jsonData: elementData, ...(parentJsonDataStack && { parentJsonDataStack }), ...(content !== undefined && { content }), ...(entry.args && { args: entry.args }) };
+    const projectdir = this.getProjectdir();
+    const context = { basename, frontmatter: {}, prefix: '', dirname, filePath, basePath, heading: '', jsonData: elementData, ...(parentJsonDataStack && { parentJsonDataStack }), ...(content !== undefined && { content }), ...(entry.args && { args: entry.args }), ...(projectdir && { projectdir }) };
     const item: CustomSearchItem = {
       name: resolveTemplate(entry.name, context),
       description: resolveTemplate(entry.description, context),

--- a/tests/unit/template-resolver.test.ts
+++ b/tests/unit/template-resolver.test.ts
@@ -535,4 +535,45 @@ describe('valueTransform support', () => {
       content: '; rm -rf /',
     }, shellQuote)).toBe("'; rm -rf /'");
   });
+
+  test('{projectdir} に valueTransform が適用される', () => {
+    expect(resolveTemplate('{projectdir}', {
+      basename: 'file',
+      frontmatter: {},
+      projectdir: '/path/with spaces',
+    }, shellQuote)).toBe("'/path/with spaces'");
+  });
+});
+
+describe('resolveTemplate with projectdir', () => {
+  test('{projectdir}を置換できる', () => {
+    expect(resolveTemplate('{projectdir}', {
+      basename: 'test',
+      frontmatter: {},
+      projectdir: '/Users/user/project',
+    })).toBe('/Users/user/project');
+  });
+
+  test('{projectdir}がundefinedの場合はそのまま残る', () => {
+    expect(resolveTemplate('{projectdir}', {
+      basename: 'test',
+      frontmatter: {},
+    })).toBe('{projectdir}');
+  });
+
+  test('{projectdir}と他の変数を組み合わせて使用できる', () => {
+    expect(resolveTemplate('git -C {projectdir} log', {
+      basename: 'test',
+      frontmatter: {},
+      projectdir: '/Users/user/project',
+    })).toBe('git -C /Users/user/project log');
+  });
+
+  test('{projectdir}が空文字の場合は空に置換される', () => {
+    expect(resolveTemplate('{projectdir}', {
+      basename: 'test',
+      frontmatter: {},
+      projectdir: '',
+    })).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- Add `{projectdir}` template variable that resolves to the detected CWD from the active window (via DirectoryManager)
- Available in all template fields (`name`, `description`, `label`, `runCommand`, etc.) and in `sourceCommand` (shell-quoted for injection safety)
- Wired via a getter function pattern to keep `CustomSearchLoader` decoupled from `DirectoryManager`

## Changes
- `src/lib/template-resolver.ts`: Add `projectdir` to `TemplateContext` and `{projectdir}` replacement in `resolveTemplate()`
- `src/managers/custom-search-loader.ts`: Add `projectdirGetter`, resolve `{projectdir}` in all 3 context construction sites and in `sourceCommand` via `resolveTemplate()` with `shellQuote`
- `src/handlers/ipc-handlers.ts`: Connect `DirectoryManager` to `CustomSearchLoader`
- `src/config/settings-yaml-generator.ts`: Add `{projectdir}` to template variable docs
- `docs/en/plugins.md`, `docs/ja/plugins.md`: Add `{projectdir}` to template variable reference table
- `tests/unit/template-resolver.test.ts`: 5 new tests (basic, undefined, combined, empty string, shellQuote)

## Test plan
- [x] All 1275 tests pass
- [x] TypeScript type check passes
- [x] Manual verification: `@gl:` plugin with `sourceCommand: "git -C {projectdir} log --oneline -50"` correctly displays git log from detected project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)