### PR TITLE
refactor(template): rename {updatedAt} variable to {mtime}

### DIFF
--- a/docs/en/migration.md
+++ b/docs/en/migration.md
@@ -18,6 +18,30 @@ Your backup is preserved, so you can refer to it when re-applying customizations
 
 ---
 
+## v0.32 → v0.33
+
+### 1. Template variable `{updatedAt}` renamed to `{mtime}`
+
+The `{updatedAt}` template variable has been renamed to `{mtime}` for consistency with other lowercase template variables (`{basename}`, `{heading}`, `{filepath}`, etc.).
+
+If you use `{updatedAt}` in your `settings.yaml` custom search entries (e.g., `orderBy` or `displayTime`), update them:
+
+**Before:**
+```yaml
+orderBy: "{updatedAt} desc"
+displayTime: "{updatedAt}"
+```
+
+**After:**
+```yaml
+orderBy: "{mtime} desc"
+displayTime: "{mtime}"
+```
+
+Also update any custom plugin YAML files that reference `{updatedAt}`.
+
+---
+
 ## v0.29 → v0.30
 
 ### 1. Shortcuts format changed (key → action)

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -244,7 +244,7 @@ searchPrefix: agent                   # → type @agent: to search
 name: "{basename}(agent)"
 label: global
 description: "{frontmatter@description}"
