### PR TITLE
fix(symbol-search): set rg cwd so includePatterns match

### DIFF
--- a/docs/en/settings.md
+++ b/docs/en/settings.md
@@ -92,6 +92,7 @@ symbolSearch:
   respectGitignore: true    # Respect .gitignore files
   maxSymbols: 200000        # Maximum number of symbols to index
   timeout: 60000            # Search timeout in milliseconds
+  followSymlinks: false     # Follow symbolic links during search
   #rgPath: null             # Custom path to rg (null = auto-detect)
   includePatterns: []       # Force include (e.g., ["*.test.ts", "vendor/**"])
   excludePatterns: []       # Additional excludes (e.g., ["*.generated.go"])

--- a/docs/ja/settings.md
+++ b/docs/ja/settings.md
@@ -92,6 +92,7 @@ symbolSearch:
   respectGitignore: true    # .gitignore を尊重
   maxSymbols: 200000        # インデックスするシンボルの最大数
   timeout: 60000            # 検索タイムアウト（ミリ秒）
+  followSymlinks: false     # シンボリックリンクをたどる
   #rgPath: null             # rg のカスタムパス（null = 自動検出）
   includePatterns: []       # 強制的に含める（例: ["*.test.ts", "vendor/**"]）
   excludePatterns: []       # 追加の除外（例: ["*.generated.go"]）

