### PR TITLE
fix(projectdir): invalidate {projectdir} command cache on directory change

### DIFF
--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -3,6 +3,7 @@ import { logger } from '../utils/utils';
 import type CustomSearchLoader from '../managers/custom-search-loader';
 import type SettingsManager from '../managers/settings-manager';
 import type PluginManager from '../managers/plugin-manager';
+import type DirectoryManager from '../managers/directory-manager';
 import type { AgentSkillItem, AgentItem } from '../types';
 import type { CommandExecutionResult } from '../types/ipc';
 import { exec } from 'child_process';
@@ -23,10 +24,21 @@ class CustomSearchHandler {
   constructor(
     customSearchLoader: CustomSearchLoader,
     settingsManager: SettingsManager,
-    pluginManagerInstance: PluginManager
+    pluginManagerInstance: PluginManager,
+    directoryManager: DirectoryManager
   ) {
     this.customSearchLoader = customSearchLoader;
     this.settingsManager = settingsManager;
+
+    // Invalidate {projectdir}-dependent command cache when directory changes
+    directoryManager.on('directory-changed', ({ previousDirectory }: { previousDirectory: string | null }) => {
+      if (!previousDirectory) return;
+      const wasInvalidated = this.customSearchLoader.invalidateProjectdirCommandCache();
+      if (wasInvalidated) {
+        this.notifyRenderer();
+        logger.debug('CustomSearch: projectdir cache invalidated on directory change');
+      }
+    });
 
     // Subscribe to settings changes for hot reload
     settingsManager.on('settings-changed', () => {

--- a/src/handlers/ipc-handlers.ts
+++ b/src/handlers/ipc-handlers.ts
@@ -74,7 +74,8 @@ class IPCHandlers {
     this.customSearchHandler = new CustomSearchHandler(
       customSearchLoader,
       settingsManager,
-      pluginManager
+      pluginManager,
+      directoryManager
     );
     this.fileHandler = new FileHandler(fileOpenerManager, directoryManager);
     this.usageHistoryHandler = new UsageHistoryHandler();

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -145,6 +145,32 @@ class CustomSearchLoader extends EventEmitter {
   }
 
   /**
+   * Invalidate commandCache entries for entries that use {projectdir} in their sourceCommand.
+   * Called when the active directory changes. Other command cache entries are preserved.
+   */
+  invalidateProjectdirCommandCache(): boolean {
+    let invalidated = false;
+    for (const entry of this.config) {
+      if (!entry.sourceCommand || !entry.sourceCommand.includes('{projectdir}')) continue;
+      const sourceId = this.getCommandSourceId(entry);
+      if (this.commandCache.has(sourceId)) {
+        this.commandCache.delete(sourceId);
+        invalidated = true;
+      }
+      this.commandFetchPromises.delete(sourceId);
+    }
+    if (invalidated) {
+      this.invalidateCache();
+      logger.debug('CustomSearch: {projectdir} command cache invalidated on directory change');
+    }
+    return invalidated;
+  }
+
+  private getCommandSourceId(entry: CustomSearchEntry): string {
+    return `sourceCommand:${entry.sourceCommand}${entry.sourceDir ? ':' + entry.sourceDir : ''}`;
+  }
+
+  /**
    * Returns the timestamp of the last cache invalidation.
    * Used by renderer to avoid unnecessary invalidation on window-shown.
    */
@@ -712,7 +738,7 @@ class CustomSearchLoader extends EventEmitter {
   private async loadCommandEntry(
     entry: CustomSearchEntry
   ): Promise<{ items: CustomSearchItem[]; watchableFiles: string[]; watchGlobs: string[] }> {
-    const sourceId = `sourceCommand:${entry.sourceCommand}${entry.sourceDir ? ':' + entry.sourceDir : ''}`;
+    const sourceId = this.getCommandSourceId(entry);
     const cached = this.commandCache.get(sourceId);
 
     let items: CustomSearchItem[];

--- a/src/managers/directory-manager.ts
+++ b/src/managers/directory-manager.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { EventEmitter } from 'events';
 import config from '../config/app-config';
 import {
   logger,
@@ -21,13 +22,14 @@ interface DirectoryData {
  * - @path highlighting restoration
  * - Window context preservation
  */
-class DirectoryManager {
+class DirectoryManager extends EventEmitter {
   private directoryFile: string;
   private currentDirectory: string | null = null;
   private currentMethod: string | null = null;
   private lastSaveTimestamp: number = 0;
 
   constructor() {
+    super();
     this.directoryFile = config.paths.directoryFile;
   }
 
@@ -137,11 +139,16 @@ class DirectoryManager {
 
   /**
    * Set the current directory (in memory only, does not persist)
+   * Emits 'directory-changed' when the directory actually changes
    */
   setDirectory(directory: string | null, method?: string): void {
+    const previous = this.currentDirectory;
     this.currentDirectory = directory;
     if (method) {
       this.currentMethod = method;
+    }
+    if (previous !== directory) {
+      this.emit('directory-changed', { directory, previousDirectory: previous });
     }
   }
 
@@ -198,6 +205,7 @@ class DirectoryManager {
     this.currentDirectory = null;
     this.currentMethod = null;
     this.lastSaveTimestamp = 0;
+    this.removeAllListeners();
   }
 }
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -170,7 +170,10 @@ describe('IPCHandlers', () => {
         mockDirectoryManager = {
             getDirectory: vi.fn(() => null),
             setDirectory: vi.fn(),
-            saveDirectory: vi.fn()
+            saveDirectory: vi.fn(),
+            on: vi.fn(),
+            emit: vi.fn(),
+            removeAllListeners: vi.fn()
         };
 
         const mockPluginManager = {


### PR DESCRIPTION
## Summary

- Fix stale `{projectdir}` template variable in CustomSearch source commands (e.g., git-log plugin) when switching between terminals with different working directories
- Add `EventEmitter` to `DirectoryManager` to emit `directory-changed` events when the detected directory changes
- Add `invalidateProjectdirCommandCache()` to `CustomSearchLoader` to selectively invalidate only `{projectdir}`-dependent command cache entries
- Wire up `CustomSearchHandler` to listen for directory changes, invalidate affected caches, and notify the renderer for re-fetch

## Test plan

- [x] TypeScript type check passes (`pnpm run typecheck`)
- [x] All 1281 tests pass (`pnpm test`)
- [x] CDP test: directory display updates correctly when switching between terminals in different directories
- [x] CDP test: `@gl:` (git-log) custom search shows correct repository logs after directory switch
- [x] Pre-push hooks pass (lint + typecheck + full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)