### PR TITLE
feat(directory-detector): support cmux.app terminal

### DIFF
--- a/native/CLAUDE.md
+++ b/native/CLAUDE.md
@@ -36,7 +36,10 @@ Other 3 tools are single `.swift` files, but `directory-detector/` is a director
 - Stops at AXWindow level to avoid returning entire window bounds
 
 ### Supported applications (directory-detector)
-Terminal.app, iTerm2, Ghostty, Warp, WezTerm, JetBrains IDEs, VSCode/Insiders/VSCodium, Cursor, Windsurf, Zed, OpenCode, Antigravity, Kiro
+Terminal.app, iTerm2, Ghostty, Warp, WezTerm, cmux, JetBrains IDEs, VSCode/Insiders/VSCodium, Cursor, Windsurf, Zed, OpenCode, Antigravity, Kiro
+
+### cmux directory detection
+cmux (`com.cmuxterm.app`) exposes a `working directory` property on its focused terminal via its AppleScript dictionary (`Contents/Resources/cmux.sdef`). The detector uses AppleScript directly instead of process tree traversal — cmux embeds Ghostty internally, but the parent app's bundle ID is what `NSWorkspace.frontmostApplication` returns, so process-tree detection wouldn't run correctly without explicit handling.
 
 ### Testing native tool changes
 - After modifying Swift source, run `cd native && make install` then `pnpm run compile` to update `dist/native-tools/`

--- a/native/directory-detector/DirectoryDetector.swift
+++ b/native/directory-detector/DirectoryDetector.swift
@@ -173,6 +173,24 @@ class DirectoryDetector {
             ]
         }
 
+        if isCmux(bundleId) {
+            if let cwd = getCmuxWorkingDirectory() {
+                return [
+                    "success": true,
+                    "directory": cwd,
+                    "appName": appName,
+                    "bundleId": bundleId,
+                    "method": "cmux-applescript"
+                ]
+            }
+
+            return [
+                "error": "Failed to detect directory from \(appName)",
+                "appName": appName,
+                "bundleId": bundleId
+            ]
+        }
+
         // Check for native terminals (Ghostty, Warp, WezTerm) with process-based detection
         if isNativeTerminal(bundleId) {
             let (directory, shellPid) = getNativeTerminalDirectory(appPid: appPid)

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -45,6 +45,47 @@ extension DirectoryDetector {
         return result.stringValue
     }
 
+    // MARK: - cmux directory detection
+
+    /// Check if bundle ID is cmux
+    static func isCmux(_ bundleId: String) -> Bool {
+        return bundleId == "com.cmuxterm.app"
+    }
+
+    /// Get working directory from cmux's focused terminal via AppleScript.
+    /// Why AppleScript instead of process-tree: cmux embeds Ghostty internally, but
+    /// the parent app's bundle ID is what NSWorkspace.frontmostApplication returns,
+    /// so process-tree detection (used for Ghostty/Warp/WezTerm) wouldn't match.
+    /// cmux exposes a "working directory" property on its focused terminal
+    /// (see Contents/Resources/cmux.sdef in the app bundle).
+    static func getCmuxWorkingDirectory() -> String? {
+        // `focused terminal` can momentarily be nil (e.g. right after a pane split or
+        // when no pane has keyboard focus). Fall back to the tab's first terminal so we
+        // still return a directory instead of failing the whole detection.
+        let script = """
+        tell application "cmux"
+            tell front window
+                tell selected tab
+                    try
+                        return working directory of focused terminal
+                    on error
+                        return working directory of (first terminal)
+                    end try
+                end tell
+            end tell
+        end tell
+        """
+
+        let appleScript = NSAppleScript(source: script)
+        var error: NSDictionary?
+        guard let result = appleScript?.executeAndReturnError(&error),
+              let value = result.stringValue,
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
     // MARK: - Native Terminal Detection (Ghostty, Warp, WezTerm)
 
     /// Check if bundle ID is Ghostty

--- a/src/renderer/directory-data-handler.ts
+++ b/src/renderer/directory-data-handler.ts
@@ -330,6 +330,7 @@ export class DirectoryDataHandler {
       'warp',
       'tabby',
       'wezterm',
+      'cmux',
       // IDEs and editors
       'visual studio code',
       'code',


### PR DESCRIPTION
## Summary
- Adds CWD detection support for [cmux](https://cmux.app) (`com.cmuxterm.app`), so Prompt Line can pick up the working directory of the focused cmux terminal when the user invokes paste/auto-detection.
- Uses cmux's AppleScript dictionary (`working directory` property on its focused terminal) instead of the process-tree path used for Ghostty/Warp/WezTerm. cmux embeds Ghostty internally, but `NSWorkspace.frontmostApplication` reports the parent bundle ID, so the existing native-terminal branch would not match.
- Falls back to the tab's first terminal when `focused terminal` is momentarily nil (e.g. just after a pane split or when no pane has keyboard focus).

## Changes
- `native/directory-detector/TerminalDetector.swift`: add `isCmux()` and `getCmuxWorkingDirectory()` (NSAppleScript-based, with fallback).
- `native/directory-detector/DirectoryDetector.swift`: route `com.cmuxterm.app` to the new helper, returning `method: "cmux-applescript"`.
- `src/renderer/directory-data-handler.ts`: add `'cmux'` to `directoryCapableApps`.
- `native/CLAUDE.md`: update supported apps list and document the cmux detection rationale.

## Test plan
- [x] Build native tools: `cd native && make install`
- [x] Verify directly: `./src/native-tools/directory-detector detect --bundleId com.cmuxterm.app` returns `{"success": true, "directory": "...", "method": "cmux-applescript"}`
- [x] Verified the fallback path: when `focused terminal` is nil the AppleScript `on error` branch returns the first terminal's CWD instead of failing the whole detection.
- [ ] Manual end-to-end check inside Prompt Line with cmux as the previously active app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)