### PR TITLE
perf(template-resolver): precompile templates and cache JSON path tokens

### DIFF
--- a/src/lib/template-resolver.ts
+++ b/src/lib/template-resolver.ts
@@ -19,6 +19,10 @@
  * フォールバック構文:
  * - テンプレート全体で `|` を使うと、左側が空文字の場合に右側にフォールバック
  * - 例: "{frontmatter@description}|{heading}" → frontmatterが空なら最初のheadingを使用
+ *
+ * パフォーマンス:
+ * - 同じテンプレート文字列に対する解析結果をプロセス内でキャッシュ（LRUなし、YAML由来で有界）
+ * - {json@...} のパストークナイズ結果も別キャッシュで再利用
  */
 
 export interface TemplateContext {
@@ -42,6 +46,221 @@ export interface TemplateContext {
   projectdir?: string;
 }
 
+type ValueTransform = (v: string) => string;
+
+/** Compiled op kinds. The discriminator `k` is numeric for fast switch dispatch. */
+const enum OpKind {
+  LIT = 0,
+  VAR = 1,
+  DIRNAME_N = 2,
+  PATHDIR = 3,
+  FRONTMATTER = 4,
+  ARGS = 5,
+  JSON = 6,
+  JSON_PARENT = 7,
+}
+
+type Op =
+  | { k: OpKind.LIT; v: string }
+  | { k: OpKind.VAR; name: string; raw: string }
+  | { k: OpKind.DIRNAME_N; level: number; raw: string }
+  | { k: OpKind.PATHDIR; level: number; raw: string }
+  | { k: OpKind.FRONTMATTER; field: string; raw: string }
+  | { k: OpKind.ARGS; key: string; raw: string }
+  | { k: OpKind.JSON; tokens: string[]; pathRaw: string; raw: string }
+  | { k: OpKind.JSON_PARENT; level: number; tokens: string[]; pathRaw: string; raw: string };
+
+type Segment = Op[];
+interface Compiled {
+  segments: Segment[];
+}
+
+// Module-level caches. Templates are user-authored (YAML) so the set of distinct
+// strings is bounded; the size caps below are a safety net for any caller that
+// feeds dynamic strings through.
+const templateCache = new Map<string, Compiled>();
+const jsonPathTokenCache = new Map<string, string[]>();
+const TEMPLATE_CACHE_MAX = 500;
+const JSON_PATH_CACHE_MAX = 1000;
+
+const INDEX_TOKEN_RE = /^\[(-?\d+)\]$/;
+
+/** Parse a JSON path like "items[0].name" into tokens like ["items", "[0]", "name"]. */
+function tokenizeJsonPath(path: string): string[] {
+  let tokens = jsonPathTokenCache.get(path);
+  if (tokens) return tokens;
+  if (jsonPathTokenCache.size >= JSON_PATH_CACHE_MAX) jsonPathTokenCache.clear();
+  tokens = path.split(/\.|\[/).reduce<string[]>((acc, part) => {
+    if (part === '') return acc;
+    acc.push(part.endsWith(']') ? '[' + part : part);
+    return acc;
+  }, []);
+  jsonPathTokenCache.set(path, tokens);
+  return tokens;
+}
+
+/** Parse a single `{...}` token's inner content into an op. */
+function parseToken(raw: string): Op {
+  // {dirname:N}
+  const dirMatch = /^dirname:(\d+)$/.exec(raw);
+  if (dirMatch) return { k: OpKind.DIRNAME_N, level: parseInt(dirMatch[1]!, 10), raw };
+
+  // {pathdir:N}
+  const pathMatch = /^pathdir:(\d+)$/.exec(raw);
+  if (pathMatch) return { k: OpKind.PATHDIR, level: parseInt(pathMatch[1]!, 10), raw };
+
+  // {frontmatter@field} (requires at least one char after @, matching original regex `[^}]+`)
+  if (raw.startsWith('frontmatter@') && raw.length > 'frontmatter@'.length) {
+    return { k: OpKind.FRONTMATTER, field: raw.slice('frontmatter@'.length), raw };
+  }
+
+  // {args.key}
+  if (raw.startsWith('args.') && raw.length > 'args.'.length) {
+    return { k: OpKind.ARGS, key: raw.slice('args.'.length), raw };
+  }
+
+  // {json:N@path}
+  const jpMatch = /^json:(\d+)@(.+)$/.exec(raw);
+  if (jpMatch) {
+    const pathRaw = jpMatch[2]!;
+    return {
+      k: OpKind.JSON_PARENT,
+      level: parseInt(jpMatch[1]!, 10),
+      tokens: tokenizeJsonPath(pathRaw),
+      pathRaw,
+      raw,
+    };
+  }
+
+  // {json@path}
+  if (raw.startsWith('json@') && raw.length > 'json@'.length) {
+    const pathRaw = raw.slice('json@'.length);
+    return {
+      k: OpKind.JSON,
+      tokens: tokenizeJsonPath(pathRaw),
+      pathRaw,
+      raw,
+    };
+  }
+
+  // Bare {name}. Unknown names fall back to literal at runtime (see runVar).
+  return { k: OpKind.VAR, name: raw, raw };
+}
+
+/** Scan a pipe-free segment into a list of ops (literals + tokens). */
+function compileSegment(segmentText: string): Segment {
+  const ops: Segment = [];
+  const re = /\{([^}]+)\}/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(segmentText)) !== null) {
+    if (m.index > last) {
+      ops.push({ k: OpKind.LIT, v: segmentText.slice(last, m.index) });
+    }
+    ops.push(parseToken(m[1]!));
+    last = m.index + m[0].length;
+  }
+  if (last < segmentText.length) {
+    ops.push({ k: OpKind.LIT, v: segmentText.slice(last) });
+  }
+  return ops;
+}
+
+/** Compile a full template string (top-level `|` split into fallback segments). */
+function compile(template: string): Compiled {
+  let cached = templateCache.get(template);
+  if (cached) return cached;
+  if (templateCache.size >= TEMPLATE_CACHE_MAX) templateCache.clear();
+  const segments = template.split('|').map(compileSegment);
+  cached = { segments };
+  templateCache.set(template, cached);
+  return cached;
+}
+
+/** Resolve a bare {name} op. Returns `undefined` when the name is unresolvable
+ *  (i.e., the original literal must be emitted). */
+function runVar(name: string, ctx: TemplateContext): string | undefined {
+  switch (name) {
+    case 'basename': return ctx.basename;
+    case 'dirname': return ctx.dirname;
+    case 'heading': return ctx.heading ?? '';
+    case 'line': return ctx.line ?? '';
+    case 'content': return ctx.content;
+    case 'filepath': return ctx.filePath ? ctx.filePath : undefined;
+    case 'projectdir': return ctx.projectdir;
+    case 'prefix': return ctx.prefix;
+    default: return undefined;
+  }
+}
+
+/** Walk a JSON path (pre-tokenized) and return the string value. */
+function walkJsonPath(data: Record<string, unknown>, tokens: string[]): string {
+  let current: unknown = data;
+  for (let i = 0; i < tokens.length; i++) {
+    if (current === null || current === undefined) return '';
+    const token = tokens[i]!;
+    if (token.startsWith('[')) {
+      const indexMatch = INDEX_TOKEN_RE.exec(token);
+      if (!indexMatch || !Array.isArray(current)) return '';
+      const index = parseInt(indexMatch[1]!, 10);
+      current = index < 0 ? current[current.length + index] : current[index];
+    } else {
+      if (typeof current !== 'object' || Array.isArray(current)) return '';
+      current = (current as Record<string, unknown>)[token];
+    }
+  }
+  if (current === null || current === undefined) return '';
+  if (typeof current === 'object') return JSON.stringify(current);
+  return String(current);
+}
+
+/** Evaluate one op against a context. */
+function execOp(op: Op, ctx: TemplateContext, t: ValueTransform): string {
+  if (op.k === OpKind.LIT) return op.v;
+
+  if (ctx.values) {
+    const v = ctx.values[op.raw];
+    if (v !== undefined) return t(v);
+  }
+
+  switch (op.k) {
+    case OpKind.VAR: {
+      const resolved = runVar(op.name, ctx);
+      return resolved !== undefined ? t(resolved) : `{${op.raw}}`;
+    }
+    case OpKind.DIRNAME_N:
+      return ctx.filePath ? t(getDirname(ctx.filePath, op.level)) : `{${op.raw}}`;
+    case OpKind.PATHDIR:
+      return (ctx.filePath && ctx.basePath) ? t(getPathdir(ctx.filePath, ctx.basePath, op.level)) : `{${op.raw}}`;
+    case OpKind.FRONTMATTER:
+      return t(ctx.frontmatter[op.field] ?? '');
+    case OpKind.ARGS:
+      return ctx.args !== undefined ? t(ctx.args[op.key] ?? '') : `{${op.raw}}`;
+    case OpKind.JSON:
+      return ctx.jsonData ? t(walkJsonPath(ctx.jsonData, op.tokens)) : `{${op.raw}}`;
+    case OpKind.JSON_PARENT: {
+      const stack = ctx.parentJsonDataStack;
+      if (!stack) return `{${op.raw}}`;
+      const index = op.level - 1;
+      if (index < 0 || index >= stack.length) return '';
+      return t(walkJsonPath(stack[index]!, op.tokens));
+    }
+  }
+}
+
+/** Run an entire segment (literal + ops) and concatenate. */
+function execSegment(seg: Segment, ctx: TemplateContext, t: ValueTransform): string {
+  if (seg.length === 1) {
+    const only = seg[0]!;
+    if (only.k === OpKind.LIT) return only.v;
+  }
+  let out = '';
+  for (let i = 0; i < seg.length; i++) {
+    out += execOp(seg[i]!, ctx, t);
+  }
+  return out;
+}
+
 /**
  * テンプレート変数を解決する
  * @param template - テンプレート文字列
@@ -57,106 +276,19 @@ export interface TemplateContext {
 export function resolveTemplate(
   template: string,
   context: TemplateContext,
-  valueTransform?: (value: string) => string,
+  valueTransform?: ValueTransform,
 ): string {
-  const t = valueTransform ?? ((v: string) => v);
-
-  // フォールバック構文: "templateA|templateB" → templateAが空ならtemplateBを使用
-  const pipeIndex = template.indexOf('|');
-  if (pipeIndex !== -1) {
-    const primary = template.slice(0, pipeIndex);
-    const fallback = template.slice(pipeIndex + 1);
-    const primaryResult = resolveTemplate(primary, context, valueTransform);
-    return primaryResult || resolveTemplate(fallback, context, valueTransform);
+  const t = valueTransform ?? identity;
+  const { segments } = compile(template);
+  // Fallback chain: return first non-empty segment.
+  for (let i = 0; i < segments.length; i++) {
+    const result = execSegment(segments[i]!, context, t);
+    if (result !== '') return result;
   }
-
-  let result = template;
-
-  // Replace values-defined template variables (e.g., {prefix}, {custom_key}, etc.)
-  if (context.values) {
-    for (const [key, value] of Object.entries(context.values)) {
-      const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      result = result.replace(new RegExp(`\\{${escapedKey}\\}`, 'g'), t(value));
-    }
-  }
-
-  // Backward compatibility: Replace {prefix} from legacy context.prefix
-  if (context.prefix !== undefined && !context.values?.prefix) {
-    result = result.replace(/\{prefix\}/g, t(context.prefix));
-  }
-
-  // Replace {basename}
-  result = result.replace(/\{basename\}/g, t(context.basename));
-
-  // Replace {dirname} and {dirname:N}
-  if (context.filePath) {
-    result = result.replace(/\{dirname:(\d+)\}/g, (_, level: string) => {
-      return t(getDirname(context.filePath!, parseInt(level, 10)));
-    });
-  }
-  if (context.dirname !== undefined) {
-    result = result.replace(/\{dirname\}/g, t(context.dirname));
-  }
-
-  // Replace {pathdir:N} — N-th directory segment counting down from basePath
-  if (context.filePath && context.basePath) {
-    result = result.replace(/\{pathdir:(\d+)\}/g, (_, level: string) => {
-      return t(getPathdir(context.filePath!, context.basePath!, parseInt(level, 10)));
-    });
-  }
-
-  // Replace {heading}
-  result = result.replace(/\{heading\}/g, t(context.heading ?? ''));
-
-  // Replace {line}
-  result = result.replace(/\{line\}/g, t(context.line ?? ''));
-
-  // Replace {content}
-  if (context.content !== undefined) {
-    result = result.replace(/\{content\}/g, t(context.content));
-  }
-
-  // Replace {filepath}
-  if (context.filePath) {
-    result = result.replace(/\{filepath\}/g, t(context.filePath));
-  }
-
-  // Replace {projectdir}
-  if (context.projectdir !== undefined) {
-    result = result.replace(/\{projectdir\}/g, t(context.projectdir));
-  }
-
-  // Replace {frontmatter@fieldName}
-  result = result.replace(/\{frontmatter@([^}]+)\}/g, (_, fieldName: string) => {
-    return t(context.frontmatter[fieldName] ?? '');
-  });
-
-  // Replace {json:N@path} (parent JSON data reference)
-  if (context.parentJsonDataStack) {
-    result = result.replace(/\{json:(\d+)@([^}]+)\}/g, (_, level: string, jsonPath: string) => {
-      const index = parseInt(level, 10) - 1; // N=1 → index 0 (direct parent)
-      const stack = context.parentJsonDataStack!;
-      if (index < 0 || index >= stack.length) return '';
-      return t(resolveJsonPath(stack[index]!, jsonPath));
-    });
-  }
-
-  // Replace {args.key}
-  if (context.args) {
-    result = result.replace(/\{args\.([^}]+)\}/g, (_, key: string) => {
-      return t(context.args![key] ?? '');
-    });
-  }
-
-  // Replace {json@path}
-  if (context.jsonData) {
-    result = result.replace(/\{json@([^}]+)\}/g, (_, jsonPath: string) => {
-      return t(resolveJsonPath(context.jsonData!, jsonPath));
-    });
-  }
-
-  return result;
+  return '';
 }
+
+function identity(v: string): string { return v; }
 
 /**
  * ファイルの親ディレクトリ名を取得
@@ -276,50 +408,7 @@ export function parseJsonContent(content: string): Record<string, unknown> | nul
  * - 値がobject/arrayの場合はJSON.stringifyして返す
  */
 export function resolveJsonPath(data: Record<string, unknown>, path: string): string {
-  // パスをトークンに分割: "items[0].name" -> ["items", "[0]", "name"]
-  const tokens = path.split(/\.|\[/).reduce<string[]>((acc, part) => {
-    if (part === '') return acc;
-    if (part.endsWith(']')) {
-      acc.push('[' + part);
-    } else {
-      acc.push(part);
-    }
-    return acc;
-  }, []);
-
-  let current: unknown = data;
-
-  for (const token of tokens) {
-    if (current === null || current === undefined) {
-      return '';
-    }
-
-    const indexMatch = token.match(/^\[(-?\d+)\]$/);
-    if (indexMatch) {
-      // 配列インデックスアクセス
-      if (!Array.isArray(current)) {
-        return '';
-      }
-      const index = parseInt(indexMatch[1]!, 10);
-      current = index < 0 ? current[current.length + index] : current[index];
-    } else {
-      // オブジェクトキーアクセス
-      if (typeof current !== 'object' || Array.isArray(current)) {
-        return '';
-      }
-      current = (current as Record<string, unknown>)[token];
-    }
-  }
-
-  if (current === null || current === undefined) {
-    return '';
-  }
-
-  if (typeof current === 'object') {
-    return JSON.stringify(current);
-  }
-
-  return String(current);
+  return walkJsonPath(data, tokenizeJsonPath(path));
 }
 
 /**

--- a/tests/unit/template-resolver.test.ts
+++ b/tests/unit/template-resolver.test.ts
@@ -724,7 +724,7 @@ describe('resolveTemplate pathological / special inputs', () => {
       }
     });
 
-    test('cache 上限（500 超）を超える距違なテンプレートでも正しく解決する', () => {
+    test('cache 上限（500 超）を超える相異なテンプレートでも正しく解決する', () => {
       const ctx = { basename: 'x', frontmatter: {}, jsonData: { v: 'ok' } };
       for (let i = 0; i < 700; i++) {
         expect(resolveTemplate(`#${i}:{json@v}`, ctx)).toBe(`#${i}:ok`);

--- a/tests/unit/template-resolver.test.ts
+++ b/tests/unit/template-resolver.test.ts
@@ -577,3 +577,169 @@ describe('resolveTemplate with projectdir', () => {
     })).toBe('');
   });
 });
+
+describe('resolveTemplate pathological / special inputs', () => {
+  describe('special characters in values', () => {
+    test('emoji / surrogate pair を壊さずに展開する', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { display: '🎉 surrogate 𝕳𝖊𝖑𝖑𝖔 👨‍👩‍👧‍👦' },
+      };
+      expect(resolveTemplate('{json@display}', ctx)).toBe('🎉 surrogate 𝕳𝖊𝖑𝖑𝖔 👨‍👩‍👧‍👦');
+    });
+
+    test('ANSI escape / control chars / null byte を保持する', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { display: '\u001b[31mRED\u001b[0m\tnull\u0000end\r\n' },
+      };
+      expect(resolveTemplate('{json@display}', ctx)).toBe('\u001b[31mRED\u001b[0m\tnull\u0000end\r\n');
+    });
+
+    test('RTL・合字・正規化違い（NFC/NFD）を壊さない', () => {
+      const composed = 'café';               // NFC
+      const decomposed = 'cafe\u0301';       // NFD
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { a: composed, b: decomposed, rtl: 'שלום עולם' },
+      };
+      expect(resolveTemplate('{json@a}', ctx)).toBe(composed);
+      expect(resolveTemplate('{json@b}', ctx)).toBe(decomposed);
+      expect(resolveTemplate('{json@rtl}', ctx)).toBe('שלום עולם');
+    });
+
+    test('値側に含まれる {json@...} ライクな文字列は再解釈しない', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { display: 'literal {json@foo} and {basename}' },
+      };
+      expect(resolveTemplate('{json@display}', ctx))
+        .toBe('literal {json@foo} and {basename}');
+    });
+
+    test('正規表現メタ文字を含むキー／値を正しく扱う', () => {
+      // Note: トークン内に `|` `{` `}` を含むキーはテンプレート構文と衝突するため非対応
+      const ctx = {
+        basename: 'x',
+        frontmatter: { 'a.b*c': 'matched' },
+        values: { '.*+?^()[].\\': 'escaped-value' },
+      };
+      expect(resolveTemplate('{frontmatter@a.b*c}', ctx)).toBe('matched');
+      expect(resolveTemplate('{.*+?^()[].\\}', ctx)).toBe('escaped-value');
+    });
+  });
+
+  describe('large data', () => {
+    test('1MB の文字列を content として展開してもクラッシュしない', () => {
+      const huge = 'x'.repeat(1024 * 1024);
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { display: huge } };
+      const out = resolveTemplate('{json@display}', ctx);
+      expect(out).toHaveLength(huge.length);
+      expect(out[0]).toBe('x');
+    });
+
+    test('オブジェクト値は JSON.stringify で返される（歴史的挙動の維持）', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { items: [1, 2, { nested: true }] },
+      };
+      expect(resolveTemplate('{json@items}', ctx)).toBe('[1,2,{"nested":true}]');
+    });
+
+    test('50 段のネストを辿れる', () => {
+      let deep: Record<string, unknown> = { leaf: 'found' };
+      for (let i = 50; i > 0; i--) deep = { [`l${i}`]: deep };
+      const path = Array.from({ length: 50 }, (_, i) => `l${i + 1}`).join('.') + '.leaf';
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: deep };
+      expect(resolveTemplate(`{json@${path}}`, ctx)).toBe('found');
+    });
+
+    test('50 段の pipe フォールバック後に最後の非空セグメントを返す', () => {
+      const segs = Array.from({ length: 50 }, (_, i) => `{json@missing${i}}`);
+      const tmpl = segs.join('|') + '|found';
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: {} };
+      expect(resolveTemplate(tmpl, ctx)).toBe('found');
+    });
+  });
+
+  describe('unexpected data shapes', () => {
+    test('jsonData が null/undefined ならリテラルを残す', () => {
+      const ctx = { basename: 'x', frontmatter: {} };
+      expect(resolveTemplate('{json@foo}', ctx)).toBe('{json@foo}');
+    });
+
+    test('パス途中が配列・プリミティブでも安全に空を返す', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { arr: [1, 2, 3], prim: 'string', obj: { x: null } },
+      };
+      // 配列にキーアクセス→空
+      expect(resolveTemplate('{json@arr.foo}', ctx)).toBe('');
+      // プリミティブにキーアクセス→空
+      expect(resolveTemplate('{json@prim.foo}', ctx)).toBe('');
+      // null 値→空
+      expect(resolveTemplate('{json@obj.x}', ctx)).toBe('');
+      // 配列の負インデックス
+      expect(resolveTemplate('{json@arr[-1]}', ctx)).toBe('3');
+      // 範囲外
+      expect(resolveTemplate('{json@arr[99]}', ctx)).toBe('');
+      // 存在しないキー
+      expect(resolveTemplate('{json@missing.key.path}', ctx)).toBe('');
+    });
+
+    test('値が 0/false/空文字のとき pipe フォールバックは発動する', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { a: '', b: 0, c: false, d: 'hit' },
+      };
+      // '' はフォールバック対象
+      expect(resolveTemplate('{json@a}|{json@d}', ctx)).toBe('hit');
+      // 0 は "0" になるのでフォールバックしない (非空文字列)
+      expect(resolveTemplate('{json@b}|{json@d}', ctx)).toBe('0');
+      // false は "false" になる
+      expect(resolveTemplate('{json@c}|{json@d}', ctx)).toBe('false');
+    });
+
+    test('ブレース内に @ や : を含む不正トークンはリテラルのまま残る', () => {
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { a: 1 } };
+      expect(resolveTemplate('{json@}', ctx)).toBe('{json@}');
+      expect(resolveTemplate('{frontmatter@}', ctx)).toBe('{frontmatter@}');
+      expect(resolveTemplate('{json:abc@x}', ctx)).toBe('{json:abc@x}');
+    });
+  });
+
+  describe('cache robustness', () => {
+    test('同じテンプレートを 10,000 回呼んでも結果が一貫する', () => {
+      const tmpl = '{json@a}|{json@b}|{json@c}';
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { a: '', b: '', c: 'ok' } };
+      for (let i = 0; i < 10_000; i++) {
+        expect(resolveTemplate(tmpl, ctx)).toBe('ok');
+      }
+    });
+
+    test('cache 上限（500 超）を超える距違なテンプレートでも正しく解決する', () => {
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { v: 'ok' } };
+      for (let i = 0; i < 700; i++) {
+        expect(resolveTemplate(`#${i}:{json@v}`, ctx)).toBe(`#${i}:ok`);
+      }
+      // 直後に古いテンプレートを呼んでも、再解決で同じ結果になる
+      expect(resolveTemplate('#0:{json@v}', ctx)).toBe('#0:ok');
+    });
+
+    test('values 優先（json/frontmatter/args より先）を保つ', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: { name: 'fm' },
+        values: { 'frontmatter@name': 'values-wins' },
+      };
+      expect(resolveTemplate('{frontmatter@name}', ctx)).toBe('values-wins');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the 14-regex-replace chain in `resolveTemplate` with a precompile-then-execute design; each distinct template string is parsed once into an Op array and cached by string key.
- Cache `resolveJsonPath` path tokenization in a separate module-level Map so `"pastedContents.1.content".split(...)` does not run per JSONL row.
- Public API (`resolveTemplate`, `resolveJsonPath`) is behavior-preserving — verified via 85 unit tests (69 existing + 16 new pathological cases) and A/B testing the user's real `~/.claude/history.jsonl` against the `main` branch.

## Motivation

The `claude/custom-search/history` plugin (sourcePath: `~/.claude/history.jsonl`) becomes noticeably slow in environments with large histories. Investigation showed `resolveTemplate` was called 10+ times per JSONL row, and each call ran up to 14 regex-replace passes multiplied by 9 recursive pipe-fallback segments. For 10k rows that's tens of millions of regex scans per cold reload — and cold reload is triggered every time `history.jsonl` changes (chokidar → `invalidate-custom-search` → next window show).

## Measured speedup

Benchmarked via `.agentsws/scripts/bench-history.ts`:

| Scenario | Before | After | Speedup |
|---|---|---|---|
| Real `~/.claude/history.jsonl` (10k rows, 2.8 MB) | 295 ms | **73 ms** | **4.0x** |
| Synthetic 50k rows with 4KB pastedContents | 1316 ms | **394 ms** | **3.3x** |
| Synthetic 50k reload after invalidate | 1355 ms | **440 ms** | **3.1x** |
| `resolveTemplate` × 100k (micro) | 460 ms | **24 ms** | **19x** |

Verified on the installed app via CDP IPC: cold reload of 11k total items (10,877 mentions + 155 commands from all sources combined) completes in ~157 ms median over three invalidate/query cycles.

## Implementation notes

- `const enum OpKind` with numeric discriminator for a tight `switch` in `execOp`. TypeScript narrowing on the `Op` discriminated union keeps the hot path cast-free.
- `templateCache` capped at 500 entries, `jsonPathTokenCache` at 1000 — on overflow both call `.clear()` as a simple safety net (tests cover this path). YAML-authored templates stay well under the cap in practice.
- `TOKEN_REGEX` is a local regex inside `compileSegment` (not module-state) to remove the shared-state footgun.
- `INDEX_TOKEN_RE` hoisted to module scope; `token.startsWith('[')` replaces the opaque `charCodeAt(0) === 91` check.

## Pathological coverage

`.agentsws/scripts/bench-pathological.ts` (report tracked in `.agentsws/reports/bench-pathological.txt`) runs eight pathological scenarios — massive `display` fields, 50-level deep paths, 1000-key-wide objects, unicode/emoji/surrogate/RTL/ANSI/null-byte mix, giant JSON.stringify results, malformed JSON lines, cache churn, 50-segment pipe chains. All realistic scenarios complete in under 200 ms. The one outlier (2k rows × 500-key JSON.stringify → 7972 ms) is a **pre-existing** behavior of `resolveJsonPath` unrelated to this refactor — captured in the follow-up report.

## Follow-up

A separate report (`.agentsws/reports/template-resolver-followup-issues.md`) catalogs existing edge cases in main (pipe-inside-braces, `{json@a..b}` silent normalization, missing escape syntax, etc.). These are preserved-on-purpose in this PR (behavior-preserving refactor) and are proposed as follow-up PRs.

## Test plan

- [x] `pnpm test` — 1316 tests pass (1 skipped), no regressions
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — only pre-existing style warnings, no new errors
- [x] Unit tests: 85 cases including 16 new pathological cases (emoji/surrogate, ANSI/null-byte, 1MB values, 50-level nesting, 50-segment pipes, cache overflow, values-precedence)
- [x] Installed on `/Applications/Prompt Line.app` and verified via CDP that `get-agents('r:...')` returns correct items and cold reload clocks at ~157 ms median for 11k items
- [x] A/B parity: `/tmp/verify-main-behavior.ts` confirms 5+ edge-case inputs return byte-identical results on `main` vs this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)