### PR TITLE
fix(directory): correctly detect CWD on Ghostty pane switch

### DIFF
--- a/native/directory-detector/DirectoryDetector.swift
+++ b/native/directory-detector/DirectoryDetector.swift
@@ -193,18 +193,29 @@ class DirectoryDetector {
 
         // Check for native terminals (Ghostty, Warp, WezTerm) with process-based detection
         if isNativeTerminal(bundleId) {
-            let (directory, shellPid) = getNativeTerminalDirectory(appPid: appPid)
-
-            // Determine the method name based on the terminal
+            let directory: String?
+            let shellPid: pid_t?
             let methodName: String
-            if isGhostty(bundleId) {
-                methodName = "ghostty-process"
-            } else if isWarp(bundleId) {
-                methodName = "warp-process"
-            } else if isWezTerm(bundleId) {
-                methodName = "wezterm-process"
+
+            if isWezTerm(bundleId) {
+                // WezTerm exposes a CLI that reports the focused pane directly,
+                // which is much more reliable than tty mtime — background panes
+                // redraw their prompts and skew mtime away from the focused one.
+                let result = getWezTermDirectory(appPid: appPid)
+                directory = result.directory
+                shellPid = result.shellPid
+                methodName = result.usedCli ? "wezterm-cli" : "wezterm-process"
             } else {
-                methodName = "native-terminal-process"
+                let result = getNativeTerminalDirectory(appPid: appPid)
+                directory = result.directory
+                shellPid = result.shellPid
+                if isGhostty(bundleId) {
+                    methodName = "ghostty-process"
+                } else if isWarp(bundleId) {
+                    methodName = "warp-process"
+                } else {
+                    methodName = "native-terminal-process"
+                }
             }
 
             if let cwd = directory {

--- a/native/directory-detector/DirectoryDetector.swift
+++ b/native/directory-detector/DirectoryDetector.swift
@@ -205,13 +205,19 @@ class DirectoryDetector {
                 directory = result.directory
                 shellPid = result.shellPid
                 methodName = result.usedCli ? "wezterm-cli" : "wezterm-process"
+            } else if isGhostty(bundleId) {
+                // Ghostty's AXWindow.AXDocument carries the focused pane's CWD,
+                // which updates instantly on pane focus changes. tty mtime is
+                // lossy here because background panes redraw their prompts.
+                let result = getGhosttyDirectory(appPid: appPid)
+                directory = result.directory
+                shellPid = result.shellPid
+                methodName = result.usedAx ? "ghostty-ax" : "ghostty-process"
             } else {
                 let result = getNativeTerminalDirectory(appPid: appPid)
                 directory = result.directory
                 shellPid = result.shellPid
-                if isGhostty(bundleId) {
-                    methodName = "ghostty-process"
-                } else if isWarp(bundleId) {
+                if isWarp(bundleId) {
                     methodName = "warp-process"
                 } else {
                     methodName = "native-terminal-process"

--- a/native/directory-detector/ProcessTree.swift
+++ b/native/directory-detector/ProcessTree.swift
@@ -170,9 +170,11 @@ extension DirectoryDetector {
 
         do {
             try process.run()
+            // Drain the pipe before waiting — `ps -ax` output exceeds the 64KB pipe
+            // buffer on busy systems, so waiting first would deadlock the writer.
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
 
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
             guard let output = String(data: data, encoding: .utf8) else {
                 return [:]
             }
@@ -559,9 +561,10 @@ extension DirectoryDetector {
 
         do {
             try process.run()
+            // Drain the pipe before waiting — see getAllProcessNodes for the same pattern.
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
 
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
             guard let output = String(data: data, encoding: .utf8) else {
                 return [:]
             }

--- a/native/directory-detector/ProcessTree.swift
+++ b/native/directory-detector/ProcessTree.swift
@@ -233,9 +233,13 @@ extension DirectoryDetector {
     }
 
     /// Check if command name is a shell
-    /// Handles formats like: "zsh", "/bin/zsh", "zsh (qterm)", "-zsh"
+    /// Handles formats like: "zsh", "/bin/zsh", "zsh (qterm)", "-zsh".
+    /// Keep `nu` and `pwsh` here too — the previous detector used
+    /// `pgrep -f "zsh|bash|fish|sh|nu|pwsh"`, and dropping them silently
+    /// breaks CWD detection for Nushell/PowerShell users in Warp and on the
+    /// Ghostty/WezTerm process-tree fallback path.
     static func isShellCommand(_ command: String) -> Bool {
-        let shellNames = ["zsh", "bash", "fish", "sh"]
+        let shellNames = ["zsh", "bash", "fish", "sh", "nu", "pwsh"]
         let baseName = (command as NSString).lastPathComponent.lowercased()
 
         // Check exact match

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -228,9 +228,60 @@ extension DirectoryDetector {
         return modDate.timeIntervalSince1970
     }
 
-    /// Get CWD from Ghostty terminal (wrapper for getNativeTerminalDirectory)
-    static func getGhosttyDirectory(appPid: pid_t) -> (directory: String?, shellPid: pid_t?) {
-        return getNativeTerminalDirectory(appPid: appPid)
+    /// Get CWD from Ghostty terminal.
+    /// Ghostty exposes the focused pane's working directory via the AXWindow's
+    /// `AXDocument` attribute (the proxy-icon URL). This updates instantly on
+    /// pane/tab focus changes, while tty mtime can lag by seconds because
+    /// background panes keep redrawing their prompts.
+    /// Falls back to the generic process-tree detector if AX is unavailable.
+    static func getGhosttyDirectory(appPid: pid_t) -> (directory: String?, shellPid: pid_t?, usedAx: Bool) {
+        if let path = getGhosttyDirectoryViaAx(appPid: appPid) {
+            // shellPid is only emitted as metadata; nothing in the renderer
+            // depends on it. Skip the ps walk entirely when AX gives us a
+            // direct answer — that keeps detection well under 50ms.
+            return (path, nil, true)
+        }
+        let fallback = getNativeTerminalDirectory(appPid: appPid)
+        return (fallback.directory, fallback.shellPid, false)
+    }
+
+    /// Read the focused pane's CWD from AXWindow.AXDocument. Returns nil when
+    /// the attribute is missing or doesn't decode as a `file://` URL.
+    private static func getGhosttyDirectoryViaAx(appPid: pid_t) -> String? {
+        let appRef = AXUIElementCreateApplication(appPid)
+
+        var focusedWinRef: CFTypeRef?
+        let winResult = AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &focusedWinRef)
+        guard winResult == .success, let focusedWindow = focusedWinRef else { return nil }
+        let win = focusedWindow as! AXUIElement
+
+        var docRef: CFTypeRef?
+        let docResult = AXUIElementCopyAttributeValue(win, "AXDocument" as CFString, &docRef)
+        guard docResult == .success else { return nil }
+
+        // AXDocument is documented as a String containing a file URL on macOS,
+        // but defensively accept NSURL too in case Ghostty switches encoding.
+        let urlString: String?
+        if let s = docRef as? String {
+            urlString = s
+        } else if let url = docRef as? NSURL {
+            urlString = url.absoluteString
+        } else {
+            urlString = nil
+        }
+
+        guard let str = urlString,
+              let url = URL(string: str),
+              url.isFileURL else {
+            return nil
+        }
+
+        var path = url.path
+        // Other detectors return paths without a trailing slash; normalise here.
+        if path.hasSuffix("/") && path != "/" {
+            path.removeLast()
+        }
+        return path.isEmpty ? nil : path
     }
 
     /// Get CWD from Warp terminal (wrapper for getNativeTerminalDirectory)

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -113,37 +113,27 @@ extension DirectoryDetector {
     /// Works for Ghostty, Warp, WezTerm, and other native terminals
     /// Uses the same fast approach as Electron IDE detection
     static func getNativeTerminalDirectory(appPid: pid_t) -> (directory: String?, shellPid: pid_t?) {
-        // Step 1: Snapshot every process via `ps`. We avoid `pgrep -f` here because
-        // macOS pgrep silently drops long-running processes whose KERN_PROCARGS2 has
-        // become unreadable, which can hide the focused login shell in old Ghostty
-        // tabs and flip CWD detection to an unrelated tab.
-        let allNodes = getAllProcessNodes()
-        if allNodes.isEmpty {
+        // One `ps` call gathers pid/ppid/tty/comm for every process. We avoid
+        // `pgrep -f` because macOS pgrep silently drops long-running processes
+        // whose KERN_PROCARGS2 has become unreadable — the focused login shell
+        // of an old Ghostty tab is exactly the one that gets dropped.
+        let snapshot = snapshotProcessesWithTty()
+        if snapshot.isEmpty {
             return (nil, nil)
         }
 
-        let parentMap = buildParentMapFast()
-        if parentMap.isEmpty {
-            return (nil, nil)
+        // Reuse the snapshot for parent lookups so we don't fork another `ps`.
+        var parentMap: [pid_t: pid_t] = [:]
+        parentMap.reserveCapacity(snapshot.count)
+        for entry in snapshot {
+            parentMap[entry.pid] = entry.ppid
         }
 
-        // Step 2: Keep shell processes that descend from this terminal app.
-        var terminalShells: [pid_t] = []
-        for (pid, node) in allNodes where isShellCommand(node.command) {
-            if isDescendantOf(pid, ancestorPid: appPid, parentMap: parentMap, maxDepth: 10) {
-                terminalShells.append(pid)
-            }
-        }
-
-        if terminalShells.isEmpty {
-            return (nil, nil)
-        }
-
-        // Step 3: Pick the shell whose tty was most recently active.
-        // A pty's mtime advances on read/write traffic, so it tracks the tab/window
-        // the user just interacted with. Ghostty's AX hierarchy only exposes the
-        // focused window's title — there is no direct pty mapping — so tty mtime
-        // is what lets us resolve focus across multiple terminal windows/tabs.
+        // Pick the shell whose tty was most recently active. A pty's mtime
+        // advances on read/write traffic, so it tracks the tab/window the user
+        // just interacted with. Ghostty's AX hierarchy only exposes the focused
+        // window's title — there is no direct pty mapping — so tty mtime is
+        // what lets us resolve focus across multiple terminal windows/tabs.
         struct ShellCandidate {
             let pid: pid_t
             let cwd: String
@@ -151,18 +141,19 @@ extension DirectoryDetector {
         }
 
         var candidates: [ShellCandidate] = []
-        for shellPid in terminalShells {
-            guard let cwd = getCwdFromPid(shellPid) else { continue }
-            let mtime = getTtyModTime(for: shellPid) ?? 0
-            candidates.append(ShellCandidate(pid: shellPid, cwd: cwd, ttyMtime: mtime))
+        for entry in snapshot where isShellCommand(entry.comm) && !entry.tty.isEmpty {
+            guard isDescendantOf(entry.pid, ancestorPid: appPid, parentMap: parentMap, maxDepth: 10) else { continue }
+            guard let cwd = getCwdFromPid(entry.pid) else { continue }
+            let mtime = mtimeForTty(entry.tty) ?? 0
+            candidates.append(ShellCandidate(pid: entry.pid, cwd: cwd, ttyMtime: mtime))
         }
 
         if candidates.isEmpty {
             return (nil, nil)
         }
 
-        // Sort shells with a known tty mtime first (newest first); shells without a
-        // resolvable tty fall back to pid order (newest first).
+        // Sort shells with a known tty mtime first (newest first); shells
+        // without a resolvable tty fall back to pid order (newest first).
         candidates.sort { lhs, rhs in
             if lhs.ttyMtime > 0 && rhs.ttyMtime > 0 {
                 return lhs.ttyMtime > rhs.ttyMtime
@@ -174,6 +165,63 @@ extension DirectoryDetector {
 
         let focused = candidates[0]
         return (focused.cwd, focused.pid)
+    }
+
+    private struct ProcessEntry {
+        let pid: pid_t
+        let ppid: pid_t
+        let tty: String
+        let comm: String
+    }
+
+    /// Capture pid/ppid/tty/comm for every process in a single `ps` invocation.
+    private static func snapshotProcessesWithTty() -> [ProcessEntry] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-axo", "pid=,ppid=,tty=,comm="]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            // Drain before waiting — `ps -ax` output exceeds the 64KB pipe
+            // buffer on busy systems, and waiting first would deadlock.
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            guard let output = String(data: data, encoding: .utf8) else {
+                return []
+            }
+
+            var entries: [ProcessEntry] = []
+            entries.reserveCapacity(256)
+
+            for rawLine in output.split(separator: "\n") {
+                let line = rawLine.trimmingCharacters(in: .whitespaces)
+                if line.isEmpty { continue }
+                let parts = line.split(separator: " ", maxSplits: 3, omittingEmptySubsequences: true)
+                if parts.count < 4 { continue }
+                guard let pid = Int32(parts[0]),
+                      let ppid = Int32(parts[1]) else { continue }
+                let tty = parts[2] == "??" ? "" : String(parts[2])
+                entries.append(ProcessEntry(pid: pid, ppid: ppid, tty: tty, comm: String(parts[3])))
+            }
+
+            return entries
+        } catch {
+            return []
+        }
+    }
+
+    private static func mtimeForTty(_ tty: String) -> TimeInterval? {
+        let path = tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modDate = attrs[.modificationDate] as? Date else {
+            return nil
+        }
+        return modDate.timeIntervalSince1970
     }
 
     /// Get CWD from Ghostty terminal (wrapper for getNativeTerminalDirectory)

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -238,8 +238,102 @@ extension DirectoryDetector {
         return getNativeTerminalDirectory(appPid: appPid)
     }
 
-    /// Get CWD from WezTerm terminal (wrapper for getNativeTerminalDirectory)
-    static func getWezTermDirectory(appPid: pid_t) -> (directory: String?, shellPid: pid_t?) {
-        return getNativeTerminalDirectory(appPid: appPid)
+    /// Get CWD from WezTerm terminal.
+    /// Prefers `wezterm cli` because tty mtime is unreliable on WezTerm —
+    /// background panes/tabs keep redrawing prompts (starship, themes), so
+    /// the focused pane often has neither the newest mtime nor a clear lead.
+    /// Falls back to the generic process-tree detector if the CLI fails.
+    static func getWezTermDirectory(appPid: pid_t) -> (directory: String?, shellPid: pid_t?, usedCli: Bool) {
+        if let result = getWezTermDirectoryViaCli() {
+            return (result.directory, result.shellPid, true)
+        }
+        let fallback = getNativeTerminalDirectory(appPid: appPid)
+        return (fallback.directory, fallback.shellPid, false)
+    }
+
+    /// Ask the running WezTerm GUI which pane is focused via `wezterm cli`.
+    /// Returns nil if the CLI is unavailable, the daemon is not reachable,
+    /// or the JSON shape is unexpected — callers should fall back.
+    private static func getWezTermDirectoryViaCli() -> (directory: String, shellPid: pid_t?)? {
+        guard let focusedPaneId = runWezTermCli(args: ["cli", "list-clients", "--format", "json"])
+            .flatMap({ parseFirstFocusedPaneId(from: $0) }) else {
+            return nil
+        }
+
+        guard let paneListData = runWezTermCli(args: ["cli", "list", "--format", "json"]),
+              let panes = (try? JSONSerialization.jsonObject(with: paneListData)) as? [[String: Any]],
+              let pane = panes.first(where: { ($0["pane_id"] as? Int) == focusedPaneId }),
+              let cwdString = pane["cwd"] as? String,
+              let directory = pathFromCwdString(cwdString) else {
+            return nil
+        }
+
+        let shellPid: pid_t? = (pane["tty_name"] as? String).flatMap { tty in
+            getShellPidFromTty(tty)
+        }
+
+        return (directory, shellPid)
+    }
+
+    /// Locate the WezTerm CLI. Prefer the binary the user already has on
+    /// PATH; fall back to the bundled binary so we still work when PATH
+    /// isn't inherited (e.g. Electron launched from Finder).
+    private static func wezTermCliPath() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/wezterm",
+            "/usr/local/bin/wezterm",
+            "/Applications/WezTerm.app/Contents/MacOS/wezterm"
+        ]
+        let fileManager = FileManager.default
+        return candidates.first { fileManager.isExecutableFile(atPath: $0) }
+    }
+
+    private static func runWezTermCli(args: [String]) -> Data? {
+        guard let cliPath = wezTermCliPath() else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: cliPath)
+        process.arguments = args
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            return data
+        } catch {
+            return nil
+        }
+    }
+
+    private static func parseFirstFocusedPaneId(from data: Data) -> Int? {
+        guard let clients = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+            return nil
+        }
+        // WezTerm reports one client per connected GUI; the GUI process is
+        // what we care about. Take the first entry that has a focused pane.
+        for client in clients {
+            if let paneId = client["focused_pane_id"] as? Int {
+                return paneId
+            }
+        }
+        return nil
+    }
+
+    /// Convert a `cwd` string from `wezterm cli list` into a filesystem path.
+    /// WezTerm reports either a `file://` URL (with percent-encoding) or, on
+    /// older builds, a bare path.
+    private static func pathFromCwdString(_ cwd: String) -> String? {
+        if cwd.hasPrefix("file://") {
+            if let url = URL(string: cwd), url.isFileURL {
+                return url.path
+            }
+            return nil
+        }
+        return cwd.isEmpty ? nil : cwd
     }
 }

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -158,21 +158,41 @@ extension DirectoryDetector {
                 return (nil, nil)
             }
 
-            let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
+            // Step 4: Pick the shell whose tty was most recently active.
+            // The pty device's mtime updates on read/write activity, so it tracks the
+            // tab/window the user just interacted with. AX APIs only expose Ghostty's
+            // focused window title (no pty mapping), so tty mtime is what lets us
+            // resolve focus across multiple terminal windows/tabs.
+            struct ShellCandidate {
+                let pid: pid_t
+                let cwd: String
+                let ttyMtime: TimeInterval
+            }
 
-            // Step 4: Check CWD of each shell, prefer non-home directories
-            for shellPid in terminalShells.prefix(5) {
-                if let cwd = getCwdFromPid(shellPid), cwd != homeDir {
-                    return (cwd, shellPid)
+            var candidates: [ShellCandidate] = []
+            for shellPid in terminalShells.prefix(10) {
+                guard let cwd = getCwdFromPid(shellPid) else { continue }
+                let mtime = getTtyModTime(for: shellPid) ?? 0
+                candidates.append(ShellCandidate(pid: shellPid, cwd: cwd, ttyMtime: mtime))
+            }
+
+            if candidates.isEmpty {
+                return (nil, nil)
+            }
+
+            // Sort shells with a known tty mtime first (newest first); shells without a
+            // resolvable tty fall back to pgrep order (already newest-pid-first).
+            candidates.sort { lhs, rhs in
+                if lhs.ttyMtime > 0 && rhs.ttyMtime > 0 {
+                    return lhs.ttyMtime > rhs.ttyMtime
                 }
+                if lhs.ttyMtime > 0 { return true }
+                if rhs.ttyMtime > 0 { return false }
+                return lhs.pid > rhs.pid
             }
 
-            // Fallback: return first shell even if in home directory
-            if let firstPid = terminalShells.first, let cwd = getCwdFromPid(firstPid) {
-                return (cwd, firstPid)
-            }
-
-            return (nil, nil)
+            let focused = candidates[0]
+            return (focused.cwd, focused.pid)
         } catch {
             return (nil, nil)
         }

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -113,89 +113,67 @@ extension DirectoryDetector {
     /// Works for Ghostty, Warp, WezTerm, and other native terminals
     /// Uses the same fast approach as Electron IDE detection
     static func getNativeTerminalDirectory(appPid: pid_t) -> (directory: String?, shellPid: pid_t?) {
-        // Step 1: Get all shell processes using pgrep (very fast)
-        let pgrepProcess = Process()
-        pgrepProcess.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-        pgrepProcess.arguments = ["-f", "zsh|bash|fish|sh|nu|pwsh"]
-
-        let pgrepPipe = Pipe()
-        pgrepProcess.standardOutput = pgrepPipe
-        pgrepProcess.standardError = FileHandle.nullDevice
-
-        do {
-            try pgrepProcess.run()
-            pgrepProcess.waitUntilExit()
-
-            let pgrepData = pgrepPipe.fileHandleForReading.readDataToEndOfFile()
-            guard let pgrepOutput = String(data: pgrepData, encoding: .utf8) else {
-                return (nil, nil)
-            }
-
-            let shellPids = pgrepOutput.split(separator: "\n")
-                .compactMap { Int32(String($0)) }
-                .sorted(by: >) // Newest first
-
-            if shellPids.isEmpty {
-                return (nil, nil)
-            }
-
-            // Step 2: Build parent map from ps output (single call)
-            let parentMap = buildParentMapFast()
-            if parentMap.isEmpty {
-                return (nil, nil)
-            }
-
-            // Step 3: For each shell, check if it's a descendant of the terminal app
-            var terminalShells: [pid_t] = []
-
-            for shellPid in shellPids {
-                if isDescendantOf(shellPid, ancestorPid: appPid, parentMap: parentMap, maxDepth: 10) {
-                    terminalShells.append(shellPid)
-                }
-            }
-
-            if terminalShells.isEmpty {
-                return (nil, nil)
-            }
-
-            // Step 4: Pick the shell whose tty was most recently active.
-            // The pty device's mtime updates on read/write activity, so it tracks the
-            // tab/window the user just interacted with. AX APIs only expose Ghostty's
-            // focused window title (no pty mapping), so tty mtime is what lets us
-            // resolve focus across multiple terminal windows/tabs.
-            struct ShellCandidate {
-                let pid: pid_t
-                let cwd: String
-                let ttyMtime: TimeInterval
-            }
-
-            var candidates: [ShellCandidate] = []
-            for shellPid in terminalShells.prefix(10) {
-                guard let cwd = getCwdFromPid(shellPid) else { continue }
-                let mtime = getTtyModTime(for: shellPid) ?? 0
-                candidates.append(ShellCandidate(pid: shellPid, cwd: cwd, ttyMtime: mtime))
-            }
-
-            if candidates.isEmpty {
-                return (nil, nil)
-            }
-
-            // Sort shells with a known tty mtime first (newest first); shells without a
-            // resolvable tty fall back to pgrep order (already newest-pid-first).
-            candidates.sort { lhs, rhs in
-                if lhs.ttyMtime > 0 && rhs.ttyMtime > 0 {
-                    return lhs.ttyMtime > rhs.ttyMtime
-                }
-                if lhs.ttyMtime > 0 { return true }
-                if rhs.ttyMtime > 0 { return false }
-                return lhs.pid > rhs.pid
-            }
-
-            let focused = candidates[0]
-            return (focused.cwd, focused.pid)
-        } catch {
+        // Step 1: Snapshot every process via `ps`. We avoid `pgrep -f` here because
+        // macOS pgrep silently drops long-running processes whose KERN_PROCARGS2 has
+        // become unreadable, which can hide the focused login shell in old Ghostty
+        // tabs and flip CWD detection to an unrelated tab.
+        let allNodes = getAllProcessNodes()
+        if allNodes.isEmpty {
             return (nil, nil)
         }
+
+        let parentMap = buildParentMapFast()
+        if parentMap.isEmpty {
+            return (nil, nil)
+        }
+
+        // Step 2: Keep shell processes that descend from this terminal app.
+        var terminalShells: [pid_t] = []
+        for (pid, node) in allNodes where isShellCommand(node.command) {
+            if isDescendantOf(pid, ancestorPid: appPid, parentMap: parentMap, maxDepth: 10) {
+                terminalShells.append(pid)
+            }
+        }
+
+        if terminalShells.isEmpty {
+            return (nil, nil)
+        }
+
+        // Step 3: Pick the shell whose tty was most recently active.
+        // A pty's mtime advances on read/write traffic, so it tracks the tab/window
+        // the user just interacted with. Ghostty's AX hierarchy only exposes the
+        // focused window's title — there is no direct pty mapping — so tty mtime
+        // is what lets us resolve focus across multiple terminal windows/tabs.
+        struct ShellCandidate {
+            let pid: pid_t
+            let cwd: String
+            let ttyMtime: TimeInterval
+        }
+
+        var candidates: [ShellCandidate] = []
+        for shellPid in terminalShells {
+            guard let cwd = getCwdFromPid(shellPid) else { continue }
+            let mtime = getTtyModTime(for: shellPid) ?? 0
+            candidates.append(ShellCandidate(pid: shellPid, cwd: cwd, ttyMtime: mtime))
+        }
+
+        if candidates.isEmpty {
+            return (nil, nil)
+        }
+
+        // Sort shells with a known tty mtime first (newest first); shells without a
+        // resolvable tty fall back to pid order (newest first).
+        candidates.sort { lhs, rhs in
+            if lhs.ttyMtime > 0 && rhs.ttyMtime > 0 {
+                return lhs.ttyMtime > rhs.ttyMtime
+            }
+            if lhs.ttyMtime > 0 { return true }
+            if rhs.ttyMtime > 0 { return false }
+            return lhs.pid > rhs.pid
+        }
+
+        let focused = candidates[0]
+        return (focused.cwd, focused.pid)
     }
 
     /// Get CWD from Ghostty terminal (wrapper for getNativeTerminalDirectory)

--- a/native/directory-detector/TerminalDetector.swift
+++ b/native/directory-detector/TerminalDetector.swift
@@ -206,7 +206,11 @@ extension DirectoryDetector {
                 guard let pid = Int32(parts[0]),
                       let ppid = Int32(parts[1]) else { continue }
                 let tty = parts[2] == "??" ? "" : String(parts[2])
-                entries.append(ProcessEntry(pid: pid, ppid: ppid, tty: tty, comm: String(parts[3])))
+                // `ps` pads each column to a fixed width, so the comm slice
+                // can carry a leading space (e.g. " -zsh"). Trim before use —
+                // otherwise isShellCommand misses WezTerm's "-zsh" entries.
+                let comm = parts[3].trimmingCharacters(in: .whitespaces)
+                entries.append(ProcessEntry(pid: pid, ppid: ppid, tty: tty, comm: comm))
             }
 
             return entries

--- a/src/managers/window/directory-detector.ts
+++ b/src/managers/window/directory-detector.ts
@@ -195,11 +195,26 @@ class DirectoryDetector {
   }
 
   /**
-   * Notify renderer of directory data update
+   * Notify renderer of directory data update.
+   *
+   * If the renderer is still loading (a fresh BrowserWindow was just created
+   * — e.g. when WindowManager recreates on a desktop-space signature change)
+   * the IPC listener may not be registered yet, so `webContents.send` would
+   * silently drop the event. In that case we defer the send until
+   * `did-finish-load`, which fires after the renderer registers its handlers.
    */
   private notifyRenderer(inputWindow: BrowserWindow, data: DirectoryInfo): void {
-    if (!inputWindow.isDestroyed()) {
-      inputWindow.webContents.send('directory-data-updated', data);
+    if (inputWindow.isDestroyed()) return;
+    const wc = inputWindow.webContents;
+    const send = (): void => {
+      if (!inputWindow.isDestroyed()) {
+        wc.send('directory-data-updated', data);
+      }
+    };
+    if (wc.isLoading()) {
+      wc.once('did-finish-load', send);
+    } else {
+      send();
     }
   }
 

--- a/src/renderer/directory-data-handler.ts
+++ b/src/renderer/directory-data-handler.ts
@@ -161,9 +161,13 @@ export class DirectoryDataHandler {
             this.callbacks.updateHintText(formattedPath);
           }
 
-          // Only save directory to draft if it's NOT already from draft
-          // (to avoid redundant IPC call when directory is from draft fallback)
-          if (!data.directoryData.fromDraft) {
+          // Only save directory to draft when this came from a fresh detection.
+          // Skip writes for cache hits and draft fallbacks: the user may have
+          // switched tabs/panes since the cache was written, so we must let the
+          // background detection's `directory-data-updated` event provide the
+          // authoritative value. Otherwise a stale cache directory races the
+          // detection result and can overwrite it.
+          if (!data.directoryData.fromDraft && !data.directoryData.fromCache) {
             await electronAPI.invoke('set-draft-directory', data.directoryData.directory);
           }
         }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -50,6 +50,15 @@ export class PromptLineRenderer {
   private defaultHintText: string = 'Multi-line text and Image supported'; // Default hint text
   // Queue for pending window-shown data to handle race condition with init()
   private pendingWindowData: WindowData | null = null;
+  // Queue for pending directory-data-updated payloads that arrive before init()
+  // finishes. Without this, the BG detection result silently no-ops because
+  // domManager.initializeElements has not yet wired up #hintText.
+  private pendingDirectoryData: DirectoryInfo | null = null;
+  // Tracks the in-flight handleWindowShown promise so a directory-data-updated
+  // event that arrives while window-shown is still awaiting its own internal
+  // IPC roundtrips waits for it to settle. Otherwise the BG result lands first
+  // and window-shown overwrites the hint with the cached/stale directory.
+  private inflightWindowShown: Promise<void> | null = null;
   // Stored handler reference for cleanup
   private customSearchUpdateHandler: (() => void) | null = null;
   private commandErrorHandler: ((e: Event) => void) | null = null;
@@ -137,6 +146,14 @@ export class PromptLineRenderer {
         console.debug('[PromptLineRenderer] Processing pending window-shown data');
         await this.directoryDataHandler.handleWindowShown(this.pendingWindowData);
         this.pendingWindowData = null;
+      }
+      // Then process any pending background-detection update. Order matters:
+      // window-shown sets the hint to the cached directory; the BG update
+      // overwrites it with the freshly detected one.
+      if (this.pendingDirectoryData) {
+        console.debug('[PromptLineRenderer] Processing pending directory-data-updated');
+        await this.directoryDataHandler.handleDirectoryDataUpdated(this.pendingDirectoryData);
+        this.pendingDirectoryData = null;
       }
     } catch (error) {
       rendererLogger.error('Failed to initialize renderer:', error);
@@ -520,24 +537,58 @@ export class PromptLineRenderer {
       return;
     }
 
-    try {
-      const lastChange = await electronAPI.customSearch.getLastChangeTimestamp();
-      if (lastChange > this.lastCustomSearchChangeTimestamp) {
-        this.lastCustomSearchChangeTimestamp = lastChange;
+    // Mark window-shown as in-flight so a concurrent directory-data-updated
+    // does not overtake us and get its hint write overwritten when the
+    // window-shown body resumes.
+    const work = (async (): Promise<void> => {
+      try {
+        const lastChange = await electronAPI.customSearch.getLastChangeTimestamp();
+        if (lastChange > this.lastCustomSearchChangeTimestamp) {
+          this.lastCustomSearchChangeTimestamp = lastChange;
+          this.agentSkillManager?.invalidateCache();
+          this.fileSearchManager?.clearAgentsCache();
+          this.agentSkillManager?.prefetchSkills();
+        }
+      } catch {
         this.agentSkillManager?.invalidateCache();
         this.fileSearchManager?.clearAgentsCache();
-        this.agentSkillManager?.prefetchSkills();
+        electronAPI.invoke('invalidate-custom-search').catch(() => {});
       }
-    } catch {
-      this.agentSkillManager?.invalidateCache();
-      this.fileSearchManager?.clearAgentsCache();
-      electronAPI.invoke('invalidate-custom-search').catch(() => {});
+      await this.directoryDataHandler.handleWindowShown(data);
+    })();
+    this.inflightWindowShown = work;
+    try {
+      await work;
+    } finally {
+      if (this.inflightWindowShown === work) this.inflightWindowShown = null;
     }
-
-    await this.directoryDataHandler.handleWindowShown(data);
   }
 
   private async handleDirectoryDataUpdated(data: DirectoryInfo): Promise<void> {
+    // Defer in two cases:
+    //   1. init() hasn't finished wiring up domManager — the hint write would
+    //      land on a null hintTextEl.
+    //   2. window-shown is still pending (init's queue has not consumed it
+    //      yet) — without this, the BG result lands first, then window-shown
+    //      runs and overwrites the hint with the cached/stale directory.
+    if (!this.initCompleted || this.pendingWindowData) {
+      console.debug('[PromptLineRenderer] Queueing directory-data-updated', {
+        initCompleted: this.initCompleted,
+        hasPendingWindow: !!this.pendingWindowData
+      });
+      this.pendingDirectoryData = data;
+      return;
+    }
+    // If window-shown is mid-flight (started before us but its body is still
+    // awaiting an internal IPC), wait for it to settle before applying the
+    // BG-detection update. Otherwise we'd be overwritten by its tail.
+    if (this.inflightWindowShown) {
+      try {
+        await this.inflightWindowShown;
+      } catch {
+        // window-shown errors are logged elsewhere; we just need ordering
+      }
+    }
     await this.directoryDataHandler.handleDirectoryDataUpdated(data);
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug where Prompt Line displayed the previous Ghostty pane's CWD (and underlying file index) when launched right after switching panes. Reopening it would correct itself, but the first invocation always lagged one pane behind.

The branch contains the full investigation arc — earlier commits tightened native CWD detection (process-tree → AX `AXDocument` for Ghostty, `wezterm cli` for WezTerm, comm-field trimming) and stopped cached `directoryData` from racing fresh detection. The final commit closes the remaining race that the user could still reproduce.

### Root cause of the final race

`DesktopSpaceManager` mixes a 1-second `TimeSlot_*` synthetic window into the space signature, so any Prompt Line show after the 2 s cache TTL flips the signature and `WindowManager` destroys + recreates the input `BrowserWindow`. The fresh renderer was still loading when:

1. `notifyRenderer` fired `webContents.send('directory-data-updated', ...)` → IPC listeners not yet registered → event silently dropped.
2. Even when delivery worked, `directory-data-updated` could land while `handleWindowShown` was mid-await; the BG result hit `#hintText` first, then the `window-shown` tail overwrote it with the cached/stale directory.

### Fix

- **`src/managers/window/directory-detector.ts`** — `notifyRenderer` now defers the send until `did-finish-load` when the renderer is still loading.
- **`src/renderer/renderer.ts`** — added a `pendingDirectoryData` queue (mirroring `pendingWindowData`) and an `inflightWindowShown` promise so:
  - `directory-data-updated` is queued while init() is incomplete or `window-shown` is still pending, and flushed in `init()` after `pendingWindowData`.
  - When both run after init, `handleDirectoryDataUpdated` waits for any in-flight `handleWindowShown` to settle before applying the BG result.

## Test plan

- [x] `pnpm run pre-push` (lint + typecheck + 1350 tests) passes locally.
- [x] On-device verification through CDP, cycling focus across three Ghostty panes (`prompt-line-wt-fix-ghostty-05010034`, `setup`, `claude`) with `electronAPI.window.show()` and reading `#hintText`. Before the fix the hint kept showing the previous pane's CWD; after the fix all five probes match the focused pane's CWD at +0.05s and +2.05s.
- [ ] Manual sanity check: reopen Prompt Line in any Ghostty pane after switching panes/tabs and confirm the displayed directory and `@` file search reflect the focused pane on the first invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)