### PR TITLE
feat(tooltip): add tooltip support to customSearch with Markdown link rendering

### DIFF
--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -166,8 +166,8 @@ class CustomSearchHandler {
         if (item.argumentHint) {
           cmd.argumentHint = item.argumentHint;
         }
-        if (item.frontmatter) {
-          cmd.frontmatter = item.frontmatter;
+        if (item.tooltip) {
+          cmd.tooltip = item.tooltip;
         }
         if (item.inputFormat) {
           cmd.inputFormat = item.inputFormat;
@@ -301,8 +301,8 @@ class CustomSearchHandler {
           description: item.description,
           filePath: item.filePath,
         };
-        if (item.frontmatter) {
-          agent.frontmatter = item.frontmatter;
+        if (item.tooltip) {
+          agent.tooltip = item.tooltip;
         }
         if (item.inputFormat) {
           agent.inputFormat = item.inputFormat;

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -34,6 +34,7 @@ interface PluginEntryYaml {
   displayTime?: string;
   inputFormat?: string;
   excludeMarker?: string;
+  tooltip?: string;
 }
 
 /**
@@ -256,6 +257,7 @@ class PluginLoader {
     if (yamlData.displayTime !== undefined) entry.displayTime = yamlData.displayTime;
     if (yamlData.inputFormat !== undefined) entry.inputFormat = yamlData.inputFormat;
     if (yamlData.excludeMarker !== undefined) entry.excludeMarker = yamlData.excludeMarker;
+    if (yamlData.tooltip !== undefined) entry.tooltip = yamlData.tooltip;
 
     // Apply overrides (from plugin path suffixes like @suffix?params)
     if (overrides?.searchPrefix !== undefined) entry.searchPrefix = overrides.searchPrefix;
@@ -346,7 +348,7 @@ class PluginLoader {
         name: cmd.name,
         description: (cmd.description || '').replace(/\n+/g, ' ').trim(),
         filePath: filePath,
-        frontmatter: frontmatterLines.join('\n'),
+        tooltip: frontmatterLines.join('\n'),
         inputFormat: 'name',
         source: toolName,
         displayName: displayName
@@ -397,7 +399,7 @@ class PluginLoader {
           name: agent.name,
           description: (agent.description || '').replace(/\n+/g, ' ').trim(),
           filePath: filePath,
-          frontmatter: frontmatterLines.join('\n'),
+          tooltip: frontmatterLines.join('\n'),
           label: displayName,
         };
         if (color) {

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -1014,7 +1014,7 @@ class CustomSearchLoader extends EventEmitter {
 
       const sortKey = this.resolveSortKey(entry, context);
       if (sortKey) item.sortKey = sortKey;
-      if (rawFrontmatter) item.frontmatter = rawFrontmatter;
+      if (rawFrontmatter) item.tooltip = rawFrontmatter;
       this.applyOptionalItemFields(item, entry, context);
       item.updatedAt = fileStat.mtimeMs;
 
@@ -1036,7 +1036,7 @@ class CustomSearchLoader extends EventEmitter {
     return resolveValues(filePath, entry.values, entry.prefixPattern, expandedPath);
   }
 
-  /** label/color/icon/argumentHint のオプションフィールドをアイテムに適用する */
+  /** label/color/icon/argumentHint/tooltip/runCommand のオプションフィールドをアイテムに適用する */
   private applyOptionalItemFields(
     item: CustomSearchItem,
     entry: CustomSearchEntry,
@@ -1075,6 +1075,10 @@ class CustomSearchLoader extends EventEmitter {
     }
     if (entry.sourceDir) {
       item.sourceDir = entry.sourceDir;
+    }
+    if (entry.tooltip) {
+      const resolvedTooltip = resolveTemplate(entry.tooltip, context);
+      if (resolvedTooltip) item.tooltip = resolvedTooltip;
     }
   }
 

--- a/src/renderer/agent-skill-manager.ts
+++ b/src/renderer/agent-skill-manager.ts
@@ -46,7 +46,7 @@ interface AgentSkillItem {
   icon?: string;  // Codicon icon class name (e.g., "codicon-rocket")
   argumentHint?: string; // Hint text shown when editing arguments (after Tab selection)
   filePath: string;
-  frontmatter?: string;  // Front Matter 全文（ポップアップ表示用）
+  tooltip?: string;  // Tooltip popup content（ポップアップ表示用テキスト）
   inputFormat?: InputFormatType;  // 入力フォーマット（'name' | テンプレート e.g. '{filepath}', '{content}'）
   inputText?: string;  // テンプレート解決済みの入力テキスト
   source?: string;  // Source tool identifier (e.g., 'claude-code') for filtering
@@ -694,8 +694,7 @@ export class AgentSkillManager implements IInitializable {
         item.appendChild(descSpan);
       }
 
-      // Add info icon for frontmatter popup (only if frontmatter exists)
-      if (cmd.frontmatter) {
+      if (cmd.tooltip) {
         const infoIcon = document.createElement('span');
         infoIcon.className = 'frontmatter-info-icon';
         infoIcon.textContent = 'ⓘ';

--- a/src/renderer/frontmatter-popup-manager.ts
+++ b/src/renderer/frontmatter-popup-manager.ts
@@ -8,6 +8,7 @@ import { UI_TIMING } from '../constants';
 
 interface AgentSkillItemLike {
   name: string;
+  filePath: string;
   tooltip?: string;
 }
 
@@ -84,28 +85,11 @@ export class FrontmatterPopupManager {
   /**
    * Add file path as frontmatter line to content container
    */
-  private async addFilePathLine(contentDiv: HTMLElement, command: AgentSkillItemLike): Promise<void> {
+  private addFilePathLine(contentDiv: HTMLElement, command: AgentSkillItemLike): void {
+    const filePath = command.filePath;
+    if (!filePath || filePath.startsWith('command-source:')) return;
+
     try {
-      // Determine if this is an agent skill or agent, then get file path
-      let filePath: string | null | undefined;
-      try {
-        // Try agent skill API first
-        filePath = await window.electronAPI?.agentSkills?.getFilePath?.(command.name);
-      } catch (_err) {
-        // Silently ignore error - will try agent API next
-      }
-
-      // If no agent skill file path, try agent API
-      if (!filePath) {
-        try {
-          filePath = await window.electronAPI?.agents?.getFilePath?.(command.name);
-        } catch (_err) {
-          // Silently ignore error
-        }
-      }
-
-      if (!filePath) return;
-
       // Replace home directory with ~ for display
       const displayPath = filePath.replace(/^\/Users\/[^/]+/, '~');
 
@@ -220,7 +204,7 @@ export class FrontmatterPopupManager {
   /**
    * Show the frontmatter popup for a command
    */
-  public async show(command: AgentSkillItemLike, targetElement: HTMLElement): Promise<void> {
+  public show(command: AgentSkillItemLike, targetElement: HTMLElement): void {
     const suggestionsContainer = this.callbacks.getSuggestionsContainer();
     if (!this.frontmatterPopup || !command.tooltip || !suggestionsContainer) return;
 
@@ -238,7 +222,7 @@ export class FrontmatterPopupManager {
     this.renderFrontmatter(contentDiv, command.tooltip);
 
     // Add file path line as last frontmatter item (before hint)
-    await this.addFilePathLine(contentDiv, command);
+    this.addFilePathLine(contentDiv, command);
 
     this.frontmatterPopup.appendChild(contentDiv);
 
@@ -333,7 +317,7 @@ export class FrontmatterPopupManager {
   /**
    * Show tooltip for the currently selected item (if auto-show is enabled)
    */
-  public async showForSelectedItem(): Promise<void> {
+  public showForSelectedItem(): void {
     const suggestionsContainer = this.callbacks.getSuggestionsContainer();
     if (!this.autoShowTooltip || !suggestionsContainer) return;
 
@@ -349,17 +333,17 @@ export class FrontmatterPopupManager {
     const selectedItem = suggestionsContainer.querySelector('.agent-skill-suggestion-item.selected');
     const infoIcon = selectedItem?.querySelector('.frontmatter-info-icon') as HTMLElement;
     if (infoIcon) {
-      await this.show(selectedSkill, infoIcon);
+      this.show(selectedSkill, infoIcon);
     }
   }
 
   /**
    * Toggle auto-show tooltip mode
    */
-  public async toggleAutoShow(): Promise<void> {
+  public toggleAutoShow(): void {
     this.autoShowTooltip = !this.autoShowTooltip;
     if (this.autoShowTooltip) {
-      await this.showForSelectedItem();
+      this.showForSelectedItem();
     } else {
       this.hide();
     }

--- a/src/renderer/frontmatter-popup-manager.ts
+++ b/src/renderer/frontmatter-popup-manager.ts
@@ -66,13 +66,17 @@ export class FrontmatterPopupManager {
       this.scheduleHide();
     });
 
-    // Capture wheel events on document when popup is visible
-    document.addEventListener('wheel', (e) => {
-      if (this.isPopupVisible && this.frontmatterPopup) {
-        // Prevent default scrolling behavior
-        e.preventDefault();
-        // Scroll the popup instead
-        this.frontmatterPopup.scrollTop += e.deltaY;
+    // Handle wheel events on popup element only (scroll popup content)
+    this.frontmatterPopup.addEventListener('wheel', (e) => {
+      const popup = this.frontmatterPopup;
+      if (popup) {
+        const canScrollDown = popup.scrollTop < popup.scrollHeight - popup.clientHeight;
+        const canScrollUp = popup.scrollTop > 0;
+        if ((e.deltaY > 0 && canScrollDown) || (e.deltaY < 0 && canScrollUp)) {
+          e.preventDefault();
+          e.stopPropagation();
+          popup.scrollTop += e.deltaY;
+        }
       }
     }, { passive: false });
 
@@ -308,5 +312,17 @@ export class FrontmatterPopupManager {
    */
   public getIsVisible(): boolean {
     return this.isPopupVisible;
+  }
+
+  /**
+   * Clean up resources
+   */
+  public destroy(): void {
+    this.cancelHide();
+    this.cleanupRowListeners();
+    if (this.frontmatterPopup && this.frontmatterPopup.parentNode) {
+      this.frontmatterPopup.parentNode.removeChild(this.frontmatterPopup);
+      this.frontmatterPopup = null;
+    }
   }
 }

--- a/src/renderer/frontmatter-popup-manager.ts
+++ b/src/renderer/frontmatter-popup-manager.ts
@@ -8,7 +8,7 @@ import { UI_TIMING } from '../constants';
 
 interface AgentSkillItemLike {
   name: string;
-  frontmatter?: string;
+  tooltip?: string;
 }
 
 /**
@@ -222,7 +222,7 @@ export class FrontmatterPopupManager {
    */
   public async show(command: AgentSkillItemLike, targetElement: HTMLElement): Promise<void> {
     const suggestionsContainer = this.callbacks.getSuggestionsContainer();
-    if (!this.frontmatterPopup || !command.frontmatter || !suggestionsContainer) return;
+    if (!this.frontmatterPopup || !command.tooltip || !suggestionsContainer) return;
 
     // Cancel any pending hide
     this.cancelHide();
@@ -235,7 +235,7 @@ export class FrontmatterPopupManager {
     // Create content container with parsed frontmatter
     const contentDiv = document.createElement('div');
     contentDiv.className = 'frontmatter-content';
-    this.renderFrontmatter(contentDiv, command.frontmatter);
+    this.renderFrontmatter(contentDiv, command.tooltip);
 
     // Add file path line as last frontmatter item (before hint)
     await this.addFilePathLine(contentDiv, command);
@@ -340,7 +340,7 @@ export class FrontmatterPopupManager {
     const filteredSkills = this.callbacks.getFilteredSkills();
     const selectedIndex = this.callbacks.getSelectedIndex();
     const selectedSkill = filteredSkills[selectedIndex];
-    if (!selectedSkill?.frontmatter) {
+    if (!selectedSkill?.tooltip) {
       this.hide();
       return;
     }

--- a/src/renderer/frontmatter-popup-manager.ts
+++ b/src/renderer/frontmatter-popup-manager.ts
@@ -4,6 +4,7 @@
  */
 
 import { calculatePopupPosition, applyPopupPosition } from './utils/popup-position-calculator';
+import { renderFrontmatter } from './utils/frontmatter-renderer';
 import { UI_TIMING } from '../constants';
 
 interface AgentSkillItemLike {
@@ -146,60 +147,6 @@ export class FrontmatterPopupManager {
     }
   }
 
-  /**
-   * Render frontmatter content with clickable reference links
-   */
-  private renderFrontmatter(container: HTMLElement, frontmatter: string): void {
-    const lines = frontmatter.split('\n');
-
-    for (const line of lines) {
-      const colonIndex = line.indexOf(':');
-      if (colonIndex === -1) {
-        // Plain text line
-        const textNode = document.createTextNode(line);
-        container.appendChild(textNode);
-        container.appendChild(document.createElement('br'));
-        continue;
-      }
-
-      const key = line.substring(0, colonIndex).trim();
-      const value = line.substring(colonIndex + 1).trim();
-
-      // Create line container
-      const lineDiv = document.createElement('div');
-      lineDiv.className = 'frontmatter-line';
-
-      // Add key
-      const keySpan = document.createElement('span');
-      keySpan.className = 'frontmatter-key';
-      keySpan.textContent = key + ': ';
-      lineDiv.appendChild(keySpan);
-
-      // Check if value is a URL (for reference field)
-      if (key === 'reference' && value.startsWith('http')) {
-        const link = document.createElement('a');
-        link.href = value;
-        link.textContent = value;
-        link.className = 'frontmatter-link';
-        link.target = '_blank';
-        link.rel = 'noopener noreferrer';
-        // Handle click to open in external browser
-        link.addEventListener('click', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          window.electronAPI?.shell?.openExternal?.(value);
-        });
-        lineDiv.appendChild(link);
-      } else {
-        const valueSpan = document.createElement('span');
-        valueSpan.className = 'frontmatter-value';
-        valueSpan.textContent = value;
-        lineDiv.appendChild(valueSpan);
-      }
-
-      container.appendChild(lineDiv);
-    }
-  }
 
   /**
    * Show the frontmatter popup for a command
@@ -219,7 +166,7 @@ export class FrontmatterPopupManager {
     // Create content container with parsed frontmatter
     const contentDiv = document.createElement('div');
     contentDiv.className = 'frontmatter-content';
-    this.renderFrontmatter(contentDiv, command.tooltip);
+    renderFrontmatter(contentDiv, command.tooltip);
 
     // Add file path line as last frontmatter item (before hint)
     this.addFilePathLine(contentDiv, command);

--- a/src/renderer/mentions/managers/mention-initializer.ts
+++ b/src/renderer/mentions/managers/mention-initializer.ts
@@ -191,7 +191,7 @@ export class MentionInitializer {
       onFileSelected: (path: string) => this.deps.callbacks.onFileSelected(path),
       setCurrentQuery: (query: string) => { this.deps.state.currentQuery = query; },
       getCurrentPath: () => this.deps.state.currentPath,
-      showTooltipForSelectedItem: async () => await this.deps.popupManager.showTooltipForSelectedItem(),
+      showTooltipForSelectedItem: () => this.deps.popupManager.showTooltipForSelectedItem(),
       renderSuggestions: (_suggestions: SuggestionItem[]) => null // Will be set after suggestionUIManager is initialized
     });
   }
@@ -312,9 +312,9 @@ export class MentionInitializer {
         getCurrentQuery: () => this.deps.state.currentQuery,
         getCodeSearchQuery: () => this.deps.state.codeSearchQuery,
         countFilesInDirectory: (path: string) => this.callbacks.countFilesInDirectory(path),
-        onMouseEnterInfo: async (suggestion: SuggestionItem, target: HTMLElement) => {
+        onMouseEnterInfo: (suggestion: SuggestionItem, target: HTMLElement) => {
           if (suggestion.type === 'agent' && suggestion.agent) {
-            await this.deps.popupManager.showFrontmatterPopup(suggestion.agent, target);
+            this.deps.popupManager.showFrontmatterPopup(suggestion.agent, target);
           }
         },
         onMouseLeaveInfo: () => this.deps.popupManager.schedulePopupHide(),
@@ -330,7 +330,7 @@ export class MentionInitializer {
         restoreDefaultHint: () => this.callbacks.restoreDefaultHint(),
         matchesSearchPrefix: async (query: string, type: 'command' | 'mention') => this.callbacks.matchesSearchPrefix(query, type),
         getMaxSuggestions: async (type: 'command' | 'mention') => this.callbacks.getMaxSuggestions(type),
-        showTooltipForSelectedItem: async () => await this.deps.popupManager.showTooltipForSelectedItem(),
+        showTooltipForSelectedItem: () => this.deps.popupManager.showTooltipForSelectedItem(),
         setCurrentPath: (path: string) => { this.deps.state.currentPath = path; },
         setCurrentQuery: (query: string) => { this.deps.state.currentQuery = query; },
         setFilteredFiles: (files: FileInfo[]) => { this.deps.state.filteredFiles = files; },

--- a/src/renderer/mentions/managers/popup-manager.ts
+++ b/src/renderer/mentions/managers/popup-manager.ts
@@ -10,6 +10,7 @@
 
 import type { AgentItem } from '../../../types';
 import { calculatePopupPosition, applyPopupPosition } from '../../utils/popup-position-calculator';
+import { renderFrontmatter } from '../../utils/frontmatter-renderer';
 import { UI_TIMING } from '../../../constants';
 
 /**
@@ -165,55 +166,6 @@ export class PopupManager {
     }
   }
 
-  /**
-   * Render frontmatter content with clickable reference links
-   */
-  private renderFrontmatter(container: HTMLElement, frontmatter: string): void {
-    const lines = frontmatter.split('\n');
-
-    for (const line of lines) {
-      const colonIndex = line.indexOf(':');
-      if (colonIndex === -1) {
-        const textNode = document.createTextNode(line);
-        container.appendChild(textNode);
-        container.appendChild(document.createElement('br'));
-        continue;
-      }
-
-      const key = line.substring(0, colonIndex).trim();
-      const value = line.substring(colonIndex + 1).trim();
-
-      const lineDiv = document.createElement('div');
-      lineDiv.className = 'frontmatter-line';
-
-      const keySpan = document.createElement('span');
-      keySpan.className = 'frontmatter-key';
-      keySpan.textContent = key + ': ';
-      lineDiv.appendChild(keySpan);
-
-      if (key === 'reference' && value.startsWith('http')) {
-        const link = document.createElement('a');
-        link.href = value;
-        link.textContent = value;
-        link.className = 'frontmatter-link';
-        link.target = '_blank';
-        link.rel = 'noopener noreferrer';
-        link.addEventListener('click', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          window.electronAPI?.shell?.openExternal?.(value);
-        });
-        lineDiv.appendChild(link);
-      } else {
-        const valueSpan = document.createElement('span');
-        valueSpan.className = 'frontmatter-value';
-        valueSpan.textContent = value;
-        lineDiv.appendChild(valueSpan);
-      }
-
-      container.appendChild(lineDiv);
-    }
-  }
 
   /**
    * Show frontmatter popup for an agent
@@ -234,7 +186,7 @@ export class PopupManager {
     // Create content container with parsed frontmatter (clickable reference links)
     const contentDiv = document.createElement('div');
     contentDiv.className = 'frontmatter-content';
-    this.renderFrontmatter(contentDiv, agent.tooltip);
+    renderFrontmatter(contentDiv, agent.tooltip);
 
     // Add file path line after frontmatter content
     this.addFilePathLine(contentDiv, agent.filePath);

--- a/src/renderer/mentions/managers/popup-manager.ts
+++ b/src/renderer/mentions/managers/popup-manager.ts
@@ -105,11 +105,10 @@ export class PopupManager {
   /**
    * Add file path line to the frontmatter content
    */
-  private async addFilePathLine(contentDiv: HTMLElement, agentName: string): Promise<void> {
-    try {
-      const filePath = await window.electronAPI?.agents?.getFilePath?.(agentName);
-      if (!filePath) return;
+  private addFilePathLine(contentDiv: HTMLElement, filePath: string): void {
+    if (!filePath || filePath.startsWith('command-source:')) return;
 
+    try {
       // Replace home directory with ~ for display
       const displayPath = filePath.replace(/^\/Users\/[^/]+/, '~');
 
@@ -162,7 +161,6 @@ export class PopupManager {
       lineDiv.appendChild(link);
       contentDiv.appendChild(lineDiv);
     } catch (error) {
-      // Silently fail - file link is optional
       console.error('Failed to add file path line:', error);
     }
   }
@@ -221,7 +219,7 @@ export class PopupManager {
    * Show frontmatter popup for an agent
    * Position: to the left of the info icon
    */
-  public async showFrontmatterPopup(agent: AgentItem, targetElement: HTMLElement): Promise<void> {
+  public showFrontmatterPopup(agent: AgentItem, targetElement: HTMLElement): void {
     const suggestionsContainer = this.callbacks.getSuggestionsContainer();
     if (!this.frontmatterPopup || !agent.tooltip || !suggestionsContainer) return;
 
@@ -239,7 +237,7 @@ export class PopupManager {
     this.renderFrontmatter(contentDiv, agent.tooltip);
 
     // Add file path line after frontmatter content
-    await this.addFilePathLine(contentDiv, agent.name);
+    this.addFilePathLine(contentDiv, agent.filePath);
 
     this.frontmatterPopup.appendChild(contentDiv);
 
@@ -346,7 +344,7 @@ export class PopupManager {
   /**
    * Show tooltip for the currently selected item (agent only)
    */
-  public async showTooltipForSelectedItem(): Promise<void> {
+  public showTooltipForSelectedItem(): void {
     const suggestionsContainer = this.callbacks.getSuggestionsContainer();
     if (!this.autoShowTooltip || !suggestionsContainer) return;
 
@@ -360,7 +358,7 @@ export class PopupManager {
     const selectedItem = suggestionsContainer.querySelector('.file-suggestion-item.selected');
     const infoIcon = selectedItem?.querySelector('.frontmatter-info-icon') as HTMLElement;
     if (infoIcon) {
-      await this.showFrontmatterPopup(suggestion.agent, infoIcon);
+      this.showFrontmatterPopup(suggestion.agent, infoIcon);
     }
   }
 

--- a/src/renderer/mentions/managers/popup-manager.ts
+++ b/src/renderer/mentions/managers/popup-manager.ts
@@ -106,7 +106,7 @@ export class PopupManager {
   /**
    * Add file path line to the frontmatter content
    */
-  private addFilePathLine(contentDiv: HTMLElement, filePath: string): void {
+  private addFilePathLine(contentDiv: HTMLElement, filePath: string, agent: AgentItem): void {
     if (!filePath || filePath.startsWith('command-source:')) return;
 
     try {
@@ -136,10 +136,9 @@ export class PopupManager {
         e.stopPropagation();
 
         try {
-          // First, get the agent and insert it into textarea
-          const suggestion = this.callbacks.getSelectedSuggestion?.();
-          if (suggestion?.type === 'agent' && suggestion.agent && this.callbacks.onSelectAgent) {
-            this.callbacks.onSelectAgent(suggestion.agent);
+          // Insert the agent captured at popup-creation time (not current selection)
+          if (this.callbacks.onSelectAgent) {
+            this.callbacks.onSelectAgent(agent);
           }
 
           // Then, open the file in editor
@@ -189,7 +188,7 @@ export class PopupManager {
     renderFrontmatter(contentDiv, agent.tooltip);
 
     // Add file path line after frontmatter content
-    this.addFilePathLine(contentDiv, agent.filePath);
+    this.addFilePathLine(contentDiv, agent.filePath, agent);
 
     this.frontmatterPopup.appendChild(contentDiv);
 

--- a/src/renderer/mentions/managers/popup-manager.ts
+++ b/src/renderer/mentions/managers/popup-manager.ts
@@ -223,7 +223,7 @@ export class PopupManager {
    */
   public async showFrontmatterPopup(agent: AgentItem, targetElement: HTMLElement): Promise<void> {
     const suggestionsContainer = this.callbacks.getSuggestionsContainer();
-    if (!this.frontmatterPopup || !agent.frontmatter || !suggestionsContainer) return;
+    if (!this.frontmatterPopup || !agent.tooltip || !suggestionsContainer) return;
 
     // Cancel any pending hide
     this.cancelPopupHide();
@@ -236,7 +236,7 @@ export class PopupManager {
     // Create content container with parsed frontmatter (clickable reference links)
     const contentDiv = document.createElement('div');
     contentDiv.className = 'frontmatter-content';
-    this.renderFrontmatter(contentDiv, agent.frontmatter);
+    this.renderFrontmatter(contentDiv, agent.tooltip);
 
     // Add file path line after frontmatter content
     await this.addFilePathLine(contentDiv, agent.name);
@@ -351,7 +351,7 @@ export class PopupManager {
     if (!this.autoShowTooltip || !suggestionsContainer) return;
 
     const suggestion = this.callbacks.getSelectedSuggestion();
-    if (!suggestion || suggestion.type !== 'agent' || !suggestion.agent?.frontmatter) {
+    if (!suggestion || suggestion.type !== 'agent' || !suggestion.agent?.tooltip) {
       this.hideFrontmatterPopup();
       return;
     }

--- a/src/renderer/mentions/managers/suggestion-ui-manager.ts
+++ b/src/renderer/mentions/managers/suggestion-ui-manager.ts
@@ -681,7 +681,7 @@ export class SuggestionUIManager {
 
     // displayTime: null means explicitly hidden, undefined means no display
     const timeValue = agent.displayTime;
-    if (timeValue != null && timeValue !== undefined) {
+    if (timeValue != null) {
       const timeSpan = document.createElement('span');
       timeSpan.className = 'agent-skill-updated-at';
       timeSpan.textContent = formatTime(timeValue);

--- a/src/renderer/mentions/managers/suggestion-ui-manager.ts
+++ b/src/renderer/mentions/managers/suggestion-ui-manager.ts
@@ -688,7 +688,7 @@ export class SuggestionUIManager {
       item.appendChild(timeSpan);
     }
 
-    if (agent.frontmatter && this.callbacks.onMouseEnterInfo) {
+    if (agent.tooltip && this.callbacks.onMouseEnterInfo) {
       const infoIcon = document.createElement('span');
       infoIcon.className = 'frontmatter-info-icon';
       infoIcon.textContent = 'ⓘ';

--- a/src/renderer/utils/frontmatter-renderer.ts
+++ b/src/renderer/utils/frontmatter-renderer.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared utility for rendering frontmatter tooltip content
+ */
+
+export function renderFrontmatter(container: HTMLElement, frontmatter: string): void {
+  const lines = frontmatter.split('\n');
+
+  for (const line of lines) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) {
+      container.appendChild(document.createTextNode(line));
+      container.appendChild(document.createElement('br'));
+      continue;
+    }
+
+    const key = line.substring(0, colonIndex).trim();
+    const value = line.substring(colonIndex + 1).trim();
+
+    const lineDiv = document.createElement('div');
+    lineDiv.className = 'frontmatter-line';
+
+    const keySpan = document.createElement('span');
+    keySpan.className = 'frontmatter-key';
+    keySpan.textContent = key + ': ';
+    lineDiv.appendChild(keySpan);
+
+    if (value.startsWith('http')) {
+      const link = document.createElement('a');
+      link.href = value;
+      link.textContent = value;
+      link.className = 'frontmatter-link';
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.electronAPI?.shell?.openExternal?.(value);
+      });
+      lineDiv.appendChild(link);
+    } else {
+      const valueSpan = document.createElement('span');
+      valueSpan.className = 'frontmatter-value';
+      valueSpan.textContent = value;
+      lineDiv.appendChild(valueSpan);
+    }
+
+    container.appendChild(lineDiv);
+  }
+}

--- a/src/renderer/utils/frontmatter-renderer.ts
+++ b/src/renderer/utils/frontmatter-renderer.ts
@@ -63,7 +63,7 @@ export function renderFrontmatter(container: HTMLElement, frontmatter: string): 
     keySpan.textContent = key + ': ';
     lineDiv.appendChild(keySpan);
 
-    if (value.startsWith('http')) {
+    if (/^https?:\/\//.test(value)) {
       const link = document.createElement('a');
       link.href = value;
       link.textContent = value;

--- a/src/renderer/utils/frontmatter-renderer.ts
+++ b/src/renderer/utils/frontmatter-renderer.ts
@@ -2,13 +2,50 @@
  * Shared utility for rendering frontmatter tooltip content
  */
 
+const MARKDOWN_LINK_PATTERN = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+
+/**
+ * Append text with Markdown link syntax [text](url) rendered as clickable <a> elements.
+ * Non-link text is appended as text nodes.
+ */
+function appendWithMarkdownLinks(container: HTMLElement, text: string): void {
+  MARKDOWN_LINK_PATTERN.lastIndex = 0;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = MARKDOWN_LINK_PATTERN.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      container.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+    }
+    const label = match[1]!;
+    const url = match[2]!;
+    const link = document.createElement('a');
+    link.href = url;
+    link.textContent = label;
+    link.className = 'frontmatter-link';
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      window.electronAPI?.shell?.openExternal?.(url);
+    });
+    container.appendChild(link);
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    container.appendChild(document.createTextNode(text.slice(lastIndex)));
+  }
+}
+
 export function renderFrontmatter(container: HTMLElement, frontmatter: string): void {
   const lines = frontmatter.split('\n');
 
   for (const line of lines) {
     const colonIndex = line.indexOf(':');
     if (colonIndex === -1) {
-      container.appendChild(document.createTextNode(line));
+      appendWithMarkdownLinks(container, line);
       container.appendChild(document.createElement('br'));
       continue;
     }
@@ -40,7 +77,7 @@ export function renderFrontmatter(container: HTMLElement, frontmatter: string): 
     } else {
       const valueSpan = document.createElement('span');
       valueSpan.className = 'frontmatter-value';
-      valueSpan.textContent = value;
+      appendWithMarkdownLinks(valueSpan, value);
       lineDiv.appendChild(valueSpan);
     }
 

--- a/src/renderer/utils/frontmatter-renderer.ts
+++ b/src/renderer/utils/frontmatter-renderer.ts
@@ -39,19 +39,21 @@ function appendWithMarkdownLinks(container: HTMLElement, text: string): void {
   }
 }
 
+const KEY_VALUE_PATTERN = /^([\w-]+):\s*(.*)/;
+
 export function renderFrontmatter(container: HTMLElement, frontmatter: string): void {
   const lines = frontmatter.split('\n');
 
   for (const line of lines) {
-    const colonIndex = line.indexOf(':');
-    if (colonIndex === -1) {
+    const kvMatch = KEY_VALUE_PATTERN.exec(line);
+    if (!kvMatch) {
       appendWithMarkdownLinks(container, line);
       container.appendChild(document.createElement('br'));
       continue;
     }
 
-    const key = line.substring(0, colonIndex).trim();
-    const value = line.substring(colonIndex + 1).trim();
+    const key = kvMatch[1]!;
+    const value = kvMatch[2]!;
 
     const lineDiv = document.createElement('div');
     lineDiv.className = 'frontmatter-line';

--- a/src/renderer/utils/shortcut-formatter.ts
+++ b/src/renderer/utils/shortcut-formatter.ts
@@ -1,3 +1,10 @@
+function makeKbd(text: string, className?: string): HTMLElement {
+  const kbd = document.createElement('kbd');
+  if (className) kbd.className = className;
+  kbd.textContent = text;
+  return kbd;
+}
+
 export function formatShortcut(shortcut: string): string {
   return shortcut
     .replace(/Cmd/gi, '⌘')
@@ -30,12 +37,13 @@ export function updateShortcutsDisplay(
     
     const parts = pasteKey.split('+');
     const modifiers = parts.slice(0, -1).join('+');
-    const key = parts[parts.length - 1];
+    const key = parts[parts.length - 1] ?? '';
     
-    headerShortcutsEl.innerHTML = `
-      <kbd>${modifiers}</kbd>+<kbd>${key}</kbd> Paste
-      <kbd>${closeKey}</kbd> Close
-    `;
+    headerShortcutsEl.replaceChildren(
+      makeKbd(modifiers), document.createTextNode(`+`),
+      makeKbd(key), document.createTextNode(` Paste `),
+      makeKbd(closeKey), document.createTextNode(` Close`)
+    );
   }
 
   // Update history navigation shortcuts
@@ -52,10 +60,14 @@ export function updateShortcutsDisplay(
     const prevParts = formattedPrev.split('+');
     
     const nextModifier = nextParts.slice(0, -1).join('+');
-    const nextKey = nextParts[nextParts.length - 1];
-    const prevKey = prevParts[prevParts.length - 1];
+    const nextKey = nextParts[nextParts.length - 1] ?? '';
+    const prevKey = prevParts[prevParts.length - 1] ?? '';
     
-    historyShortcutsEl.innerHTML = `<kbd class="history-kbd">${nextModifier}</kbd>+<kbd class="history-kbd">${nextKey}</kbd>/<kbd class="history-kbd">${prevKey}</kbd>`;
+    historyShortcutsEl.replaceChildren(
+      makeKbd(nextModifier, 'history-kbd'), document.createTextNode(`+`),
+      makeKbd(nextKey, 'history-kbd'), document.createTextNode(`/`),
+      makeKbd(prevKey, 'history-kbd')
+    );
   }
 
   // Update search button tooltip

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -444,6 +444,8 @@ export interface MentionEntry {
   sourceCommand?: string;
   /** オプション: テンプレート引数（例: { open: "iTerm" } → {args.open} で参照可能） */
   args?: Record<string, string>;
+  /** オプション: tooltip popup に表示するテキスト（テンプレート変数使用可）。設定時はファイルのfrontmatterより優先 */
+  tooltip?: string;
 }
 
 // ============================================================================
@@ -515,6 +517,8 @@ export interface CustomSearchEntry {
   args?: Record<string, string>;
   /** オプション: sourceCommand/runCommand 実行時の作業ディレクトリ（YAMLファイルのディレクトリパス） */
   sourceDir?: string;
+  /** オプション: tooltip popup に表示するテキスト（テンプレート変数使用可）。設定時はファイルのfrontmatterより優先 */
+  tooltip?: string;
 }
 
 /**
@@ -529,8 +533,8 @@ export interface CustomSearchItem {
   type: CustomSearchType;
   /** ファイルパス */
   filePath: string;
-  /** 元のfrontmatter文字列 */
-  frontmatter?: string;
+  /** Tooltip popup content（ポップアップ表示用テキスト） */
+  tooltip?: string;
   /** label（オプション） */
   label?: string;
   /** ラベルとハイライトの色（オプション） */
@@ -567,7 +571,7 @@ export interface AgentSkillItem {
   icon?: string;  // Codicon icon class name (e.g., "codicon-rocket")
   argumentHint?: string; // Hint text shown when editing arguments (after Tab selection)
   filePath: string;
-  frontmatter?: string;  // Front Matter 全文（ポップアップ表示用）
+  tooltip?: string;  // Tooltip popup content（ポップアップ表示用テキスト）
   inputFormat?: InputFormatType;  // 入力フォーマット（'name' | テンプレート e.g. '{filepath}', '{content}'）
   inputText?: string;  // テンプレート解決済みの入力テキスト
   source?: string;  // Source tool identifier (e.g., 'claude-code') for filtering
@@ -583,7 +587,7 @@ export interface AgentItem {
   name: string;
   description: string;
   filePath: string;
-  frontmatter?: string;  // Front Matter 全文（ポップアップ表示用）
+  tooltip?: string;  // Tooltip popup content（ポップアップ表示用テキスト）
   inputFormat?: InputFormatType;  // 入力フォーマット（'name' | テンプレート e.g. '{filepath}', '{content}'）
   inputText?: string;  // テンプレート解決済みの入力テキスト
   color?: ColorValue;

--- a/tests/unit/custom-search-loader.test.ts
+++ b/tests/unit/custom-search-loader.test.ts
@@ -957,9 +957,9 @@ Content`;
 
       const items = await loader.getItems('command');
 
-      expect(items[0]?.frontmatter).toBeDefined();
-      expect(items[0]?.frontmatter).toContain('description: Test description');
-      expect(items[0]?.frontmatter).toContain('argument-hint: <arg>');
+      expect(items[0]?.tooltip).toBeDefined();
+      expect(items[0]?.tooltip).toContain('description: Test description');
+      expect(items[0]?.tooltip).toContain('argument-hint: <arg>');
     });
 
     test('should not include frontmatter when file has no frontmatter', async () => {
@@ -967,7 +967,7 @@ Content`;
 
       const items = await loader.getItems('command');
 
-      expect(items[0]?.frontmatter).toBeUndefined();
+      expect(items[0]?.tooltip).toBeUndefined();
     });
   });
 
@@ -2085,7 +2085,7 @@ Content`;
       const items = await loader.getItems('command');
 
       expect(items).toHaveLength(1);
-      expect(items[0]?.frontmatter).toBeUndefined();
+      expect(items[0]?.tooltip).toBeUndefined();
     });
   });
 
@@ -2456,7 +2456,7 @@ Content`;
       // frontmatter@description is empty for all items
       items.forEach(item => {
         expect(item.description).toBe('');
-        expect(item.frontmatter).toBeUndefined();
+        expect(item.tooltip).toBeUndefined();
       });
     });
 

--- a/tests/unit/popup-manager.test.ts
+++ b/tests/unit/popup-manager.test.ts
@@ -113,13 +113,13 @@ describe('PopupManager', () => {
         tooltip: 'This is the agent description'
       };
 
-      await popupManager.showFrontmatterPopup(agent, targetElement);
+      popupManager.showFrontmatterPopup(agent, targetElement);
 
       const popup = document.getElementById('frontmatterPopup');
       expect(popup?.style.display).toBe('block');
 
       const content = popup?.querySelector('.frontmatter-content');
-      expect(content?.textContent).toBe('This is the agent description');
+      expect(content?.textContent).toContain('This is the agent description');
     });
 
     test('should show hint message in popup', async () => {
@@ -132,7 +132,7 @@ describe('PopupManager', () => {
         tooltip: 'Agent description'
       };
 
-      await popupManager.showFrontmatterPopup(agent, targetElement);
+      popupManager.showFrontmatterPopup(agent, targetElement);
 
       const popup = document.getElementById('frontmatterPopup');
       const hint = popup?.querySelector('.frontmatter-hint');
@@ -356,7 +356,7 @@ describe('PopupManager', () => {
         }
       });
 
-      await popupManager.showTooltipForSelectedItem();
+      popupManager.showTooltipForSelectedItem();
 
       const popup = document.getElementById('frontmatterPopup');
       expect(popup?.style.display).toBe('block');

--- a/tests/unit/popup-manager.test.ts
+++ b/tests/unit/popup-manager.test.ts
@@ -110,7 +110,7 @@ describe('PopupManager', () => {
         name: 'test-agent',
         description: 'Test agent description',
         filePath: '/path/to/agent',
-        frontmatter: 'This is the agent description'
+        tooltip: 'This is the agent description'
       };
 
       await popupManager.showFrontmatterPopup(agent, targetElement);
@@ -129,7 +129,7 @@ describe('PopupManager', () => {
         name: 'test-agent',
         description: 'Test agent description',
         filePath: '/path/to/agent',
-        frontmatter: 'Agent description'
+        tooltip: 'Agent description'
       };
 
       await popupManager.showFrontmatterPopup(agent, targetElement);
@@ -146,7 +146,7 @@ describe('PopupManager', () => {
         name: 'test-agent',
         description: 'Test agent description',
         filePath: '/path/to/agent',
-        frontmatter: undefined
+        tooltip: undefined
       };
 
       popupManager.showFrontmatterPopup(agent as any, targetElement);
@@ -164,7 +164,7 @@ describe('PopupManager', () => {
         name: 'test-agent',
         description: 'Test agent description',
         filePath: '/path/to/agent',
-        frontmatter: 'Agent description'
+        tooltip: 'Agent description'
       };
 
       popupManager.showFrontmatterPopup(agent, targetElement);
@@ -352,7 +352,7 @@ describe('PopupManager', () => {
           name: 'test-agent',
           description: 'Test agent description',
           filePath: '/path/to/agent',
-          frontmatter: 'Agent description'
+          tooltip: 'Agent description'
         }
       });
 
@@ -372,7 +372,7 @@ describe('PopupManager', () => {
           name: 'test-agent',
           description: 'Test agent description',
           filePath: '/path/to/agent',
-          frontmatter: 'Agent description'
+          tooltip: 'Agent description'
         }
       });
 

--- a/tests/unit/utils/shortcut-formatter.test.ts
+++ b/tests/unit/utils/shortcut-formatter.test.ts
@@ -81,10 +81,7 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, historyShortcutsEl, shortcuts);
 
-    expect(headerShortcutsEl.innerHTML).toBe(`
-      <kbd>⌘</kbd>+<kbd>↵</kbd> Paste
-      <kbd>Esc</kbd> Close
-    `);
+    expect(headerShortcutsEl.innerHTML).toBe('<kbd>⌘</kbd>+<kbd>↵</kbd> Paste <kbd>Esc</kbd> Close');
   });
 
   test('should update history shortcuts display', () => {
@@ -119,10 +116,7 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, historyShortcutsEl, shortcuts);
 
-    expect(headerShortcutsEl.innerHTML).toBe(`
-      <kbd>⌘+⇧</kbd>+<kbd>↵</kbd> Paste
-      <kbd>Esc</kbd> Close
-    `);
+    expect(headerShortcutsEl.innerHTML).toBe('<kbd>⌘+⇧</kbd>+<kbd>↵</kbd> Paste <kbd>Esc</kbd> Close');
   });
 
   test('should handle null elements gracefully', () => {
@@ -144,10 +138,7 @@ describe('updateShortcutsDisplay', () => {
 
     updateShortcutsDisplay(headerShortcutsEl, null, shortcuts);
 
-    expect(headerShortcutsEl.innerHTML).toBe(`
-      <kbd>⌘</kbd>+<kbd>↵</kbd> Paste
-      <kbd>Esc</kbd> Close
-    `);
+    expect(headerShortcutsEl.innerHTML).toBe('<kbd>⌘</kbd>+<kbd>↵</kbd> Paste <kbd>Esc</kbd> Close');
   });
 
   test('should handle only history element', () => {


### PR DESCRIPTION
## Summary

- Add `tooltip` field support to customSearch entries, rendering the same rich popup as agentSkill
- Auto-linkify any value starting with `http` as a clickable `<a>` element
- Support Markdown link syntax `[text](url)` in tooltip text for inline links
- Extract shared `renderFrontmatter` utility from both popup managers (DRY)
- Fix key detection regex to prevent URL colons (`https:`) from being misidentified as key-value separators

## Changes

### New feature: tooltip for customSearch (`583b716`)
- Added `tooltip` field to `CustomSearchEntry` type
- `custom-search-handler.ts`: include `tooltip` in IPC response
- `plugin-loader.ts`: load `tooltip` from YAML
- `custom-search-loader.ts`: propagate `tooltip` through entry building
- `suggestion-ui-manager.ts`: show tooltip indicator for customSearch items
- `frontmatter-popup-manager.ts`: display tooltip popup for customSearch items

### Refactor: shared renderer and IPC cleanup (`9f69604`, `ae7ad8d`)
- Eliminated async IPC round-trips in `addFilePathLine` by passing `filePath` directly
- Extracted `renderFrontmatter()` into `src/renderer/utils/frontmatter-renderer.ts`
- Both `FrontmatterPopupManager` and `PopupManager` now share one implementation
- Auto-linkify all `http` values (previously only `reference:` key was linkified)

### feat: Markdown link syntax (`af2ffe5`)
- `[text](url)` in any tooltip value renders as a clickable `<a>` element
- Plain text around links is preserved as text nodes

### fix: URL colon misparse (`ec95c8d`)
- Changed key detection from `indexOf(':')` to `/^([\w-]+):\s*(.*)/`
- Prevents `commit [hash](https://...)` lines from being split at `https:`

## Test plan

- [ ] customSearch entry with `tooltip` field shows popup on hover/selection
- [ ] `http` values in tooltip render as clickable links
- [ ] `[text](url)` syntax in tooltip values renders as inline links
- [ ] `commit [hash](https://github.com/...)` tooltip line renders hash as clickable link
- [ ] Existing agentSkill tooltip behavior unchanged
- [ ] Unit tests pass: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)