### PR TITLE
feat(shortcuts): add "run=" action to execute shell commands from settings.yaml

### DIFF
--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -17,6 +17,7 @@ shortcuts:
   Cmd+f: search                     # Enable search mode in history
   # Ctrl+m: "input=@md:"  # Custom action (e.g. input text field "input=xxx")
   # Ctrl+g: "input=@ghq:"
+  # Ctrl+e: "run=code {projectdir}"  # Run shell command (template variable: {projectdir})
 
 # Plugins (refs: `prompt-line-plugin help`)
 #plugins:

--- a/src/config/default-settings.ts
+++ b/src/config/default-settings.ts
@@ -45,7 +45,8 @@ export const defaultSettings: UserSettings = {
    *     Cmd+Shift+Space: main    # Show/hide the input window (global)
    *     Cmd+Enter: paste          # Paste text and close window
    *     Escape: close             # Close window without pasting
-   *     # Ctrl+m: "input=@md:"   # Custom action (inserts text into input field)
+   *     # Ctrl+m: "input=@md:"           # Custom action (inserts text into input field)
+   *     # Ctrl+e: "run=code {projectdir}" # Custom action (runs shell command in CWD)
    */
   shortcuts: {
     main: 'Cmd+Shift+Space',   // Show/hide the input window (global hotkey)

--- a/src/config/settings-yaml-generator.ts
+++ b/src/config/settings-yaml-generator.ts
@@ -540,6 +540,7 @@ function buildShortcutsSection(settings: UserSettings): string {
     `${pad(`  ${s.search}: search`)}# Enable search mode in history`,
     `  # Ctrl+m: "input=@md:"  # Custom action (e.g. input text field "input=xxx")`,
     `  # Ctrl+g: "input=@ghq:"`,
+    `  # Ctrl+e: "run=code {projectdir}"  # Run shell command (template variable: {projectdir})`,
   ];
   return lines.join('\n');
 }

--- a/src/handlers/CLAUDE.md
+++ b/src/handlers/CLAUDE.md
@@ -1,6 +1,6 @@
 # IPC Handlers Module
 
-Central communication bridge between main and renderer processes. 9 specialized handler files, 52 IPC channels total.
+Central communication bridge between main and renderer processes. 9 specialized handler files, 53 IPC channels total.
 
 ## File Structure
 
@@ -10,7 +10,7 @@ Central communication bridge between main and renderer processes. 9 specialized 
 | `paste-handler.ts` | Text/image paste with security validation |
 | `history-draft-handler.ts` | History CRUD, draft management, @path caching |
 | `window-handler.ts` | Window visibility and focus control |
-| `system-handler.ts` | App info, config, settings retrieval |
+| `system-handler.ts` | App info, config, settings retrieval, `run=` shortcut command execution |
 | `custom-search-handler.ts` | Slash commands, agent selection, plugin hot reload, source file hot reload, shell command execution |
 | `file-handler.ts` | File operations, external URL handling |
 | `usage-history-handler.ts` | Usage tracking for files, symbols, agents |

--- a/src/handlers/ipc-handlers.ts
+++ b/src/handlers/ipc-handlers.ts
@@ -68,7 +68,7 @@ class IPCHandlers {
       windowManager
     );
     this.windowHandler = new WindowHandler(windowManager);
-    this.systemHandler = new SystemHandler(settingsManager);
+    this.systemHandler = new SystemHandler(settingsManager, directoryManager);
     // Connect DirectoryManager to CustomSearchLoader for {projectdir} template variable
     customSearchLoader.setProjectdirGetter(() => directoryManager.getDirectory());
     this.customSearchHandler = new CustomSearchHandler(

--- a/src/handlers/system-handler.ts
+++ b/src/handlers/system-handler.ts
@@ -1,8 +1,13 @@
 import path from 'path';
+import { exec } from 'child_process';
 import { IpcMainInvokeEvent, shell } from 'electron';
 import config from '../config/app-config';
 import { logger } from '../utils/utils';
+import { resolveTemplate } from '../lib/template-resolver';
+import { shellQuote } from '../utils/security';
+import { getEnhancedEnv } from '../utils/shell-env';
 import type SettingsManager from '../managers/settings-manager';
+import type DirectoryManager from '../managers/directory-manager';
 import type { IPCResult } from '../types';
 
 interface AppInfoResult {
@@ -30,9 +35,11 @@ const VALID_CONFIG_SECTIONS = ['shortcuts', 'history', 'draft', 'timing', 'app',
 
 class SystemHandler {
   private settingsManager: SettingsManager;
+  private directoryManager: DirectoryManager;
 
-  constructor(settingsManager: SettingsManager) {
+  constructor(settingsManager: SettingsManager, directoryManager: DirectoryManager) {
     this.settingsManager = settingsManager;
+    this.directoryManager = directoryManager;
   }
 
   setupHandlers(ipcMain: typeof import('electron').ipcMain): void {
@@ -41,10 +48,11 @@ class SystemHandler {
     ipcMain.handle('open-settings', this.handleOpenSettings.bind(this));
     ipcMain.handle('open-settings-directory', this.handleOpenSettingsDirectory.bind(this));
     ipcMain.handle('get-file-search-max-suggestions', this.handleGetFileSearchMaxSuggestions.bind(this));
+    ipcMain.handle('execute-shortcut-command', this.handleExecuteShortcutCommand.bind(this));
   }
 
   removeHandlers(ipcMain: typeof import('electron').ipcMain): void {
-    const handlers = ['get-app-info', 'get-config', 'open-settings', 'open-settings-directory', 'get-file-search-max-suggestions'];
+    const handlers = ['get-app-info', 'get-config', 'open-settings', 'open-settings-directory', 'get-file-search-max-suggestions', 'execute-shortcut-command'];
 
     handlers.forEach(handler => {
       ipcMain.removeAllListeners(handler);
@@ -159,6 +167,56 @@ class SystemHandler {
     } catch (error) {
       logger.error('Failed to get fileSearch maxSuggestions:', error);
       return 50; // Default fallback
+    }
+  }
+
+  /**
+   * Handler: execute-shortcut-command
+   * Runs a shell command bound to a "run=" shortcut from settings.yaml.
+   * Resolves {projectdir} and other supported template variables, executes
+   * fire-and-forget with the active CWD, and returns immediately.
+   */
+  private async handleExecuteShortcutCommand(
+    _event: IpcMainInvokeEvent,
+    command: string
+  ): Promise<IPCResult> {
+    if (!command || typeof command !== 'string') {
+      return { success: false, error: 'Invalid command' };
+    }
+
+    try {
+      const projectdir = this.directoryManager.getDirectory() ?? '';
+      // shellQuote is applied only to resolved template variable values (e.g. {projectdir}),
+      // not to the literal command parts written by the user in settings.yaml.
+      // This protects paths with spaces/quotes while leaving the command structure intact.
+      const resolvedCommand = resolveTemplate(
+        command,
+        { basename: '', frontmatter: {}, projectdir },
+        shellQuote
+      );
+
+      logger.info('Executing shortcut command', { commandLength: resolvedCommand.length });
+
+      exec(resolvedCommand, {
+        timeout: 30000,
+        env: getEnhancedEnv(this.settingsManager.getAdditionalPaths()),
+        ...(projectdir && { cwd: projectdir })
+      }, (error, _stdout, stderr) => {
+        if (error) {
+          logger.error('Shortcut command execution failed', {
+            error: error.message,
+            stderr: stderr?.trim() || undefined
+          });
+        } else if (stderr?.trim()) {
+          logger.warn('Shortcut command produced stderr', { stderr: stderr.trim() });
+        }
+      });
+
+      return { success: true };
+    } catch (error) {
+      const message = (error as Error).message;
+      logger.error('Failed to start shortcut command:', error);
+      return { success: false, error: message };
     }
   }
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -87,6 +87,8 @@ const ALLOWED_CHANNELS = [
   'get-custom-search-last-change',
   // Custom search command execution
   'execute-custom-search-command',
+  // Shortcut "run=" command execution
+  'execute-shortcut-command',
   // Settings update notification channel
   'settings-updated',
   // Custom search update notification channel
@@ -356,6 +358,13 @@ const electronAPI: ElectronAPI = {
   shell: {
     openExternal: async (url: string): Promise<{ success: boolean; error?: string }> => {
       return ipcRenderer.invoke('open-external-url', url);
+    }
+  },
+
+  // Shortcut "run=" command execution
+  shortcut: {
+    exec: async (command: string): Promise<IPCResult> => {
+      return ipcRenderer.invoke('execute-shortcut-command', command);
     }
   },
 

--- a/src/renderer/event-handler.ts
+++ b/src/renderer/event-handler.ts
@@ -48,6 +48,7 @@ export class EventHandler implements IInitializable {
     onUndo: () => boolean;
     onSaveDraftToHistory: () => Promise<void>;
     onCustomSearchActivate: (triggerText: string) => void;
+    onRunCommand: (command: string) => Promise<void>;
   }) {
     this.onTabKeyInsert = callbacks.onTabKeyInsert;
     this.onShiftTabKeyPress = callbacks.onShiftTabKeyPress;
@@ -86,6 +87,10 @@ export class EventHandler implements IInitializable {
 
   public setCustomSearchShortcuts(shortcuts: Array<{ shortcut: string; triggerText: string }>): void {
     this.shortcutHandler.setCustomSearchShortcuts(shortcuts);
+  }
+
+  public setRunShortcuts(shortcuts: Array<{ shortcut: string; command: string }>): void {
+    this.shortcutHandler.setRunShortcuts(shortcuts);
   }
 
   /**

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -170,7 +170,8 @@ export class PromptLineRenderer {
       onSearchToggle: this.handleSearchToggle.bind(this),
       onUndo: this.handleUndo.bind(this),
       onSaveDraftToHistory: this.handleSaveDraftToHistory.bind(this),
-      onCustomSearchActivate: this.handleCustomSearchActivate.bind(this)
+      onCustomSearchActivate: this.handleCustomSearchActivate.bind(this),
+      onRunCommand: this.handleRunCommand.bind(this)
     });
 
     this.eventHandler.setTextarea(this.domManager.textarea);
@@ -672,22 +673,45 @@ export class PromptLineRenderer {
   }
 
   /**
-   * Extract shortcut entries from customSearch settings and pass to event handler
+   * Execute a "run=" shortcut command via main process and close the window.
+   * Fire-and-forget: the window always closes after the IPC roundtrip,
+   * regardless of command success/failure (errors are logged to ~/.prompt-line/app.log).
+   * This matches the typical use case (launching an editor, opening a folder).
+   */
+  private async handleRunCommand(command: string): Promise<void> {
+    try {
+      const result = await electronAPI.shortcut.exec(command);
+      if (!result.success) {
+        rendererLogger.error('Shortcut command execution failed:', result.error);
+      }
+    } catch (error) {
+      rendererLogger.error('Failed to invoke shortcut command:', error);
+    }
+    await this.handleWindowHideCallback();
+  }
+
+  /**
+   * Extract shortcut entries from customShortcuts and dispatch to event handler.
+   * Supported action prefixes:
+   *   "input=<text>" — insert <text> into the textarea (and trigger custom-search detection)
+   *   "run=<command>" — execute <command> as a shell command (template variables allowed)
    */
   private updateCustomSearchShortcuts(): void {
-    const shortcuts: Array<{ shortcut: string; triggerText: string }> = [];
+    const customSearchShortcuts: Array<{ shortcut: string; triggerText: string }> = [];
+    const runShortcuts: Array<{ shortcut: string; command: string }> = [];
 
-    // Settings custom shortcuts (from {key: action} format, e.g., Ctrl+m: "input=@md:")
     if (this.userSettings?.customShortcuts) {
       for (const { key, action } of this.userSettings.customShortcuts) {
         if (action.startsWith('input=')) {
-          const triggerText = action.slice('input='.length);
-          shortcuts.push({ shortcut: key, triggerText });
+          customSearchShortcuts.push({ shortcut: key, triggerText: action.slice('input='.length) });
+        } else if (action.startsWith('run=')) {
+          runShortcuts.push({ shortcut: key, command: action.slice('run='.length) });
         }
       }
     }
 
-    this.eventHandler?.setCustomSearchShortcuts(shortcuts);
+    this.eventHandler?.setCustomSearchShortcuts(customSearchShortcuts);
+    this.eventHandler?.setRunShortcuts(runShortcuts);
   }
 
   // Search functionality callbacks

--- a/src/renderer/shortcut-handler.ts
+++ b/src/renderer/shortcut-handler.ts
@@ -16,6 +16,7 @@ export class ShortcutHandler {
   private fileSearchManager: { isActive(): boolean } | null = null;
   private userSettings: UserSettings | null = null;
   private customSearchShortcuts: Array<{ shortcut: string; triggerText: string }> = [];
+  private runShortcuts: Array<{ shortcut: string; command: string }> = [];
   private onTextPaste: (text: string) => Promise<void>;
   private onWindowHide: () => Promise<void>;
   private onTabKeyInsert: (e: KeyboardEvent) => void;
@@ -25,6 +26,7 @@ export class ShortcutHandler {
   private onUndo: () => boolean;
   private onSaveDraftToHistory: () => Promise<void>;
   private onCustomSearchActivate: (triggerText: string) => void;
+  private onRunCommand: (command: string) => Promise<void>;
 
   constructor(callbacks: {
     onTextPaste: (text: string) => Promise<void>;
@@ -36,6 +38,7 @@ export class ShortcutHandler {
     onUndo: () => boolean;
     onSaveDraftToHistory: () => Promise<void>;
     onCustomSearchActivate: (triggerText: string) => void;
+    onRunCommand: (command: string) => Promise<void>;
   }) {
     this.onTextPaste = callbacks.onTextPaste;
     this.onWindowHide = callbacks.onWindowHide;
@@ -46,6 +49,7 @@ export class ShortcutHandler {
     this.onUndo = callbacks.onUndo;
     this.onSaveDraftToHistory = callbacks.onSaveDraftToHistory;
     this.onCustomSearchActivate = callbacks.onCustomSearchActivate;
+    this.onRunCommand = callbacks.onRunCommand;
   }
 
   public setTextarea(textarea: HTMLTextAreaElement | null): void {
@@ -70,6 +74,10 @@ export class ShortcutHandler {
 
   public setCustomSearchShortcuts(shortcuts: Array<{ shortcut: string; triggerText: string }>): void {
     this.customSearchShortcuts = shortcuts;
+  }
+
+  public setRunShortcuts(shortcuts: Array<{ shortcut: string; command: string }>): void {
+    this.runShortcuts = shortcuts;
   }
 
   public setIsComposing(isComposing: boolean): void {
@@ -126,6 +134,11 @@ export class ShortcutHandler {
 
     // Handle custom search shortcuts (e.g., Ctrl+g → @ghq:)
     if (this.handleCustomSearchShortcuts(e)) {
+      return true;
+    }
+
+    // Handle "run=" shortcuts (e.g., Ctrl+e → run shell command)
+    if (await this.handleRunShortcuts(e)) {
       return true;
     }
 
@@ -289,6 +302,27 @@ export class ShortcutHandler {
       if (matchesShortcutString(e, shortcut)) {
         e.preventDefault();
         this.onCustomSearchActivate(triggerText);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async handleRunShortcuts(e: KeyboardEvent): Promise<boolean> {
+    if (this.runShortcuts.length === 0) {
+      return false;
+    }
+
+    // Skip if IME is active
+    if (this.isComposing || e.isComposing) {
+      return false;
+    }
+
+    for (const { shortcut, command } of this.runShortcuts) {
+      if (matchesShortcutString(e, shortcut)) {
+        e.preventDefault();
+        await this.onRunCommand(command);
         return true;
       }
     }

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -260,6 +260,9 @@ export interface ElectronAPI {
   shell: {
     openExternal: (url: string) => Promise<IPCResult>;
   };
+  shortcut: {
+    exec: (command: string) => Promise<IPCResult>;
+  };
   codeSearch: {
     checkRg: () => Promise<RgCheckResult>;
     getSupportedLanguages: () => Promise<{ languages: SupportedLanguage[] }>;

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -657,11 +657,11 @@ describe('IPCHandlers', () => {
 
             ipcHandlers.removeAllHandlers();
 
-            // Should be called for each handler (count: 47 handlers)
+            // Should be called for each handler (count: 48 handlers)
             // paste-handler: 2, window-handler: 3, history-draft-handler: 14 (includes 2 at-path cache handlers + save-draft-to-history)
-            // system-handler: 5, file-handler: 4 (includes reveal-in-finder), custom-search-handler: 13 (includes has-command-file + 3 slash command cache handlers + invalidate-custom-search + execute-custom-search-command + get-custom-search-last-change), code-search-handler: 1
+            // system-handler: 6 (includes execute-shortcut-command), file-handler: 4 (includes reveal-in-finder), custom-search-handler: 13 (includes has-command-file + 3 slash command cache handlers + invalidate-custom-search + execute-custom-search-command + get-custom-search-last-change), code-search-handler: 1
             // usage-history-handler: 6 (record/get bonuses for file, symbol, agent)
-            expect(ipcMain.removeAllListeners).toHaveBeenCalledTimes(47);
+            expect(ipcMain.removeAllListeners).toHaveBeenCalledTimes(48);
             expect(logger.info).toHaveBeenCalledWith('All IPC handlers removed via coordinator');
         });
     });


### PR DESCRIPTION
## Summary

- Add a new `run=<shell command>` shortcut action so users can bind shell commands to keyboard shortcuts in `settings.yaml` (mirrors the existing `input=...` style).
- Example: `Ctrl+e: "run=code {projectdir}"` launches VS Code in the active project directory and closes the prompt window.
- `{projectdir}` (and other `template-resolver` variables) expand via `resolveTemplate` with `shellQuote`, so paths containing spaces or quotes stay shell-safe.
- Execution is fire-and-forget through a new `execute-shortcut-command` IPC handler on `SystemHandler`: 30 s timeout, `getEnhancedEnv()` for PATH augmentation, `cwd` set to the active project dir, errors logged to `~/.prompt-line/app.log`.

## Why

The existing `input=@prefix:` action only inserts text into the textarea. A common workflow — open the current directory in an external tool — required no convenient shortcut. `run=` closes that gap with the smallest possible surface area while reusing all of the existing template-resolution / shell-quoting / env-augmentation utilities.

## Implementation notes

- No changes to `SettingsManager`: unknown action strings already flow into `customShortcuts: [{ key, action }]`. The renderer splits them on prefix in `updateCustomSearchShortcuts()`.
- `ShortcutHandler` gets a sibling `handleRunShortcuts()` next to the existing `handleCustomSearchShortcuts()` (kept symmetric rather than abstracted — only two cases, YAGNI).
- `SystemHandler` was the most natural home (system-level, not paste / not custom-search-allowlist). Constructor now takes `DirectoryManager` to read the CWD.
- No allowlist check on the command string: unlike `execute-custom-search-command` (where a renderer-supplied string must match a loaded item), `run=` commands originate from the user's own `settings.yaml`, so the trust boundary differs.
- Window auto-closes after the IPC roundtrip regardless of success — matches the typical "launch & dismiss" UX (errors still surface in the log).

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — 1350 tests pass (1 skipped). Updated `tests/unit/ipc-handlers.test.ts` handler count from 47 → 48.
- [x] `pnpm run lint` — 0 errors (only pre-existing warnings)
- [x] `pnpm run compile` — full build (tsc + Vite + Swift native tools) succeeds
- [x] `pnpm run generate:settings-example` — regenerated `settings.example.yaml` with `run=` example
- [ ] Manual: bind `Ctrl+e: "run=code {projectdir}"` in `settings.yaml`, focus a project window, trigger the shortcut, confirm the editor opens at the right directory and the prompt window closes
- [ ] Manual: bind a deliberately failing command (e.g. `run=nonexistent-cmd`), confirm the window still closes and the error is in `~/.prompt-line/app.log`
- [ ] Manual: confirm `input=@md:` etc. still work unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)