### PR TITLE
feat(excludeIf): add template-based item exclusion for plugin entries

### DIFF
--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -223,6 +223,7 @@ icon: codicon-terminal
 | `values` | No | Template variable patterns |
 | `triggers` | No | Trigger characters (default: `["/"]`) |
 | `args` | No | Template arguments |
+| `excludeIf` | No | Expression to exclude individual items from search (see [excludeIf](#excludeif)) |
 
 \* At least one of `sourcePath` or `sourceCommand` is required.
 
@@ -258,6 +259,8 @@ icon: codicon-hubot
 | `runCommand` | Shell command on Ctrl+Enter |
 | `excludeMarker` | Skip directories with this file |
 | `tooltip` | Tooltip popup text (template variables supported). Overrides file frontmatter when set |
+
+(`excludeIf` is shared with agent-skills; see [excludeIf](#excludeif).)
 
 #### Tooltip
 
@@ -334,6 +337,56 @@ runCommand: "./open.sh {line}"
 ```
 
 ---
+
+## excludeIf
+
+The `excludeIf` field excludes individual items from search based on the result of a template expression. Available for both `agent-skills` and `custom-search`.
+
+### Syntax
+
+Two forms are supported:
+
+| Form | Semantics |
+|------|-----------|
+| `excludeIf: "<template>"` | Exclude when the resolved template is **non-empty** (truthy check) |
+| `excludeIf: "<template>==<value>"` | Exclude when the resolved template **exactly equals** `<value>` |
+
+- The left side (before `==`) is resolved as a template — you can use `{frontmatter@...}`, `{json@...}`, `{basename}`, and others.
+- The right side (after `==`) is treated as a literal string (not template-resolved).
+- Both sides are trimmed of leading/trailing whitespace.
+
+### Examples
+
+**Exclude files where frontmatter `hidden` is set:**
+```yaml
+sourcePath: ~/.claude/skills/**/SKILL.md
+name: "{frontmatter@name}"
+description: "{frontmatter@description}"
+excludeIf: "{frontmatter@hidden}"           # exclude if hidden has any value
+```
+
+**Exclude files where frontmatter is `searchable: false`:**
+```yaml
+sourcePath: ~/notes/**/*.md
+name: "{basename}"
+searchPrefix: note
+excludeIf: "{frontmatter@searchable}==false"
+```
+
+**Exclude draft items by status:**
+```yaml
+sourcePath: ~/articles/*.md
+name: "{frontmatter@title}"
+excludeIf: "{frontmatter@status}==draft"
+```
+
+**Works for JSONL sources too (e.g., exclude system records):**
+```yaml
+sourcePath: ~/.claude/history.jsonl
+name: "{json@display}"
+searchPrefix: r
+excludeIf: "{json@type}==system"
+```
 
 ## Template Variables
 

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -223,6 +223,7 @@ icon: codicon-terminal
 | `values` | No | テンプレート変数パターン |
 | `triggers` | No | トリガー文字（デフォルト: `["/"]`） |
 | `args` | No | テンプレート引数 |
+| `excludeIf` | No | 個別アイテムを検索対象から除外する条件式（[excludeIf](#excludeif) 参照） |
 
 \* `sourcePath` または `sourceCommand` のいずれかが必要。
 
@@ -258,6 +259,8 @@ icon: codicon-hubot
 | `runCommand` | Ctrl+Enterで実行するシェルコマンド |
 | `excludeMarker` | このファイルを含むディレクトリをスキップ |
 | `tooltip` | ツールチップポップアップテキスト（テンプレート変数使用可）。設定時はファイルのfrontmatterより優先 |
+
+（`excludeIf` は agent-skills と共通。[excludeIf](#excludeif) 参照）
 
 #### ツールチップ
 
@@ -334,6 +337,56 @@ runCommand: "./open.sh {line}"
 ```
 
 ---
+
+## excludeIf
+
+`excludeIf` フィールドを設定すると、テンプレート式の評価結果に応じて個別のアイテムを検索対象から除外できます。`agent-skills` と `custom-search` の両方で利用可能です。
+
+### 構文
+
+2つの形式をサポートします：
+
+| 形式 | セマンティクス |
+|------|----------------|
+| `excludeIf: "<template>"` | テンプレート解決の結果が**非空**なら除外（truthy チェック） |
+| `excludeIf: "<template>==<value>"` | テンプレート解決の結果が `<value>` と**完全一致**したら除外 |
+
+- 左辺（`==` の前）はテンプレートとして解決されます（`{frontmatter@...}`, `{json@...}`, `{basename}` など使用可）。
+- 右辺（`==` の後）は literal 文字列として扱われます（テンプレート解決されません）。
+- `<template>` も `<value>` も前後の空白はトリムされます。
+
+### 例
+
+**frontmatter の `hidden` フィールドが設定されたファイルを除外：**
+```yaml
+sourcePath: ~/.claude/skills/**/SKILL.md
+name: "{frontmatter@name}"
+description: "{frontmatter@description}"
+excludeIf: "{frontmatter@hidden}"           # hidden フィールドに値があれば除外
+```
+
+**frontmatter で `searchable: false` が指定されたファイルを除外：**
+```yaml
+sourcePath: ~/notes/**/*.md
+name: "{basename}"
+searchPrefix: note
+excludeIf: "{frontmatter@searchable}==false"
+```
+
+**ステータスが draft のアイテムを除外：**
+```yaml
+sourcePath: ~/articles/*.md
+name: "{frontmatter@title}"
+excludeIf: "{frontmatter@status}==draft"
+```
+
+**JSONL ソースでも利用可能（例: 特定タイプのレコードを除外）：**
+```yaml
+sourcePath: ~/.claude/history.jsonl
+name: "{json@display}"
+searchPrefix: r
+excludeIf: "{json@type}==system"
+```
 
 ## テンプレート変数
 

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -34,6 +34,7 @@ interface PluginEntryYaml {
   displayTime?: string;
   inputFormat?: string;
   excludeMarker?: string;
+  excludeIf?: string;
   tooltip?: string;
 }
 
@@ -257,6 +258,7 @@ class PluginLoader {
     if (yamlData.displayTime !== undefined) entry.displayTime = yamlData.displayTime;
     if (yamlData.inputFormat !== undefined) entry.inputFormat = yamlData.inputFormat;
     if (yamlData.excludeMarker !== undefined) entry.excludeMarker = yamlData.excludeMarker;
+    if (yamlData.excludeIf !== undefined) entry.excludeIf = yamlData.excludeIf;
     if (yamlData.tooltip !== undefined) entry.tooltip = yamlData.tooltip;
 
     // Apply overrides (from plugin path suffixes like @suffix?params)

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -1056,6 +1056,8 @@ class CustomSearchLoader extends EventEmitter {
       const projectdir = this.getProjectdir();
       const context = { basename, frontmatter, prefix, dirname, filePath, basePath, heading, content, ...(hasValues && { values }), ...(jsonData && { jsonData }), ...(entry.args && { args: entry.args }), ...(projectdir && { projectdir }) };
 
+      if (this.shouldExcludeByTemplate(entry.excludeIf, context)) return null;
+
       const item: CustomSearchItem = {
         name: resolveTemplate(entry.name, context),
         description: resolveTemplate(entry.description, context),
@@ -1078,6 +1080,22 @@ class CustomSearchLoader extends EventEmitter {
       logger.warn('Failed to parse file', { filePath, error });
       return null;
     }
+  }
+
+  /** `==` があれば左辺テンプレートを右辺 literal と比較、なければ truthy チェック */
+  private shouldExcludeByTemplate(
+    excludeIf: string | undefined,
+    context: TemplateContext
+  ): boolean {
+    if (!excludeIf) return false;
+    const eqIdx = excludeIf.indexOf('==');
+    if (eqIdx === -1) {
+      return resolveTemplate(excludeIf, context).trim() !== '';
+    }
+    const leftTemplate = excludeIf.slice(0, eqIdx);
+    const expected = excludeIf.slice(eqIdx + 2).trim();
+    const actual = resolveTemplate(leftTemplate, context).trim();
+    return actual === expected;
   }
 
   /** エントリのvalues/prefixPatternからテンプレート変数を解決する */
@@ -1206,6 +1224,9 @@ class CustomSearchLoader extends EventEmitter {
     const basePath = entry.sourcePath ? splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir()) : '';
     const projectdir = this.getProjectdir();
     const context = { basename, frontmatter: {}, prefix, dirname, filePath, basePath, heading, line: trimmed, content, ...(values && { values }), ...(entry.args && { args: entry.args }), ...(projectdir && { projectdir }) };
+
+    if (this.shouldExcludeByTemplate(entry.excludeIf, context)) return null;
+
     const item: CustomSearchItem = {
       name: resolveTemplate(entry.name, context),
       description: resolveTemplate(entry.description, context),
@@ -1499,6 +1520,9 @@ class CustomSearchLoader extends EventEmitter {
     const basePath = entry.sourcePath ? splitSourcePath(entry.sourcePath).dir.replace(/^~/, os.homedir()) : '';
     const projectdir = this.getProjectdir();
     const context = { basename, frontmatter: {}, prefix: '', dirname, filePath, basePath, heading: '', jsonData: elementData, ...(parentJsonDataStack && { parentJsonDataStack }), ...(content !== undefined && { content }), ...(entry.args && { args: entry.args }), ...(projectdir && { projectdir }) };
+
+    if (this.shouldExcludeByTemplate(entry.excludeIf, context)) return null;
+
     const item: CustomSearchItem = {
       name: resolveTemplate(entry.name, context),
       description: resolveTemplate(entry.description, context),

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -1082,7 +1082,7 @@ class CustomSearchLoader extends EventEmitter {
     }
   }
 
-  /** `==` があれば左辺テンプレートを右辺 literal と比較、なければ truthy チェック */
+  /** If `==` is present, compare the left-side template against the right-side literal; otherwise truthy-check the resolved template. */
   private shouldExcludeByTemplate(
     excludeIf: string | undefined,
     context: TemplateContext

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -511,6 +511,12 @@ export interface CustomSearchEntry {
   runCommand?: string;
   /** オプション: このファイルが存在するディレクトリを検索対象から除外する（例: ".orphaned_at"） */
   excludeMarker?: string;
+  /**
+   * オプション: テンプレート式の評価結果で個別アイテムを除外する
+   * - `"{frontmatter@hidden}"` — テンプレート解決結果が非空なら除外
+   * - `"{frontmatter@searchable}==false"` — 解決結果が値と完全一致したら除外
+   */
+  excludeIf?: string;
   /** オプション: コマンドの標準出力を検索ソースとして使用するシェルコマンド文字列（指定時は sourcePath の代わりに使用） */
   sourceCommand?: string;
   /** オプション: テンプレート引数（例: { open: "iTerm" } → {args.open} で参照可能） */

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -512,9 +512,9 @@ export interface CustomSearchEntry {
   /** オプション: このファイルが存在するディレクトリを検索対象から除外する（例: ".orphaned_at"） */
   excludeMarker?: string;
   /**
-   * オプション: テンプレート式の評価結果で個別アイテムを除外する
-   * - `"{frontmatter@hidden}"` — テンプレート解決結果が非空なら除外
-   * - `"{frontmatter@searchable}==false"` — 解決結果が値と完全一致したら除外
+   * Optional: exclude individual items based on a template expression result
+   * - `"{frontmatter@hidden}"` — exclude when the resolved template is non-empty
+   * - `"{frontmatter@searchable}==false"` — exclude when the resolved value exactly matches the right-hand literal
    */
   excludeIf?: string;
   /** オプション: コマンドの標準出力を検索ソースとして使用するシェルコマンド文字列（指定時は sourcePath の代わりに使用） */

--- a/tests/unit/custom-search-loader.test.ts
+++ b/tests/unit/custom-search-loader.test.ts
@@ -783,6 +783,121 @@ describe('CustomSearchLoader', () => {
     });
   });
 
+  describe('excludeIf', () => {
+    test('should exclude items when frontmatter flag is non-empty (truthy check)', async () => {
+      loader = new CustomSearchLoader([
+        {
+          name: '{basename}',
+          type: 'command',
+          description: '{frontmatter@description}',
+          sourcePath: '/path/to/commands/*.md',
+          excludeIf: '{frontmatter@hidden}',
+        },
+      ]);
+
+      mockedFs.stat.mockResolvedValue({ isDirectory: () => true } as any);
+      mockedFs.readdir.mockResolvedValue([
+        createDirent('visible.md', true),
+        createDirent('secret.md', true),
+      ] as any);
+      mockedFs.readFile.mockImplementation(((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.includes('secret.md')) {
+          return Promise.resolve('---\ndescription: Secret\nhidden: true\n---\n');
+        }
+        return Promise.resolve('---\ndescription: Visible\n---\n');
+      }) as any);
+
+      const items = await loader.getItems('command');
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.name).toBe('visible');
+    });
+
+    test('should exclude items when template result equals expected value (== comparison)', async () => {
+      loader = new CustomSearchLoader([
+        {
+          name: '{basename}',
+          type: 'command',
+          description: '{frontmatter@description}',
+          sourcePath: '/path/to/commands/*.md',
+          excludeIf: '{frontmatter@searchable}==false',
+        },
+      ]);
+
+      mockedFs.stat.mockResolvedValue({ isDirectory: () => true } as any);
+      mockedFs.readdir.mockResolvedValue([
+        createDirent('a.md', true),
+        createDirent('b.md', true),
+        createDirent('c.md', true),
+      ] as any);
+      mockedFs.readFile.mockImplementation(((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.includes('a.md')) {
+          return Promise.resolve('---\ndescription: A\nsearchable: true\n---\n');
+        }
+        if (pathStr.includes('b.md')) {
+          return Promise.resolve('---\ndescription: B\nsearchable: false\n---\n');
+        }
+        return Promise.resolve('---\ndescription: C\n---\n');
+      }) as any);
+
+      const items = await loader.getItems('command');
+
+      expect(items).toHaveLength(2);
+      expect(items.map(i => i.name).sort()).toEqual(['a', 'c']);
+    });
+
+    test('should not exclude items when excludeIf is not set', async () => {
+      loader = new CustomSearchLoader([
+        {
+          name: '{basename}',
+          type: 'command',
+          description: '{frontmatter@description}',
+          sourcePath: '/path/to/commands/*.md',
+        },
+      ]);
+
+      mockedFs.stat.mockResolvedValue({ isDirectory: () => true } as any);
+      mockedFs.readdir.mockResolvedValue([createDirent('a.md', true)] as any);
+      mockedFs.readFile.mockResolvedValue('---\ndescription: A\nhidden: true\n---\n');
+
+      const items = await loader.getItems('command');
+
+      expect(items).toHaveLength(1);
+    });
+
+    test('should exclude by status value match', async () => {
+      loader = new CustomSearchLoader([
+        {
+          name: '{basename}',
+          type: 'command',
+          description: '{frontmatter@description}',
+          sourcePath: '/path/to/commands/*.md',
+          excludeIf: '{frontmatter@status}==draft',
+        },
+      ]);
+
+      mockedFs.stat.mockResolvedValue({ isDirectory: () => true } as any);
+      mockedFs.readdir.mockResolvedValue([
+        createDirent('published.md', true),
+        createDirent('draft.md', true),
+      ] as any);
+      mockedFs.readFile.mockImplementation(((filePath: any) => {
+        const pathStr = String(filePath);
+        if (pathStr.includes('draft.md')) {
+          return Promise.resolve('---\ndescription: D\nstatus: draft\n---\n');
+        }
+        return Promise.resolve('---\ndescription: P\nstatus: published\n---\n');
+      }) as any);
+
+      const items = await loader.getItems('command');
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.name).toBe('published');
+    });
+  });
+
   describe('duplicate handling', () => {
     test('should prevent duplicates within same type', async () => {
       loader = new CustomSearchLoader([


### PR DESCRIPTION
## Summary
- Add `excludeIf` field to plugin YAML (agent-skills + custom-search) for filtering individual items from search
- Two forms: `"{template}"` (truthy check) and `"{template}==<literal>"` (equality check)
- Works across markdown, JSON/JSONL, and plain-text sources

## Motivation
Plugin authors needed a way to mark specific items (e.g., frontmatter `hidden: true` or `searchable: false`) as hidden from search without moving the files. The existing `excludeMarker` only operates at the directory level — `excludeIf` fills the item-level gap.

## Examples

```yaml
# agent-skills: hide by frontmatter flag
excludeIf: "{frontmatter@hidden}"

# custom-search: hide explicitly non-searchable items
excludeIf: "{frontmatter@searchable}==false"

# JSONL: skip system-type records
excludeIf: "{json@type}==system"
```

## Design notes
- Left side (before `==`) is resolved as a template; right side is a literal
- `==` absent → truthy check on the resolved template
- Implementation is a single helper `shouldExcludeByTemplate()` called from 3 parsing paths (markdown, JSON(L), plain text)

## Test plan
- [x] Added 4 unit tests in `tests/unit/custom-search-loader.test.ts` (truthy check, `==false` comparison, default no-exclude, status value match)
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — 1299/1299 tests pass
- [x] `pnpm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)