-displayTime: "{updatedAt}"
+displayTime: "{mtime}"
 icon: codicon-hubot
 ```
 
@@ -352,7 +352,7 @@ runCommand: "./open.sh {line}"
 | `{pathdir:N}` | Nth directory from sourcePath base | e.g., `sourcePath: ~/a/b/*/file.md` → base=`~/a/b`, `{pathdir:1}`=first dir after base |
 | `{projectdir}` | Current project directory (detected CWD) | e.g., `git -C {projectdir} log` |
 | `{latest}` | Most recently modified dir | |
-| `{updatedAt}` | File modification time | |
+| `{mtime}` | File modification time | |
 | `{args.key}` | Value from `args` field | `{args.open}` |
 
 **Fallback:** `{frontmatter@description}|{heading}` — uses right side if left is empty.

--- a/docs/ja/migration.md
+++ b/docs/ja/migration.md
@@ -18,6 +18,30 @@ pnpm run migrate-settings
 
 ---
 
+## v0.32 → v0.33
+
+### 1. テンプレート変数 `{updatedAt}` を `{mtime}` にリネーム
+
+テンプレート変数 `{updatedAt}` は、他の小文字テンプレート変数（`{basename}`, `{heading}`, `{filepath}` 等）との一貫性のため `{mtime}` にリネームされました。
+
+`settings.yaml` のカスタム検索エントリで `{updatedAt}` を使用している場合は更新してください：
+
+**変更前:**
+```yaml
+orderBy: "{updatedAt} desc"
+displayTime: "{updatedAt}"
+```
+
+**変更後:**
+```yaml
+orderBy: "{mtime} desc"
+displayTime: "{mtime}"
+```
+
+カスタムプラグインYAMLファイルで `{updatedAt}` を参照している場合も同様に更新してください。
+
+---
+
 ## v0.29 → v0.30
 
 ### 1. ショートカットフォーマットの変更（キー → アクション）

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -244,7 +244,7 @@ searchPrefix: agent                   # → @agent: と入力して検索
 name: "{basename}(agent)"
 label: global
 description: "{frontmatter@description}"
-displayTime: "{updatedAt}"
+displayTime: "{mtime}"
 icon: codicon-hubot
 ```
 
@@ -352,7 +352,7 @@ runCommand: "./open.sh {line}"
 | `{pathdir:N}` | sourcePathのベースからN番目のディレクトリ | 例: `sourcePath: ~/a/b/*/file.md` → ベース=`~/a/b`、`{pathdir:1}`=ベース直下のディレクトリ |
 | `{projectdir}` | 現在のプロジェクトディレクトリ（検出されたCWD） | 例: `git -C {projectdir} log` |
 | `{latest}` | 最新の更新ディレクトリ | |
-| `{updatedAt}` | ファイル更新日時 | |
+| `{mtime}` | ファイル更新日時 | |
 | `{args.key}` | `args`フィールドの値 | `{args.open}` |
 
 **フォールバック：** `{frontmatter@description}|{heading}` — 左側が空の場合、右側を使用。

--- a/src/config/default-settings.ts
+++ b/src/config/default-settings.ts
@@ -261,7 +261,7 @@ export const commentedExamples = {
       searchPrefix: 'kb',
       shortcut: 'Ctrl+g',
       maxSuggestions: 100,
-      orderBy: '{updatedAt} desc',
+      orderBy: '{mtime} desc',
       inputFormat: '{filepath}',
       runCommand: "open -a 'Google Chrome' {filepath}"
     },

--- a/src/config/settings-yaml-generator.ts
+++ b/src/config/settings-yaml-generator.ts
@@ -357,8 +357,8 @@ function buildCustomSearchHeader(): string {
 #   values          : Map of template variable names to JSON extraction patterns (e.g., pluginName: "**/.claude-plugin/*.json@name")
 #   searchPrefix    : Prefix to trigger this search (e.g., "agent" → @agent:)
 #   maxSuggestions  : Maximum number of suggestions to display
-#   orderBy         : Sort order (e.g., "name", "name desc", "{updatedAt} desc")
-#   displayTime     : Timestamp to display (e.g., "{updatedAt}", "{json@createdAt}", "none" to hide)
+#   orderBy         : Sort order (e.g., "name", "name desc", "{mtime} desc")
+#   displayTime     : Timestamp to display (e.g., "{mtime}", "{json@createdAt}", "none" to hide)
 #   inputFormat     : Insert format ('name' = display name, or template e.g. '{filepath}', '{content}')
 #   color           : Badge color (name or hex)
 #   icon            : Codicon icon name (e.g., "agent", "rocket", "terminal")

--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -175,8 +175,8 @@ class CustomSearchHandler {
         if (item.inputText) {
           cmd.inputText = item.inputText;
         }
-        if (item.updatedAt) {
-          cmd.updatedAt = item.updatedAt;
+        if (item.mtime) {
+          cmd.mtime = item.mtime;
         }
         if (item.triggers) {
           cmd.triggers = item.triggers;
@@ -323,8 +323,8 @@ class CustomSearchHandler {
         if (item.label) {
           agent.label = item.label;
         }
-        if (item.updatedAt) {
-          agent.updatedAt = item.updatedAt;
+        if (item.mtime) {
+          agent.mtime = item.mtime;
         }
         if (item.displayTime !== undefined) {
           agent.displayTime = item.displayTime;

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -517,7 +517,7 @@ class CustomSearchLoader extends EventEmitter {
    */
   private sortItems(items: CustomSearchItem[], orderBy: string): CustomSearchItem[] {
     const { field, direction } = CustomSearchLoader.parseOrderBy(orderBy);
-    const isCustomField = field !== 'updatedAt' && field !== 'name' && field !== 'description';
+    const isCustomField = field !== 'mtime' && field !== 'name' && field !== 'description';
 
     // カスタムフィールドの場合、数値変換をソート前に1回だけ行う
     let numericValues: Map<CustomSearchItem, number> | null = null;
@@ -534,8 +534,8 @@ class CustomSearchLoader extends EventEmitter {
     }
 
     return [...items].sort((a, b) => {
-      if (field === 'updatedAt') {
-        const comparison = (a.updatedAt ?? 0) - (b.updatedAt ?? 0);
+      if (field === 'mtime') {
+        const comparison = (a.mtime ?? 0) - (b.mtime ?? 0);
         return direction === 'desc' ? -comparison : comparison;
       }
 
@@ -1016,7 +1016,7 @@ class CustomSearchLoader extends EventEmitter {
       if (sortKey) item.sortKey = sortKey;
       if (rawFrontmatter) item.tooltip = rawFrontmatter;
       this.applyOptionalItemFields(item, entry, context);
-      item.updatedAt = fileStat.mtimeMs;
+      item.mtime = fileStat.mtimeMs;
 
       const displayTime = this.resolveDisplayTime(entry, context, fileStat.mtimeMs);
       if (displayTime !== undefined) item.displayTime = displayTime;
@@ -1167,7 +1167,7 @@ class CustomSearchLoader extends EventEmitter {
     item.sortKey = sortKey ?? String(lineIndex).padStart(8, '0');
     this.applyOptionalItemFields(item, entry, context);
     this.applyInputFormat(item, entry, context);
-    item.updatedAt = mtimeMs;
+    item.mtime = mtimeMs;
 
     const displayTime = this.resolveDisplayTime(entry, context, mtimeMs);
     if (displayTime !== undefined) item.displayTime = displayTime;
@@ -1397,9 +1397,9 @@ class CustomSearchLoader extends EventEmitter {
     if (!entry.displayTime) return undefined;
     if (entry.displayTime === 'none') return null;
 
-    // {updatedAt} は特別扱い: ファイル更新日時を使用
+    // {mtime} は特別扱い: ファイル更新日時を使用
     const parsed = CustomSearchLoader.parseOrderBy(entry.displayTime);
-    if (parsed.field === 'updatedAt') {
+    if (parsed.field === 'mtime') {
       return fileMtimeMs;
     }
 
@@ -1417,7 +1417,7 @@ class CustomSearchLoader extends EventEmitter {
   private resolveSortKey(entry: CustomSearchEntry, context: Parameters<typeof resolveTemplate>[1]): string | undefined {
     if (!entry.orderBy) return undefined;
     const { field } = CustomSearchLoader.parseOrderBy(entry.orderBy);
-    if (field === 'name' || field === 'description' || field === 'updatedAt') return undefined;
+    if (field === 'name' || field === 'description' || field === 'mtime') return undefined;
     const template = CustomSearchLoader.extractOrderByTemplate(entry.orderBy);
     const resolved = resolveTemplate(template, context);
     return resolved || undefined;

--- a/src/renderer/agent-skill-manager.ts
+++ b/src/renderer/agent-skill-manager.ts
@@ -51,7 +51,7 @@ interface AgentSkillItem {
   inputText?: string;  // テンプレート解決済みの入力テキスト
   source?: string;  // Source tool identifier (e.g., 'claude-code') for filtering
   displayName?: string;  // Human-readable source name for display (e.g., 'Claude Code')
-  updatedAt?: number;  // File modification timestamp (mtimeMs)
+  mtime?: number;  // File modification timestamp (mtimeMs)
   triggers?: string[];  // Trigger prefixes (e.g., ['/', '$'])
 }
 

--- a/src/renderer/mentions/managers/file-filter-manager.ts
+++ b/src/renderer/mentions/managers/file-filter-manager.ts
@@ -501,7 +501,7 @@ export class FileFilterManager {
     // Get agent usage bonuses
     const agentBonuses = this.callbacks.getAgentUsageBonuses?.() ?? {};
 
-    // Track original agent order from backend (preserves orderBy setting like updatedAt desc)
+    // Track original agent order from backend (preserves orderBy setting like mtime desc)
     const agentOrder = new Map<AgentItem, number>();
     filteredAgents.forEach((agent, i) => agentOrder.set(agent, i));
 
@@ -521,7 +521,7 @@ export class FileFilterManager {
         if (aIsDir && !bIsDir) return -1;
         if (!aIsDir && bIsDir) return 1;
 
-        // Both agents: preserve backend sort order (e.g., orderBy: updatedAt desc)
+        // Both agents: preserve backend sort order (e.g., orderBy: mtime desc)
         if (a.type === 'agent' && b.type === 'agent') {
           return (agentOrder.get(a.agent!) ?? 0) - (agentOrder.get(b.agent!) ?? 0);
         }

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -412,7 +412,7 @@ export interface MentionEntry {
   searchPrefix?: string;
   /** オプション: ソート順（デフォルト: 'name'） - 'name', 'name desc', 'description desc' など */
   orderBy?: string;
-  /** オプション: 末尾に表示する日時テンプレート（例: "{updatedAt}", "{json@createdAt}", "none"で非表示） */
+  /** オプション: 末尾に表示する日時テンプレート（例: "{mtime}", "{json@createdAt}", "none"で非表示） */
   displayTime?: string;
   /** オプション: 入力フォーマット（デフォルト: 'name'） */
   inputFormat?: InputFormatType;
@@ -485,7 +485,7 @@ export interface CustomSearchEntry {
   searchPrefix?: string;
   /** オプション: ソート順（デフォルト: 'name'） - 'name', 'name desc', 'description desc' など */
   orderBy?: string;
-  /** オプション: 末尾に表示する日時テンプレート（例: "{updatedAt}", "{json@createdAt}", "none"で非表示） */
+  /** オプション: 末尾に表示する日時テンプレート（例: "{mtime}", "{json@createdAt}", "none"で非表示） */
   displayTime?: string;
   /** オプション: 入力フォーマット（デフォルト: 'name'） - 'name': 名前のみ, 'path': ファイルパス */
   inputFormat?: InputFormatType;
@@ -552,8 +552,8 @@ export interface CustomSearchItem {
   /** テンプレート解決済みの入力テキスト（inputFormatがテンプレートの場合に使用） */
   inputText?: string;
   /** ファイル更新日時（mtimeMs） */
-  updatedAt?: number;
-  /** 表示用日時（displayTime設定で解決された値。undefinedはupdatedAtにフォールバック、nullは非表示） */
+  mtime?: number;
+  /** 表示用日時（displayTime設定で解決された値。undefinedはmtimeにフォールバック、nullは非表示） */
   displayTime?: number | null;
   /** トリガー文字の配列（commandタイプのみ） */
   triggers?: string[];
@@ -576,7 +576,7 @@ export interface AgentSkillItem {
   inputText?: string;  // テンプレート解決済みの入力テキスト
   source?: string;  // Source tool identifier (e.g., 'claude-code') for filtering
   displayName?: string;  // Human-readable source name for display (e.g., 'Claude Code')
-  updatedAt?: number;  // File modification timestamp (mtimeMs)
+  mtime?: number;  // File modification timestamp (mtimeMs)
   triggers?: string[];  // Trigger prefixes (e.g., ['/', '$'])
 }
 
@@ -593,7 +593,7 @@ export interface AgentItem {
   color?: ColorValue;
   icon?: string;  // Codicon icon class name (e.g., "codicon-rocket")
   label?: string;
-  updatedAt?: number;  // File modification timestamp (mtimeMs)
-  displayTime?: number | null;  // Resolved display time (null = hidden, undefined = fallback to updatedAt)
+  mtime?: number;  // File modification timestamp (mtimeMs)
+  displayTime?: number | null;  // Resolved display time (null = hidden, undefined = fallback to mtime)
   runCommand?: string;  // Shell command to execute on Ctrl+Enter (template-resolved)
 }

--- a/tests/unit/custom-search-loader.test.ts
+++ b/tests/unit/custom-search-loader.test.ts
@@ -2114,6 +2114,16 @@ Content`;
       const result = CustomSearchLoader.parseOrderBy('description asc');
       expect(result).toEqual({ field: 'description', direction: 'asc' });
     });
+
+    test('should parse "{mtime} desc" to field mtime with desc direction', () => {
+      const result = CustomSearchLoader.parseOrderBy('{mtime} desc');
+      expect(result).toEqual({ field: 'mtime', direction: 'desc' });
+    });
+
+    test('should parse "{mtime}" to field mtime with asc direction (default)', () => {
+      const result = CustomSearchLoader.parseOrderBy('{mtime}');
+      expect(result).toEqual({ field: 'mtime', direction: 'asc' });
+    });
   });
 
   describe('extractOrderByTemplate', () => {


### PR DESCRIPTION
## Summary
- Rename `{updatedAt}` template variable to `{mtime}` across types, handlers, loaders, config, and docs
- Aligns with lowercase naming convention used by other template variables (`{basename}`, `{heading}`, `{filepath}`, etc.)
- Matches fs.Stats `mtime` terminology
- Cache metadata `updatedAt` (file-cache-manager, symbol-cache-manager) is intentionally unchanged as it refers to a different concept

## Test plan
- [x] All 1,279 tests pass
- [x] TypeScript type check passes
- [x] Built and installed app — 10,678 custom search items loaded without errors
- [x] Plugin YAML files updated and reinstalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)