### PR TITLE
perf(template-resolver): cache JSON.stringify for object terminals

### DIFF
--- a/src/lib/template-resolver.ts
+++ b/src/lib/template-resolver.ts
@@ -83,6 +83,13 @@ const jsonPathTokenCache = new Map<string, string[]>();
 const TEMPLATE_CACHE_MAX = 500;
 const JSON_PATH_CACHE_MAX = 1000;
 
+// Custom-search hot paths resolve 10+ templates against the same row's jsonData;
+// if a terminal lands on a large object, we would re-stringify it per call.
+// Memoize by object identity so the string is shared; GC reclaims with the row.
+// Safe because templates only read jsonData — callers must not mutate a cached
+// object and expect the serialized form to update.
+const stringifyCache = new WeakMap<object, string>();
+
 const INDEX_TOKEN_RE = /^\[(-?\d+)\]$/;
 
 /** Parse a JSON path like "items[0].name" into tokens like ["items", "[0]", "name"]. */
@@ -210,8 +217,16 @@ function walkJsonPath(data: Record<string, unknown>, tokens: string[]): string {
     }
   }
   if (current === null || current === undefined) return '';
-  if (typeof current === 'object') return JSON.stringify(current);
+  if (typeof current === 'object') return stringifyObject(current as object);
   return String(current);
+}
+
+function stringifyObject(obj: object): string {
+  const cached = stringifyCache.get(obj);
+  if (cached !== undefined) return cached;
+  const result = JSON.stringify(obj);
+  stringifyCache.set(obj, result);
+  return result;
 }
 
 /** Evaluate one op against a context. */

--- a/tests/unit/template-resolver.test.ts
+++ b/tests/unit/template-resolver.test.ts
@@ -742,4 +742,62 @@ describe('resolveTemplate pathological / special inputs', () => {
       expect(resolveTemplate('{frontmatter@name}', ctx)).toBe('values-wins');
     });
   });
+
+  describe('object stringify cache', () => {
+    test('同じオブジェクト参照への 2 回目の解決は JSON.stringify を再実行しない', () => {
+      let toJsonCalls = 0;
+      const nested = {
+        toJSON() { toJsonCalls++; return { k: 1 }; },
+      };
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { nested } };
+      expect(resolveTemplate('{json@nested}', ctx)).toBe('{"k":1}');
+      expect(resolveTemplate('{json@nested}', ctx)).toBe('{"k":1}');
+      expect(resolveTemplate('{json@nested}', ctx)).toBe('{"k":1}');
+      expect(toJsonCalls).toBe(1);
+    });
+
+    test('異なる参照のオブジェクトは独立にキャッシュされる', () => {
+      const a = { id: 'a', payload: [1, 2, 3] };
+      const b = { id: 'b', payload: [4, 5, 6] };
+      const ctxA = { basename: 'x', frontmatter: {}, jsonData: { v: a } };
+      const ctxB = { basename: 'x', frontmatter: {}, jsonData: { v: b } };
+      expect(resolveTemplate('{json@v}', ctxA)).toBe('{"id":"a","payload":[1,2,3]}');
+      expect(resolveTemplate('{json@v}', ctxB)).toBe('{"id":"b","payload":[4,5,6]}');
+    });
+
+    test('配列終端もキャッシュされる（2 回目は toJSON が呼ばれない）', () => {
+      let calls = 0;
+      const arr = [
+        { toJSON() { calls++; return 'x'; } },
+        { toJSON() { calls++; return 'y'; } },
+      ];
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { arr } };
+      expect(resolveTemplate('{json@arr}', ctx)).toBe('["x","y"]');
+      expect(resolveTemplate('{json@arr}', ctx)).toBe('["x","y"]');
+      expect(calls).toBe(2); // 1 pass over both elements, then cache hit
+    });
+
+    test('プリミティブ終端はキャッシュを経由しない（引き続き String(v) 経由）', () => {
+      const ctx = {
+        basename: 'x',
+        frontmatter: {},
+        jsonData: { n: 42, s: 'hello', b: true, z: 0 },
+      };
+      expect(resolveTemplate('{json@n}', ctx)).toBe('42');
+      expect(resolveTemplate('{json@s}', ctx)).toBe('hello');
+      expect(resolveTemplate('{json@b}', ctx)).toBe('true');
+      expect(resolveTemplate('{json@z}', ctx)).toBe('0');
+    });
+
+    test('同一 jsonData を共有する複数テンプレート呼び出しでヒットする', () => {
+      let calls = 0;
+      const big = { toJSON() { calls++; return { deep: 'v' }; } };
+      const ctx = { basename: 'x', frontmatter: {}, jsonData: { obj: big } };
+      // custom-search loader が 1 行に対して 10+ テンプレートを呼ぶ状況を模擬
+      for (let i = 0; i < 20; i++) {
+        expect(resolveTemplate('{json@obj}', ctx)).toBe('{"deep":"v"}');
+      }
+      expect(calls).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Memoize `JSON.stringify(obj)` in `walkJsonPath` by object identity so the same row's jsonData serializes once regardless of how many templates touch it. Purely additive: a module-level `WeakMap<object, string>` and a small `stringifyObject` helper; no API change.

## Motivation

[#362](https://github.com/nkmr-jp/prompt-line/pull/362) flagged a 7972ms outlier in the `2k rows × 500-key JSON.stringify` benchmark as a **pre-existing** property of `resolveJsonPath` unrelated to that refactor — proposed as a follow-up. This PR is that follow-up.

`custom-search-loader.ts` calls `resolveTemplate` 10+ times per JSONL row. Whenever a template terminal lands on a large object (e.g., `{json@payload}`), the previous implementation re-serialized the same object on every call. With a 500-key object and 10 calls per row, ~10× `JSON.stringify` per row is pure waste. Memoizing by reference eliminates the redundant work, and the WeakMap lets the GC reclaim once the row falls out of scope.

## Measured speedup

Benchmark: 2k rows × 10 `{json@payload}` calls against a fresh 500-key object per row (same shape used in the #362 outlier).

| | Time |
|---|---|
| Baseline (main) | 809.8 ms |
| With cache | **157.6 ms** |
| **Speedup** | **≈5.1x** |

(Numbers will scale larger on the actual 500-key × heavier-template real workload captured in #362's 7972ms figure.)

## Why this is safe

- `WeakMap<object, string>` keys on the object reference, not its structure, so two distinct objects with the same shape still serialize independently.
- Entries are reclaimable by the GC the moment the object becomes unreachable, so there is no unbounded growth even under high row churn.
- Templates only **read** `jsonData`; if a caller mutates a cached object in-place and expects the serialization to update, that's already a footgun on the `resolveTemplate` contract — documented in the inline comment.
- Behavior is byte-identical to main: all 1320 existing tests pass unchanged.

## Tests added (5)

- Same object reference → `JSON.stringify` runs exactly once across repeated resolves (verified via custom `toJSON` counter).
- Different references with identical shape → independent results, no stale cache bleed.
- Array terminals are cached (arrays are objects).
- Primitive terminals (number/string/boolean/0) are unaffected.
- Hot-path simulation: 20 resolves on the same jsonData → 1 serialization (custom-search-loader style).

## Test plan

- [x] `pnpm test` — 1320 tests pass (1 skipped), no regressions
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors; 7 warnings, all pre-existing style warnings unchanged
- [x] A/B benchmark on the #362 outlier scenario → 809.8ms → 157.6ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)