### PR TITLE
fix(displayTime): preserve sort order in agent dedup to show correct timestamps

### DIFF
--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -354,11 +354,12 @@ class CustomSearchHandler {
         const key = `${agent.name}:${agent.label || ''}`;
         agentMap.set(key, agent);
       }
-      const builtInKeys = new Set(agentMap.keys());
+      const insertedCustomKeys = new Set<string>();
       for (const agent of customAgents) {
         const key = `${agent.name}:${agent.label || ''}`;
-        if (builtInKeys.has(key) || !agentMap.has(key)) {
+        if (!insertedCustomKeys.has(key)) {
           agentMap.set(key, agent);
+          insertedCustomKeys.add(key);
         }
       }
 

--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -348,14 +348,18 @@ class CustomSearchHandler {
       });
 
       // Merge: built-in first, custom agents can override built-in with same name:label key
+      // Among custom agents with the same key, keep the first one (preserves sort order from searchItems)
       const agentMap = new Map<string, AgentItem>();
       for (const agent of builtInAgents) {
         const key = `${agent.name}:${agent.label || ''}`;
         agentMap.set(key, agent);
       }
+      const builtInKeys = new Set(agentMap.keys());
       for (const agent of customAgents) {
         const key = `${agent.name}:${agent.label || ''}`;
-        agentMap.set(key, agent);
+        if (builtInKeys.has(key) || !agentMap.has(key)) {
+          agentMap.set(key, agent);
+        }
       }
 
       return Array.from(agentMap.values());


### PR DESCRIPTION
## Summary

- Fix agent dedup in `handleGetAgents` to keep the first (most recent) entry when multiple custom agents share the same `name:label` key
- Previously `Map.set()` unconditionally overwrote entries, so the last (oldest) duplicate won after desc sorting, causing stale `displayTime` values

## Root cause

When JSONL sources like `@cr:` (codex history) contain duplicate names (e.g. "commit" entered 7 times), `searchItems` correctly sorts them by `{json@ts} desc` (newest first). However, `handleGetAgents` merged results into a `Map` using `agentMap.set(key, agent)` without checking for existing entries. Since the sorted array was iterated front-to-back, the oldest duplicate overwrote the newest, producing wrong `displayTime` (e.g. Sep 2025 instead of Apr 2026).

## Test plan

- [x] `pnpm run pre-push` — lint, typecheck, 1295 tests pass
- [x] CDP E2E: `@cr:` shows correct relative times ("1h ago", "8d ago") matching actual JSONL timestamps
- [x] CDP E2E: `@r:` (Claude history) unaffected
- [x] Built-in agent override preserved (custom agents still override built-in agents with same key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)