### PR TITLE
fix(paste): route cmux paste through AppleScript instead of Cmd+V

### DIFF
--- a/native/CLAUDE.md
+++ b/native/CLAUDE.md
@@ -41,6 +41,9 @@ Terminal.app, iTerm2, Ghostty, Warp, WezTerm, cmux, JetBrains IDEs, VSCode/Insid
 ### cmux directory detection
 cmux (`com.cmuxterm.app`) exposes a `working directory` property on its focused terminal via its AppleScript dictionary (`Contents/Resources/cmux.sdef`). The detector uses AppleScript directly instead of process tree traversal — cmux embeds Ghostty internally, but the parent app's bundle ID is what `NSWorkspace.frontmostApplication` returns, so process-tree detection wouldn't run correctly without explicit handling.
 
+### cmux paste handling (NOT keyboard-simulator)
+Cmd+V CGEvents posted by `keyboard-simulator paste` do not reach cmux's embedded Ghostty terminal — the parent NSApplication consumes the event and the keystroke never lands in the focused PTY. For cmux, `src/utils/native-tools/paste-operations.ts` bypasses keyboard-simulator entirely and runs a single `osascript` invocation that activates cmux and forwards Ghostty's `paste_from_clipboard` action via `cmux.sdef` (`CmuxPfAc`) to the focused terminal pane.
+
 ### Testing native tool changes
 - After modifying Swift source, run `cd native && make install` then `pnpm run compile` to update `dist/native-tools/`
 - Dev mode uses `dist/native-tools/` (NOT `src/native-tools/`) — `make install` alone is insufficient

--- a/src/utils/native-tools/app-detection.ts
+++ b/src/utils/native-tools/app-detection.ts
@@ -7,6 +7,7 @@ import { logger } from '../logger';
 import { WINDOW_DETECTOR_PATH } from './paths';
 
 const ITERM2_BUNDLE_ID = 'com.googlecode.iterm2';