--- a/src/utils/symbol-search/symbol-searcher-node.ts
+++ b/src/utils/symbol-search/symbol-searcher-node.ts
@@ -779,17 +779,23 @@ function parseRipgrepOutput(
 
 /**
  * Execute a single ripgrep search and return raw output
+ *
+ * `cwd` must be the search directory. rg matches `--glob` patterns against
+ * paths relative to its cwd, so anchored globs like `.agentsws/**` fail to
+ * match when rg inherits an unrelated parent-process cwd.
  */
 function executeRg(
   rgCommand: string,
   args: string[],
-  timeout: number
+  timeout: number,
+  cwd: string
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const execOptions = {
       timeout,
       maxBuffer: DEFAULT_MAX_BUFFER,
-      killSignal: 'SIGTERM' as const
+      killSignal: 'SIGTERM' as const,
+      cwd
     };
 
     execFile(rgCommand, args, execOptions, (error, stdout, stderr) => {
@@ -994,7 +1000,7 @@ async function searchBlockSymbols(
     args.push('-e', blockPattern, directory);
 
     try {
-      const output = await executeRg(rgCommand, args, timeout);
+      const output = await executeRg(rgCommand, args, timeout, directory);
       // Apply each config's symbolNameRegex to the same block output
       for (const config of groupConfigs) {
         const results = parseBlockOutput(output, config, language, directory, maxSymbols);
@@ -1136,7 +1142,7 @@ export async function searchSymbols(
       globalExcludesFile
     );
 
-    const normalOutput = await executeRg(rgCommand, normalArgs, timeout);
+    const normalOutput = await executeRg(rgCommand, normalArgs, timeout, directory);
     let allSymbols = parseRipgrepOutput(normalOutput, language, maxSymbols, directory);
 
     // Phase 2: Include patterns search (with --hidden --no-ignore, only when includePatterns specified)
@@ -1152,7 +1158,7 @@ export async function searchSymbols(
         globalExcludesFile
       );
 
-      const includeOutput = await executeRg(rgCommand, includeArgs, timeout);
+      const includeOutput = await executeRg(rgCommand, includeArgs, timeout, directory);
       const includeSymbols = parseRipgrepOutput(includeOutput, language, maxSymbols, directory);
       allSymbols = allSymbols.concat(includeSymbols);
     }

--- a/src/utils/symbol-search/symbol-searcher-node.ts
+++ b/src/utils/symbol-search/symbol-searcher-node.ts
@@ -8,6 +8,7 @@
  */
 
 import { execFile } from 'child_process';
+import path from 'path';
 import { logger } from '../logger';
 import { getGlobalGitExcludesFile } from '../git-excludes';
 import type {
@@ -1128,12 +1129,16 @@ export async function searchSymbols(
     const hasIncludePatterns = options.includePatterns && options.includePatterns.length > 0;
     const globalExcludesFile = await getGlobalGitExcludesFile();
 
+    // Resolve to absolute so that cwd and the rg path arg don't stack and
+    // produce `dir/dir` double-descent for relative `directory` inputs.
+    const resolvedDirectory = path.resolve(directory);
+
     // Combine all pattern regexes into one (used for both phases)
     const combinedPattern = config.patterns.map(p => `(${p.pattern})`).join('|');
 
     // Phase 1: Normal search (respects .gitignore, uses excludePatterns)
     const normalArgs = buildRgArgs(
-      directory,
+      resolvedDirectory,
       combinedPattern,
       config.rgType,
       options.excludePatterns || [],
@@ -1142,14 +1147,14 @@ export async function searchSymbols(
       globalExcludesFile
     );
 
-    const normalOutput = await executeRg(rgCommand, normalArgs, timeout, directory);
-    let allSymbols = parseRipgrepOutput(normalOutput, language, maxSymbols, directory);
+    const normalOutput = await executeRg(rgCommand, normalArgs, timeout, resolvedDirectory);
+    let allSymbols = parseRipgrepOutput(normalOutput, language, maxSymbols, resolvedDirectory);
 
     // Phase 2: Include patterns search (with --hidden --no-ignore, only when includePatterns specified)
     // This matches Swift behavior: separate rg execution for include patterns
     if (hasIncludePatterns) {
       const includeArgs = buildRgArgs(
-        directory,
+        resolvedDirectory,
         combinedPattern,
         config.rgType,
         [], // No excludePatterns for include search
@@ -1158,8 +1163,8 @@ export async function searchSymbols(
         globalExcludesFile
       );
 
-      const includeOutput = await executeRg(rgCommand, includeArgs, timeout, directory);
-      const includeSymbols = parseRipgrepOutput(includeOutput, language, maxSymbols, directory);
+      const includeOutput = await executeRg(rgCommand, includeArgs, timeout, resolvedDirectory);
+      const includeSymbols = parseRipgrepOutput(includeOutput, language, maxSymbols, resolvedDirectory);
       allSymbols = allSymbols.concat(includeSymbols);
     }
 
@@ -1168,7 +1173,7 @@ export async function searchSymbols(
     const blockConfigs = BLOCK_SEARCH_CONFIGS[language];
     if (blockConfigs && blockConfigs.length > 0) {
       const blockResults = await searchBlockSymbols(
-        rgCommand, directory, blockConfigs, language,
+        rgCommand, resolvedDirectory, blockConfigs, language,
         config.rgType, maxSymbols, timeout,
         options.excludePatterns || [],
         followSymlinks,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -114,7 +114,16 @@ vi.mock('path', () => {
     const pathMock = {
         join: vi.fn((...parts: string[]) => parts.join('/')),
         dirname: vi.fn((filePath: string) => filePath.split('/').slice(0, -1).join('/')),
-        basename: vi.fn((filePath: string) => filePath.split('/').pop())
+        basename: vi.fn((filePath: string) => filePath.split('/').pop()),
+        resolve: vi.fn((...parts: string[]) => {
+            // Minimal POSIX-ish resolve: return the last absolute segment, or join from /.
+            for (let i = parts.length - 1; i >= 0; i--) {
+                if (parts[i]!.startsWith('/')) {
+                    return parts.slice(i).join('/');
+                }
+            }
+            return '/' + parts.join('/');
+        })
     };
     return { ...pathMock, default: pathMock };
 });

--- a/tests/unit/symbol-searcher-node.test.ts
+++ b/tests/unit/symbol-searcher-node.test.ts
@@ -59,9 +59,11 @@ function mockExecFileForSearch(rgOutput: string) {
   );
 }
 
-// Helper to capture the args passed to rg for the search call
-function mockExecFileCapturingArgs(rgOutput: string): { getCapturedArgs: () => string[][] } {
-  const capturedArgs: string[][] = [];
+// Helper to capture both args and execFile options for the search call
+function mockExecFileCapturingOptions(rgOutput: string): {
+  getCapturedOptions: () => Array<{ args: string[]; options: any }>;
+} {
+  const captured: Array<{ args: string[]; options: any }> = [];
   mockedExecFile.mockImplementation(
     ((_file: any, _args: any, _options: any, callback: any) => {
       const args = Array.isArray(_args) ? _args : [];
@@ -72,12 +74,18 @@ function mockExecFileCapturingArgs(rgOutput: string): { getCapturedArgs: () => s
       } else if (_file === 'git' && args[0] === 'config') {
         cb(null, '', '');
       } else {
-        capturedArgs.push(args);
+        captured.push({ args, options: _options });
         cb(null, rgOutput, '');
       }
     }) as any
   );
-  return { getCapturedArgs: () => capturedArgs };
+  return { getCapturedOptions: () => captured };
+}
+
+// Helper to capture the args passed to rg for the search call
+function mockExecFileCapturingArgs(rgOutput: string): { getCapturedArgs: () => string[][] } {
+  const { getCapturedOptions } = mockExecFileCapturingOptions(rgOutput);
+  return { getCapturedArgs: () => getCapturedOptions().map(c => c.args) };
 }
 
 describe('symbol-searcher-node', () => {
@@ -1477,6 +1485,48 @@ describe('symbol-searcher-node', () => {
       await searchSymbols('/project', 'py', { includePatterns: ['.agentsws/**'] });
       for (const args of getCapturedArgs()) {
         expect(args).not.toContain('--ignore-file');
+      }
+    });
+  });
+
+  // ============================================================
+  // cwd propagation — relative --glob patterns like `.agentsws/**` are
+  // only matched correctly when rg runs with cwd set to the search
+  // directory. Without it, rg walks paths as absolute strings and
+  // anchored globs never match.
+  // ============================================================
+  describe('cwd propagation to rg (includePatterns glob matching)', () => {
+    test('normal search invocation sets cwd to search directory', async () => {
+      const { getCapturedOptions } = mockExecFileCapturingOptions('');
+
+      await searchSymbols('/my/project', 'py');
+      const captured = getCapturedOptions();
+      expect(captured).toHaveLength(1);
+      expect(captured[0]!.options).toMatchObject({ cwd: '/my/project' });
+    });
+
+    test('includePattern phase also sets cwd to search directory', async () => {
+      const { getCapturedOptions } = mockExecFileCapturingOptions('');
+
+      await searchSymbols('/my/project', 'py', {
+        includePatterns: ['.agentsws/**']
+      });
+      const captured = getCapturedOptions();
+      expect(captured).toHaveLength(2);
+      for (const call of captured) {
+        expect(call.options).toMatchObject({ cwd: '/my/project' });
+      }
+    });
+
+    test('block-search phase also sets cwd to search directory', async () => {
+      const { getCapturedOptions } = mockExecFileCapturingOptions('');
+
+      // Go triggers block-search phase (const/var blocks) in addition to normal phase.
+      await searchSymbols('/my/project', 'go');
+      const captured = getCapturedOptions();
+      expect(captured.length).toBeGreaterThanOrEqual(2);
+      for (const call of captured) {
+        expect(call.options).toMatchObject({ cwd: '/my/project' });
       }
     });
   });

--- a/tests/unit/symbol-searcher-node.test.ts
+++ b/tests/unit/symbol-searcher-node.test.ts
@@ -1529,5 +1529,23 @@ describe('symbol-searcher-node', () => {
         expect(call.options).toMatchObject({ cwd: '/my/project' });
       }
     });
+
+    test('resolves relative directory so cwd and rg path arg do not stack', async () => {
+      // Guard against regression where a relative `directory` (e.g. `repo/subdir`)
+      // is set as both cwd *and* the rg positional arg, which would make rg
+      // descend into cwd/subdir instead of the intended directory.
+      const { getCapturedOptions } = mockExecFileCapturingOptions('');
+
+      await searchSymbols('repo/subdir', 'py');
+      const captured = getCapturedOptions();
+      expect(captured).toHaveLength(1);
+
+      const { args, options } = captured[0]!;
+      const cwd = options.cwd as string;
+      const rgPathArg = args[args.length - 1]!;
+
+      expect(cwd).toBe(rgPathArg);
+      expect(cwd.startsWith('/')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`symbolSearch.includePatterns` silently returned zero matches for patterns like `.agentsws/**` or `.claude/artifact/**`. rg was invoked via `execFile` without a `cwd`, so it inherited the Electron parent-process cwd. rg matches `--glob` patterns against paths relative to its cwd, so anchored globs (those containing `/`) never matched when rg walked files from an absolute search-directory argument.

PR #367 addressed `followSymlinks` and `core.excludesfile` but this cwd gap was not caught.

- Make `cwd` a required parameter of `executeRg` (JSDoc already said it *must* be set).
- Pass `directory` as cwd on all three rg invocations: Phase 1 (normal), Phase 2 (includePatterns), Phase 3 (block search).
- Add regression tests that assert `cwd` is set on the `execFile` options for each phase.

### Verification

Ran the shipped app's IPC handler directly against `/Users/.../prompt-line` with the user's settings (`includePatterns: [".claude/artifact", ".agentsws/**"]`, `followSymlinks: true`):

| Pattern | Before | After |
|---|---|---|
| `.agentsws/**` | 0 | **243** |
| `.claude/artifact/**` | 0 | **145** |

Note: a bare `.claude/artifact` glob (no `/**`) remains 0 by gitignore-glob rules — it matches the directory entry itself, not files inside. That is standard glob behavior, not a bug; users should write `.claude/artifact/**` for recursive inclusion.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm test` — 1340 tests pass
- [x] Added 3 regression tests covering normal / include / block search phases
- [x] End-to-end verified in installed app via CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)