+const CMUX_BUNDLE_ID = 'com.cmuxterm.app';
 
 // Accessibility permission check result
 interface AccessibilityStatus {
@@ -177,6 +178,19 @@ export function isITerm2(app: AppInfo | string | null): boolean {
     return lower === 'iterm2' || lower === 'iterm';
   }
   return app.bundleId === ITERM2_BUNDLE_ID;
+}
+
+/**
+ * Check if the given AppInfo or app name string represents cmux.
+ * cmux requires special paste handling because it embeds Ghostty as
+ * a subprocess and Cmd+V CGEvents do not reach the focused terminal.
+ */
+export function isCmux(app: AppInfo | string | null): boolean {
+  if (!app) return false;
+  if (typeof app === 'string') {
+    return app.toLowerCase() === 'cmux';
+  }
+  return app.bundleId === CMUX_BUNDLE_ID;
 }
 
 /**

--- a/src/utils/native-tools/paste-operations.ts
+++ b/src/utils/native-tools/paste-operations.ts
@@ -4,6 +4,17 @@ import { TIMEOUTS } from '../../constants';
 import { logger } from '../logger';
 import { sanitizeCommandArgument, isCommandArgumentSafe } from '../security';
 import { KEYBOARD_SIMULATOR_PATH } from './paths';
+import { isCmux } from './app-detection';
+
+// cmux embeds Ghostty as a subprocess and the parent NSApplication consumes
+// Cmd+V CGEvents before they reach the focused PTY. We bypass keyboard-simulator
+// entirely and route activation + paste through cmux's AppleScript dictionary,
+// which forwards `paste_from_clipboard` to Ghostty's native action handler.
+const CMUX_PASTE_APPLESCRIPT =
+  'tell application "cmux"\n' +
+  '  activate\n' +
+  '  perform action "paste_from_clipboard" on focused terminal of selected tab of front window\n' +
+  'end tell';
 
 export function pasteWithNativeTool(): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -53,6 +64,33 @@ export function pasteWithNativeTool(): Promise<void> {
   });
 }
 
+function activateAndPasteCmux(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
+      killSignal: 'SIGTERM' as const
+    };
+
+    execFile('osascript', ['-e', CMUX_PASTE_APPLESCRIPT], options, (error, stdout, stderr) => {
+      if (error) {
+        logger.error('cmux AppleScript paste failed:', {
+          error: error.message,
+          code: error.code,
+          signal: error.signal,
+          stderr
+        });
+        reject(error);
+        return;
+      }
+
+      if (stdout.trim() !== 'true') {
+        logger.warn('cmux AppleScript paste returned non-true:', { stdout, stderr });
+      }
+      resolve();
+    });
+  });
+}
+
 export function activateAndPasteWithNativeTool(appInfo: AppInfo | string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (process.platform !== 'darwin') {
@@ -71,6 +109,11 @@ export function activateAndPasteWithNativeTool(appInfo: AppInfo | string): Promi
       bundleId = appInfo.bundleId || null;
     } else {
       reject(new Error('Invalid app info provided'));
+      return;
+    }
+
+    if (isCmux(appInfo)) {
+      activateAndPasteCmux().then(resolve).catch(reject);
       return;
     }
 

--- a/tests/unit/app-detection-iterm.test.ts
+++ b/tests/unit/app-detection-iterm.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../src/utils/native-tools/paths', () => ({
   WINDOW_DETECTOR_PATH: '/mock/window-detector'
 }));
 
-import { isITerm2, getITermSessionId } from '../../src/utils/native-tools/app-detection';
+import { isITerm2, isCmux, getITermSessionId } from '../../src/utils/native-tools/app-detection';
 
 describe('isITerm2', () => {
   it('should return true for AppInfo with iTerm2 bundleId', () => {
@@ -58,6 +58,32 @@ describe('isITerm2', () => {
   it('should return false for other apps', () => {
     expect(isITerm2('Terminal')).toBe(false);
     expect(isITerm2({ name: 'VS Code', bundleId: 'com.microsoft.VSCode' })).toBe(false);
+  });
+});
+
+describe('isCmux', () => {
+  it('should return true for AppInfo with cmux bundleId', () => {
+    expect(isCmux({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(true);
+  });
+
+  it('should return false for AppInfo with different bundleId', () => {
+    expect(isCmux({ name: 'cmux', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
+  });
+
+  it('should return true for string "cmux" (case-insensitive)', () => {
+    expect(isCmux('cmux')).toBe(true);
+    expect(isCmux('CMUX')).toBe(true);
+    expect(isCmux('Cmux')).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isCmux(null)).toBe(false);
+  });
+
+  it('should return false for other terminals', () => {
+    expect(isCmux('Terminal')).toBe(false);
+    expect(isCmux({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
+    expect(isCmux({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
   });
 });
 

--- a/tests/unit/paste-operations-cmux.test.ts
+++ b/tests/unit/paste-operations-cmux.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn()
+}));
+
+vi.mock('electron', () => ({
+  app: { getApplicationInfoForProtocol: vi.fn() }
+}));
+
+vi.mock('child_process', () => ({
+  execFile: mockExecFile
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}));
+
+vi.mock('../../src/utils/native-tools/paths', () => ({
+  KEYBOARD_SIMULATOR_PATH: '/mock/keyboard-simulator',
+  WINDOW_DETECTOR_PATH: '/mock/window-detector'
+}));
+
+const ORIGINAL_PLATFORM = process.platform;
+
+import { activateAndPasteWithNativeTool } from '../../src/utils/native-tools/paste-operations';
+
+describe('activateAndPasteWithNativeTool — cmux dispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+  });
+
+  it('routes cmux paste through a single osascript call combining activate + paste_from_clipboard', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, 'true\n', '');
+    });
+
+    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' });
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const [cmd, args] = mockExecFile.mock.calls[0]!;
+    expect(cmd).toBe('osascript');
+    expect(args[0]).toBe('-e');
+    expect(args[1]).toContain('tell application "cmux"');
+    expect(args[1]).toContain('activate');
+    expect(args[1]).toContain('perform action "paste_from_clipboard"');
+    expect(args[1]).toContain('focused terminal of selected tab of front window');
+  });
+
+  it('does NOT invoke keyboard-simulator for cmux (avoids ineffective Cmd+V)', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, 'true\n', '');
+    });
+
+    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' });
+
+    const usedKeyboardSimulator = mockExecFile.mock.calls.some(
+      ([cmd]) => cmd === '/mock/keyboard-simulator'
+    );
+    expect(usedKeyboardSimulator).toBe(false);
+  });
+
+  it('rejects when AppleScript paste fails', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(new Error('osascript failed'), '', 'cmux not running');
+    });
+
+    await expect(
+      activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' })
+    ).rejects.toThrow('osascript failed');
+  });
+
+  it('falls through to standard activate-and-paste-bundle for non-cmux apps', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, JSON.stringify({ success: true }), '');
+    });
+
+    await activateAndPasteWithNativeTool({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' });
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const firstCall = mockExecFile.mock.calls[0]!;
+    expect(firstCall[0]).toBe('/mock/keyboard-simulator');
+    expect(firstCall[1]).toEqual(['activate-and-paste-bundle', 'com.mitchellh.ghostty']);
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM });
+  });
+});


### PR DESCRIPTION
## Summary
- Cmd+V via `keyboard-simulator` does not paste into cmux (`com.cmuxterm.app`) because the parent NSApplication consumes Cmd+V CGEvents before they reach the embedded Ghostty PTY.
- Detect cmux by bundle ID and bypass `keyboard-simulator` entirely, instead invoking a single `osascript` call that activates cmux and forwards Ghostty's `paste_from_clipboard` action via `cmux.sdef` (`CmuxPfAc`) to the focused terminal pane.
- Adds `isCmux()` helper alongside the existing `isITerm2()` pattern.

## Why this approach
- cmux's AppleScript dictionary exposes `perform action "paste_from_clipboard" on focused terminal of selected tab of front window`, which routes through cmux's own action handler — the only reliable paste path into the embedded Ghostty.
- Combining `activate` + `perform action` into a single `tell` block keeps the hot path to one process spawn (vs. the standard non-cmux path which uses one Swift `activate-and-paste-bundle` call).
- The clipboard is already populated by the existing paste flow before the dispatch, so no text marshalling through AppleScript is needed.

## Test plan
- [x] Unit tests: `isCmux` (5 cases) + cmux dispatch (4 cases) — all pass
- [x] Full suite: 1350 passed / 1 skipped
- [x] `pnpm run typecheck` passes
- [x] `pnpm run install-app` then E2E: focus cmux → Cmd+Shift+Space → type → Cmd+Enter → paste request completes without error and `appName: "cmux"` is recorded in history
- [x] Direct verification: `osascript -e 'tell application "cmux" ... perform action "paste_from_clipboard" ...'` returns `true` and pastes clipboard content into the focused terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)