### PR TITLE
fix(paste): preserve image-path prompts when pasting into Claude Code on cmux/Ghostty/WezTerm

### DIFF
--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -11,6 +11,7 @@ import {
   checkAccessibilityPermission,
   SecureErrors
 } from '../utils/utils';
+import { sendShiftEnterToFocusedApp } from '../utils/native-tools/paste-operations';
 import { isITerm2, getITermSessionId, isCmux, isGhostty, isWezTerm } from '../utils/native-tools/app-detection';
 import type WindowManager from '../managers/window';
 import type DraftManager from '../managers/draft-manager';
@@ -38,7 +39,7 @@ const SEGMENT_PASTE_DELAY_MS = 80;
 const CLIPBOARD_SETTLE_DELAY_MS = 30;
 
 export interface PasteSegment {
-  type: 'text' | 'image';
+  type: 'text' | 'image' | 'newline';
   content: string;
 }
 
@@ -60,6 +61,26 @@ export function splitTextByImagePaths(text: string): PasteSegment[] {
     segments.push({ type: 'text', content: text.slice(lastIndex) });
   }
   return segments;
+}
+
+// Split paste text into image paths, newlines, and text runs without newlines.
+// Newlines become explicit `newline` segments so the paster can replace them
+// with Shift+Enter keystrokes — Claude Code's TUI treats a pasted newline as
+// submit, but Shift+Enter inserts a soft newline.
+export function splitTextForClaudeCodeTerminal(text: string): PasteSegment[] {
+  const result: PasteSegment[] = [];
+  const lines = text.split('\n');
+  lines.forEach((line, idx) => {
+    if (line.length > 0) {
+      for (const seg of splitTextByImagePaths(line)) {
+        result.push(seg);
+      }
+    }
+    if (idx < lines.length - 1) {
+      result.push({ type: 'newline', content: '' });
+    }
+  });
+  return result;
 }
 
 function isClaudeCodeTerminal(app: AppInfo | string | null): boolean {
@@ -139,13 +160,13 @@ class PasteHandler {
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
-      if (isClaudeCodeTerminal(previousApp)) {
-        const segments = splitTextByImagePaths(text);
-        if (segments.length > 1) {
-          await this.pasteSegments(previousApp, segments);
-          return { success: true };
-        }
+      if (isClaudeCodeTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
+        IMAGE_PATH_REGEX.lastIndex = 0;
+        const segments = splitTextForClaudeCodeTerminal(text);
+        await this.pasteSegments(previousApp, segments);
+        return { success: true };
       }
+      IMAGE_PATH_REGEX.lastIndex = 0;
       await activateAndPasteWithNativeTool(previousApp, text);
       return { success: true };
     }
@@ -169,27 +190,23 @@ class PasteHandler {
   }
 
   /**
-   * Paste segments one by one, refreshing the clipboard between each so
-   * Claude Code sees each image path as its own paste and converts it to
-   * `[Image #N]`. Trailing newline-only/whitespace-only segments after the
-   * last image are skipped to avoid leaving an empty Enter at the end.
+   * Paste segments one by one. Image paths and text runs go through the
+   * normal paste path (refreshing the clipboard each time so Claude Code
+   * sees each image path as its own paste and converts it to `[Image #N]`).
+   * `newline` segments are sent as Shift+Enter keystrokes so Claude Code
+   * inserts a soft newline instead of treating it as submit.
    */
   private async pasteSegments(previousApp: AppInfo | string, segments: PasteSegment[]): Promise<void> {
-    const lastImageIdx = segments.reduceRight(
-      (acc, seg, idx) => (acc === -1 && seg.type === 'image' ? idx : acc),
-      -1
-    );
-
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i]!;
-      const isAfterLastImage = lastImageIdx !== -1 && i > lastImageIdx;
-      const content = isAfterLastImage ? segment.content.replace(/^\s+/, '') : segment.content;
-      if (!content) continue;
-
-      clipboard.clear();
-      clipboard.writeText(content);
-      await sleep(CLIPBOARD_SETTLE_DELAY_MS);
-      await activateAndPasteWithNativeTool(previousApp, content);
+      if (segment.type === 'newline') {
+        await sendShiftEnterToFocusedApp();
+      } else if (segment.content) {
+        clipboard.clear();
+        clipboard.writeText(segment.content);
+        await sleep(CLIPBOARD_SETTLE_DELAY_MS);
+        await activateAndPasteWithNativeTool(previousApp, segment.content);
+      }
       if (i < segments.length - 1) {
         await sleep(SEGMENT_PASTE_DELAY_MS);
       }

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -92,9 +92,8 @@ class PasteHandler {
 
   /**
    * Execute paste operation with proper app handling.
-   * For cmux/Ghostty, the text is sent directly via AppleScript `input text`
-   * to bypass NSPasteboard; for other apps, the system clipboard set earlier
-   * by setClipboardAsync drives the paste.
+   * cmux/Ghostty go via AppleScript `paste_from_clipboard` (text from clipboard);
+   * WezTerm via `wezterm cli send-text` (text from argument); others via Cmd+V.
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -33,7 +33,16 @@ const MAX_PASTE_TEXT_LENGTH_BYTES = 1024 * 1024; // 1MB limit for paste text
 // when it appears in the same paste alongside other text. Splitting the
 // text into alternating text/path segments lets each path arrive as its
 // own paste so the conversion fires for each one.
-const IMAGE_PATH_REGEX = /(\S+\.(?:png|jpg|jpeg|gif|webp))/gi;
+// Match image paths in two flavors:
+//   (a) `/<path>` or `@<path>` — directory portion may contain spaces, e.g.
+//       `/Users/me/My Pictures/foo.png` or `@My Images/foo.png` (Prompt Line
+//       generates paths like `@<imagesDirectory>/<timestamp>.<ext>` so a
+//       user-configured imagesDirectory with spaces lands here verbatim).
+//       Lazy match stops at the first `.<ext>` preceded by a non-whitespace
+//       character, so a sentence like `これは /foo.png のテスト` only
+//       captures `/foo.png`.
+//   (b) `<non-whitespace>.<ext>` — a plain filename or path without spaces.
+const IMAGE_PATH_REGEX = /([/@][^\n]*?\S\.(?:png|jpg|jpeg|gif|webp)|\S+\.(?:png|jpg|jpeg|gif|webp))/gi;
 // Time between segments. Empirically, anything below ~30ms causes the next
 // paste to occasionally be merged into the previous one by Claude Code.
 const SEGMENT_PASTE_DELAY_MS = 40;

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -11,7 +11,6 @@ import {
   checkAccessibilityPermission,
   SecureErrors
 } from '../utils/utils';
-import { sendShiftEnterToFocusedApp } from '../utils/native-tools/paste-operations';
 import { isITerm2, getITermSessionId, isCmux, isGhostty, isWezTerm } from '../utils/native-tools/app-detection';
 import type WindowManager from '../managers/window';
 import type DraftManager from '../managers/draft-manager';
@@ -44,10 +43,15 @@ const SEGMENT_PASTE_DELAY_MS = 40;
 const CLIPBOARD_SETTLE_DELAY_MS = 10;
 
 export interface PasteSegment {
-  type: 'text' | 'image' | 'newline';
+  type: 'text' | 'image';
   content: string;
 }
 
+// Split paste text at image-path boundaries only. Newlines stay inside text
+// segments — pasted newlines work fine in Claude Code; only the path-bearing
+// portion needs to arrive as its own paste so it gets converted to [Image #N]
+// without dragging the surrounding text into the conversion (which drops
+// content).
 export function splitTextByImagePaths(text: string): PasteSegment[] {
   const segments: PasteSegment[] = [];
   let lastIndex = 0;
@@ -66,26 +70,6 @@ export function splitTextByImagePaths(text: string): PasteSegment[] {
     segments.push({ type: 'text', content: text.slice(lastIndex) });
   }
   return segments;
-}
-
-// Split paste text into image paths, newlines, and text runs without newlines.
-// Newlines become explicit `newline` segments so the paster can replace them
-// with Shift+Enter keystrokes — Claude Code's TUI treats a pasted newline as
-// submit, but Shift+Enter inserts a soft newline.
-export function splitTextForClaudeCodeTerminal(text: string): PasteSegment[] {
-  const result: PasteSegment[] = [];
-  const lines = text.split('\n');
-  lines.forEach((line, idx) => {
-    if (line.length > 0) {
-      for (const seg of splitTextByImagePaths(line)) {
-        result.push(seg);
-      }
-    }
-    if (idx < lines.length - 1) {
-      result.push({ type: 'newline', content: '' });
-    }
-  });
-  return result;
 }
 
 // cmux/Ghostty/WezTerm + Claude Code triggers an image-path-dropped-when-
@@ -173,9 +157,11 @@ class PasteHandler {
     if (previousApp && config.platform.isMac) {
       if (isClaudeCodeAffectedTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
         IMAGE_PATH_REGEX.lastIndex = 0;
-        const segments = splitTextForClaudeCodeTerminal(text);
-        await this.pasteSegments(previousApp, segments);
-        return { success: true };
+        const segments = splitTextByImagePaths(text);
+        if (segments.length > 1) {
+          await this.pasteSegments(previousApp, segments);
+          return { success: true };
+        }
       }
       IMAGE_PATH_REGEX.lastIndex = 0;
       await activateAndPasteWithNativeTool(previousApp);
@@ -210,14 +196,11 @@ class PasteHandler {
   private async pasteSegments(previousApp: AppInfo | string, segments: PasteSegment[]): Promise<void> {
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i]!;
-      if (segment.type === 'newline') {
-        await sendShiftEnterToFocusedApp();
-      } else if (segment.content) {
-        clipboard.clear();
-        clipboard.writeText(segment.content);
-        await sleep(CLIPBOARD_SETTLE_DELAY_MS);
-        await activateAndPasteWithNativeTool(previousApp);
-      }
+      if (!segment.content) continue;
+      clipboard.clear();
+      clipboard.writeText(segment.content);
+      await sleep(CLIPBOARD_SETTLE_DELAY_MS);
+      await activateAndPasteWithNativeTool(previousApp);
       if (i < segments.length - 1) {
         await sleep(SEGMENT_PASTE_DELAY_MS);
       }

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -35,8 +35,13 @@ const MAX_PASTE_TEXT_LENGTH_BYTES = 1024 * 1024; // 1MB limit for paste text
 // text into alternating text/path segments lets each path arrive as its
 // own paste so the conversion fires for each one.
 const IMAGE_PATH_REGEX = /(\S+\.(?:png|jpg|jpeg|gif|webp))/gi;
-const SEGMENT_PASTE_DELAY_MS = 80;
-const CLIPBOARD_SETTLE_DELAY_MS = 30;
+// Time between segments. Empirically, anything below ~30ms causes the next
+// paste to occasionally be merged into the previous one by Claude Code.
+const SEGMENT_PASTE_DELAY_MS = 40;
+// Time after writing the clipboard before triggering the AppleScript paste.
+// macOS NSPasteboard updates are synchronous from Electron's perspective but
+// the receiving terminal needs a moment to observe the change.
+const CLIPBOARD_SETTLE_DELAY_MS = 10;
 
 export interface PasteSegment {
   type: 'text' | 'image' | 'newline';

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -147,13 +147,14 @@ class PasteHandler {
 
   private async handlePasteText(_event: IpcMainInvokeEvent, text: string): Promise<PasteResult> {
     try {
-      logger.info('Paste text requested', { length: text.length });
+      const previousApp = await this.getPreviousAppAsync();
+      const appName = this.extractAppName(previousApp);
+      const previousBundleId = previousApp && typeof previousApp === 'object' ? previousApp.bundleId : null;
+      logger.info('Paste text requested', { length: text.length, appName, bundleId: previousBundleId });
 
       const validationError = this.validatePasteInput(text);
       if (validationError) return validationError;
 
-      const previousApp = await this.getPreviousAppAsync();
-      const appName = this.extractAppName(previousApp);
       const directory = this.directoryManager.getDirectory() || undefined;
       await Promise.all([
         (async () => {
@@ -274,7 +275,11 @@ class PasteHandler {
 
       const buffer = image.toPNG();
       await fs.writeFile(pathValidation.normalizedPath, buffer, { mode: 0o600 });
-      clipboard.writeText('');
+      // Use clear() not writeText('') — writeText only replaces the text type,
+      // leaving image formats (TIFF/PNG/AVIF…) on NSPasteboard. Stale image
+      // data prevents subsequent paste-from-clipboard calls from delivering
+      // the prompt text.
+      clipboard.clear();
 
       logger.info('Image saved successfully', { filepath: pathValidation.normalizedPath, relativePrefix });
       const result: { success: boolean; path: string; relativePath?: string } = { success: true, path: pathValidation.normalizedPath };
@@ -289,6 +294,11 @@ class PasteHandler {
   private async setClipboardAsync(text: string): Promise<void> {
     return new Promise((resolve) => {
       try {
+        // Clear all pasteboard types before writing text. clipboard.writeText
+        // alone may leave image formats from a prior copy on NSPasteboard,
+        // which can cause Cmd+V or paste_from_clipboard to deliver stale
+        // image data to the target terminal instead of the prompt text.
+        clipboard.clear();
         clipboard.writeText(text);
         resolve();
       } catch (error) {

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -155,15 +155,13 @@ class PasteHandler {
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
-      if (isClaudeCodeAffectedTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
-        IMAGE_PATH_REGEX.lastIndex = 0;
+      if (isClaudeCodeAffectedTerminal(previousApp)) {
         const segments = splitTextByImagePaths(text);
         if (segments.length > 1) {
           await this.pasteSegments(previousApp, segments);
           return { success: true };
         }
       }
-      IMAGE_PATH_REGEX.lastIndex = 0;
       await activateAndPasteWithNativeTool(previousApp);
       return { success: true };
     }

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -12,7 +12,7 @@ import {
   SecureErrors
 } from '../utils/utils';
 import { sendShiftEnterToFocusedApp } from '../utils/native-tools/paste-operations';
-import { isITerm2, getITermSessionId, isCmux, isGhostty, isWezTerm } from '../utils/native-tools/app-detection';
+import { isITerm2, getITermSessionId, isCmux } from '../utils/native-tools/app-detection';
 import type WindowManager from '../managers/window';
 import type DraftManager from '../managers/draft-manager';
 import type DirectoryManager from '../managers/directory-manager';
@@ -72,7 +72,7 @@ export function splitTextByImagePaths(text: string): PasteSegment[] {
 // Newlines become explicit `newline` segments so the paster can replace them
 // with Shift+Enter keystrokes — Claude Code's TUI treats a pasted newline as
 // submit, but Shift+Enter inserts a soft newline.
-export function splitTextForClaudeCodeTerminal(text: string): PasteSegment[] {
+export function splitTextForCmuxTerminal(text: string): PasteSegment[] {
   const result: PasteSegment[] = [];
   const lines = text.split('\n');
   lines.forEach((line, idx) => {
@@ -88,8 +88,12 @@ export function splitTextForClaudeCodeTerminal(text: string): PasteSegment[] {
   return result;
 }
 
-function isClaudeCodeTerminal(app: AppInfo | string | null): boolean {
-  return isCmux(app) || isGhostty(app) || isWezTerm(app);
+// Only cmux needs segmented paste because (a) it can't use Cmd+V CGEvent
+// (parent NSApp consumes it) and (b) when paste goes through cmux's
+// AppleScript bridge, Claude Code interprets pasted newlines as submit.
+// Ghostty/WezTerm/iTerm2 work fine with the standard Cmd+V CGEvent path.
+function isCmuxTerminal(app: AppInfo | string | null): boolean {
+  return isCmux(app);
 }
 
 class PasteHandler {
@@ -165,14 +169,14 @@ class PasteHandler {
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
-      if (isClaudeCodeTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
+      if (isCmuxTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
         IMAGE_PATH_REGEX.lastIndex = 0;
-        const segments = splitTextForClaudeCodeTerminal(text);
+        const segments = splitTextForCmuxTerminal(text);
         await this.pasteSegments(previousApp, segments);
         return { success: true };
       }
       IMAGE_PATH_REGEX.lastIndex = 0;
-      await activateAndPasteWithNativeTool(previousApp, text);
+      await activateAndPasteWithNativeTool(previousApp);
       return { success: true };
     }
 
@@ -210,7 +214,7 @@ class PasteHandler {
         clipboard.clear();
         clipboard.writeText(segment.content);
         await sleep(CLIPBOARD_SETTLE_DELAY_MS);
-        await activateAndPasteWithNativeTool(previousApp, segment.content);
+        await activateAndPasteWithNativeTool(previousApp);
       }
       if (i < segments.length - 1) {
         await sleep(SEGMENT_PASTE_DELAY_MS);

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -147,11 +147,12 @@ class PasteHandler {
 
   /**
    * Execute paste operation with proper app handling.
-   * cmux/Ghostty go via AppleScript `paste_from_clipboard` (text from clipboard);
-   * WezTerm via `wezterm cli send-text` (text from argument); others via Cmd+V.
-   * For Claude Code-capable terminals, paste the text in alternating
-   * text/image-path segments so Claude Code converts each path to an
-   * `[Image #N]` token (it drops paths when mixed with other text in one paste).
+   * cmux goes via AppleScript `paste_from_clipboard` (Cmd+V CGEvent doesn't
+   * reach its embedded Ghostty PTY); Ghostty/WezTerm/iTerm2/others all use
+   * keyboard-simulator Cmd+V CGEvent. For cmux/Ghostty/WezTerm + Claude Code,
+   * paste the text in alternating text/image-path segments so Claude Code
+   * converts each path to an `[Image #N]` token (it drops paths when mixed
+   * with other text in a single paste).
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
@@ -185,11 +186,10 @@ class PasteHandler {
   }
 
   /**
-   * Paste segments one by one. Image paths and text runs go through the
-   * normal paste path (refreshing the clipboard each time so Claude Code
-   * sees each image path as its own paste and converts it to `[Image #N]`).
-   * `newline` segments are sent as Shift+Enter keystrokes so Claude Code
-   * inserts a soft newline instead of treating it as submit.
+   * Paste segments one by one, refreshing the clipboard between each so
+   * Claude Code sees each image path as its own paste and converts it to
+   * `[Image #N]` (mixing a path with surrounding text in one paste makes
+   * Claude Code drop the surrounding text).
    */
   private async pasteSegments(previousApp: AppInfo | string, segments: PasteSegment[]): Promise<void> {
     for (let i = 0; i < segments.length; i++) {

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -11,7 +11,7 @@ import {
   checkAccessibilityPermission,
   SecureErrors
 } from '../utils/utils';
-import { isITerm2, getITermSessionId } from '../utils/native-tools/app-detection';
+import { isITerm2, getITermSessionId, isCmux, isGhostty, isWezTerm } from '../utils/native-tools/app-detection';
 import type WindowManager from '../managers/window';
 import type DraftManager from '../managers/draft-manager';
 import type DirectoryManager from '../managers/directory-manager';
@@ -26,6 +26,45 @@ interface PasteResult {
 
 // Constants
 const MAX_PASTE_TEXT_LENGTH_BYTES = 1024 * 1024; // 1MB limit for paste text
+
+// Image extensions used to split paste content for terminals where Claude
+// Code (or similar TUIs) may be running. Claude Code converts a paste that
+// is *only* an image path into an `[Image #N]` token, but drops the path
+// when it appears in the same paste alongside other text. Splitting the
+// text into alternating text/path segments lets each path arrive as its
+// own paste so the conversion fires for each one.
+const IMAGE_PATH_REGEX = /(\S+\.(?:png|jpg|jpeg|gif|webp))/gi;
+const SEGMENT_PASTE_DELAY_MS = 80;
+const CLIPBOARD_SETTLE_DELAY_MS = 30;
+
+export interface PasteSegment {
+  type: 'text' | 'image';
+  content: string;
+}
+
+export function splitTextByImagePaths(text: string): PasteSegment[] {
+  const segments: PasteSegment[] = [];
+  let lastIndex = 0;
+  IMAGE_PATH_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = IMAGE_PATH_REGEX.exec(text)) !== null) {
+    const matched = match[1];
+    if (matched === undefined) continue;
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: 'image', content: matched });
+    lastIndex = match.index + matched.length;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', content: text.slice(lastIndex) });
+  }
+  return segments;
+}
+
+function isClaudeCodeTerminal(app: AppInfo | string | null): boolean {
+  return isCmux(app) || isGhostty(app) || isWezTerm(app);
+}
 
 class PasteHandler {
   private windowManager: WindowManager;
@@ -94,9 +133,19 @@ class PasteHandler {
    * Execute paste operation with proper app handling.
    * cmux/Ghostty go via AppleScript `paste_from_clipboard` (text from clipboard);
    * WezTerm via `wezterm cli send-text` (text from argument); others via Cmd+V.
+   * For Claude Code-capable terminals, paste the text in alternating
+   * text/image-path segments so Claude Code converts each path to an
+   * `[Image #N]` token (it drops paths when mixed with other text in one paste).
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
+      if (isClaudeCodeTerminal(previousApp)) {
+        const segments = splitTextByImagePaths(text);
+        if (segments.length > 1) {
+          await this.pasteSegments(previousApp, segments);
+          return { success: true };
+        }
+      }
       await activateAndPasteWithNativeTool(previousApp, text);
       return { success: true };
     }
@@ -117,6 +166,34 @@ class PasteHandler {
 
     logger.warn('Auto-paste not supported on this platform');
     return { success: true, warning: 'Auto-paste not supported on this platform' };
+  }
+
+  /**
+   * Paste segments one by one, refreshing the clipboard between each so
+   * Claude Code sees each image path as its own paste and converts it to
+   * `[Image #N]`. Trailing newline-only/whitespace-only segments after the
+   * last image are skipped to avoid leaving an empty Enter at the end.
+   */
+  private async pasteSegments(previousApp: AppInfo | string, segments: PasteSegment[]): Promise<void> {
+    const lastImageIdx = segments.reduceRight(
+      (acc, seg, idx) => (acc === -1 && seg.type === 'image' ? idx : acc),
+      -1
+    );
+
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]!;
+      const isAfterLastImage = lastImageIdx !== -1 && i > lastImageIdx;
+      const content = isAfterLastImage ? segment.content.replace(/^\s+/, '') : segment.content;
+      if (!content) continue;
+
+      clipboard.clear();
+      clipboard.writeText(content);
+      await sleep(CLIPBOARD_SETTLE_DELAY_MS);
+      await activateAndPasteWithNativeTool(previousApp, content);
+      if (i < segments.length - 1) {
+        await sleep(SEGMENT_PASTE_DELAY_MS);
+      }
+    }
   }
 
   /**

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -91,11 +91,14 @@ class PasteHandler {
   }
 
   /**
-   * Execute paste operation with proper app handling
+   * Execute paste operation with proper app handling.
+   * For cmux/Ghostty, the text is sent directly via AppleScript `input text`
+   * to bypass NSPasteboard; for other apps, the system clipboard set earlier
+   * by setClipboardAsync drives the paste.
    */
-  private async executePasteOperation(previousApp: AppInfo | string | null): Promise<PasteResult> {
+  private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
-      await activateAndPasteWithNativeTool(previousApp);
+      await activateAndPasteWithNativeTool(previousApp, text);
       return { success: true };
     }
 
@@ -165,7 +168,7 @@ class PasteHandler {
       await sleep(Math.max(config.timing.windowHideDelay, 5));
 
       try {
-        return await this.executePasteOperation(previousApp);
+        return await this.executePasteOperation(previousApp, text);
       } catch (pasteError) {
         return await this.handlePasteError(pasteError as Error);
       }

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -12,7 +12,7 @@ import {
   SecureErrors
 } from '../utils/utils';
 import { sendShiftEnterToFocusedApp } from '../utils/native-tools/paste-operations';
-import { isITerm2, getITermSessionId, isCmux } from '../utils/native-tools/app-detection';
+import { isITerm2, getITermSessionId, isCmux, isGhostty, isWezTerm } from '../utils/native-tools/app-detection';
 import type WindowManager from '../managers/window';
 import type DraftManager from '../managers/draft-manager';
 import type DirectoryManager from '../managers/directory-manager';
@@ -72,7 +72,7 @@ export function splitTextByImagePaths(text: string): PasteSegment[] {
 // Newlines become explicit `newline` segments so the paster can replace them
 // with Shift+Enter keystrokes — Claude Code's TUI treats a pasted newline as
 // submit, but Shift+Enter inserts a soft newline.
-export function splitTextForCmuxTerminal(text: string): PasteSegment[] {
+export function splitTextForClaudeCodeTerminal(text: string): PasteSegment[] {
   const result: PasteSegment[] = [];
   const lines = text.split('\n');
   lines.forEach((line, idx) => {
@@ -88,12 +88,14 @@ export function splitTextForCmuxTerminal(text: string): PasteSegment[] {
   return result;
 }
 
-// Only cmux needs segmented paste because (a) it can't use Cmd+V CGEvent
-// (parent NSApp consumes it) and (b) when paste goes through cmux's
-// AppleScript bridge, Claude Code interprets pasted newlines as submit.
-// Ghostty/WezTerm/iTerm2 work fine with the standard Cmd+V CGEvent path.
-function isCmuxTerminal(app: AppInfo | string | null): boolean {
-  return isCmux(app);
+// cmux/Ghostty/WezTerm + Claude Code triggers an image-path-dropped-when-
+// mixed-with-text bug that is NOT reproducible on iTerm2, even though the
+// underlying paste mechanism (Cmd+V CGEvent) is identical for Ghostty/
+// WezTerm. The exact terminal-side cause is unclear (likely subtle
+// differences in bracketed-paste timing/chunking), so we apply the same
+// segmented paste workaround used for cmux.
+function isClaudeCodeAffectedTerminal(app: AppInfo | string | null): boolean {
+  return isCmux(app) || isGhostty(app) || isWezTerm(app);
 }
 
 class PasteHandler {
@@ -169,9 +171,9 @@ class PasteHandler {
    */
   private async executePasteOperation(previousApp: AppInfo | string | null, text: string): Promise<PasteResult> {
     if (previousApp && config.platform.isMac) {
-      if (isCmuxTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
+      if (isClaudeCodeAffectedTerminal(previousApp) && IMAGE_PATH_REGEX.test(text)) {
         IMAGE_PATH_REGEX.lastIndex = 0;
-        const segments = splitTextForCmuxTerminal(text);
+        const segments = splitTextForClaudeCodeTerminal(text);
         await this.pasteSegments(previousApp, segments);
         return { success: true };
       }

--- a/src/utils/native-tools/app-detection.ts
+++ b/src/utils/native-tools/app-detection.ts
@@ -9,6 +9,7 @@ import { WINDOW_DETECTOR_PATH } from './paths';
 const ITERM2_BUNDLE_ID = 'com.googlecode.iterm2';
 const CMUX_BUNDLE_ID = 'com.cmuxterm.app';
 const GHOSTTY_BUNDLE_ID = 'com.mitchellh.ghostty';
+const WEZTERM_BUNDLE_ID = 'com.github.wez.wezterm';
 
 // Accessibility permission check result
 interface AccessibilityStatus {
@@ -196,10 +197,10 @@ export function isCmux(app: AppInfo | string | null): boolean {
 
 /**
  * Check if the given AppInfo or app name string represents Ghostty.
- * Ghostty needs the same AppleScript-based paste path as cmux because
- * macOS NSPasteboard can retain image formats after `clipboard.writeText('')`,
- * which causes Cmd+V CGEvents to deliver stale image data (or nothing) to
- * the terminal when the user pastes a prompt that contains an image path.
+ * Ghostty needs the AppleScript paste_from_clipboard path so the paste goes
+ * through the terminal's pipeline with bracketed paste markers — required for
+ * TUI apps like Claude Code to receive embedded newlines as paste data
+ * rather than Enter keystrokes.
  */
 export function isGhostty(app: AppInfo | string | null): boolean {
   if (!app) return false;
@@ -207,6 +208,21 @@ export function isGhostty(app: AppInfo | string | null): boolean {
     return app.toLowerCase() === 'ghostty';
   }
   return app.bundleId === GHOSTTY_BUNDLE_ID;
+}
+
+/**
+ * Check if the given AppInfo or app name string represents WezTerm.
+ * WezTerm has no AppleScript dictionary, but its CLI `wezterm cli send-text`
+ * sends bracketed paste when the target pane has bracketed paste mode on.
+ * Direct CGEvent Cmd+V into WezTerm has been observed to drop content after
+ * the first newline in TUI apps (e.g. Claude Code), so we route through the CLI.
+ */
+export function isWezTerm(app: AppInfo | string | null): boolean {
+  if (!app) return false;
+  if (typeof app === 'string') {
+    return app.toLowerCase() === 'wezterm';
+  }
+  return app.bundleId === WEZTERM_BUNDLE_ID;
 }
 
 /**

--- a/src/utils/native-tools/app-detection.ts
+++ b/src/utils/native-tools/app-detection.ts
@@ -8,6 +8,7 @@ import { WINDOW_DETECTOR_PATH } from './paths';
 
 const ITERM2_BUNDLE_ID = 'com.googlecode.iterm2';
 const CMUX_BUNDLE_ID = 'com.cmuxterm.app';
+const GHOSTTY_BUNDLE_ID = 'com.mitchellh.ghostty';
 
 // Accessibility permission check result
 interface AccessibilityStatus {
@@ -191,6 +192,21 @@ export function isCmux(app: AppInfo | string | null): boolean {
     return app.toLowerCase() === 'cmux';
   }
   return app.bundleId === CMUX_BUNDLE_ID;
+}
+
+/**
+ * Check if the given AppInfo or app name string represents Ghostty.
+ * Ghostty needs the same AppleScript-based paste path as cmux because
+ * macOS NSPasteboard can retain image formats after `clipboard.writeText('')`,
+ * which causes Cmd+V CGEvents to deliver stale image data (or nothing) to
+ * the terminal when the user pastes a prompt that contains an image path.
+ */
+export function isGhostty(app: AppInfo | string | null): boolean {
+  if (!app) return false;
+  if (typeof app === 'string') {
+    return app.toLowerCase() === 'ghostty';
+  }
+  return app.bundleId === GHOSTTY_BUNDLE_ID;
 }
 
 /**

--- a/src/utils/native-tools/app-detection.ts
+++ b/src/utils/native-tools/app-detection.ts
@@ -8,8 +8,6 @@ import { WINDOW_DETECTOR_PATH } from './paths';
 
 const ITERM2_BUNDLE_ID = 'com.googlecode.iterm2';
 const CMUX_BUNDLE_ID = 'com.cmuxterm.app';
-const GHOSTTY_BUNDLE_ID = 'com.mitchellh.ghostty';
-const WEZTERM_BUNDLE_ID = 'com.github.wez.wezterm';
 
 // Accessibility permission check result
 interface AccessibilityStatus {
@@ -193,36 +191,6 @@ export function isCmux(app: AppInfo | string | null): boolean {
     return app.toLowerCase() === 'cmux';
   }
   return app.bundleId === CMUX_BUNDLE_ID;
-}
-
-/**
- * Check if the given AppInfo or app name string represents Ghostty.
- * Ghostty needs the AppleScript paste_from_clipboard path so the paste goes
- * through the terminal's pipeline with bracketed paste markers — required for
- * TUI apps like Claude Code to receive embedded newlines as paste data
- * rather than Enter keystrokes.
- */
-export function isGhostty(app: AppInfo | string | null): boolean {
-  if (!app) return false;
-  if (typeof app === 'string') {
-    return app.toLowerCase() === 'ghostty';
-  }
-  return app.bundleId === GHOSTTY_BUNDLE_ID;
-}
-
-/**
- * Check if the given AppInfo or app name string represents WezTerm.
- * WezTerm has no AppleScript dictionary, but its CLI `wezterm cli send-text`
- * sends bracketed paste when the target pane has bracketed paste mode on.
- * Direct CGEvent Cmd+V into WezTerm has been observed to drop content after
- * the first newline in TUI apps (e.g. Claude Code), so we route through the CLI.
- */
-export function isWezTerm(app: AppInfo | string | null): boolean {
-  if (!app) return false;
-  if (typeof app === 'string') {
-    return app.toLowerCase() === 'wezterm';
-  }
-  return app.bundleId === WEZTERM_BUNDLE_ID;
 }
 
 /**

--- a/src/utils/native-tools/app-detection.ts
+++ b/src/utils/native-tools/app-detection.ts
@@ -8,6 +8,8 @@ import { WINDOW_DETECTOR_PATH } from './paths';
 
 const ITERM2_BUNDLE_ID = 'com.googlecode.iterm2';
 const CMUX_BUNDLE_ID = 'com.cmuxterm.app';
+const GHOSTTY_BUNDLE_ID = 'com.mitchellh.ghostty';
+const WEZTERM_BUNDLE_ID = 'com.github.wez.wezterm';
 
 // Accessibility permission check result
 interface AccessibilityStatus {
@@ -191,6 +193,33 @@ export function isCmux(app: AppInfo | string | null): boolean {
     return app.toLowerCase() === 'cmux';
   }
   return app.bundleId === CMUX_BUNDLE_ID;
+}
+
+/**
+ * Check if the given AppInfo or app name string represents Ghostty.
+ * Ghostty + Cmd+V CGEvent works differently from iTerm2 in a way that causes
+ * Claude Code to drop image paths when mixed with text in a single paste.
+ * Marked here so the paste handler can apply segmented paste as a workaround.
+ */
+export function isGhostty(app: AppInfo | string | null): boolean {
+  if (!app) return false;
+  if (typeof app === 'string') {
+    return app.toLowerCase() === 'ghostty';
+  }
+  return app.bundleId === GHOSTTY_BUNDLE_ID;
+}
+
+/**
+ * Check if the given AppInfo or app name string represents WezTerm.
+ * Same issue as Ghostty: Cmd+V CGEvent + Claude Code drops image paths when
+ * mixed with text. Marked here so the paste handler applies segmented paste.
+ */
+export function isWezTerm(app: AppInfo | string | null): boolean {
+  if (!app) return false;
+  if (typeof app === 'string') {
+    return app.toLowerCase() === 'wezterm';
+  }
+  return app.bundleId === WEZTERM_BUNDLE_ID;
 }
 
 /**

--- a/src/utils/native-tools/paste-operations.ts
+++ b/src/utils/native-tools/paste-operations.ts
@@ -89,28 +89,6 @@ function pasteFromClipboardCmux(): Promise<void> {
   });
 }
 
-// Send a Shift+Enter keystroke to the focused app via System Events. Used to
-// produce a newline inside Claude Code's TUI input without firing the
-// Enter-as-submit handler (Claude Code reads pasted newlines as submit, but
-// honors Shift+Enter as a soft newline).
-export function sendShiftEnterToFocusedApp(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const options = {
-      timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
-      killSignal: 'SIGTERM' as const
-    };
-    const script = 'tell application "System Events" to keystroke return using shift down';
-    execFile('osascript', ['-e', script], options, (error, _stdout, stderr) => {
-      if (error) {
-        logger.error('Failed to send Shift+Enter:', { error: error.message, stderr });
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
 export function activateAndPasteWithNativeTool(appInfo: AppInfo | string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (process.platform !== 'darwin') {

--- a/src/utils/native-tools/paste-operations.ts
+++ b/src/utils/native-tools/paste-operations.ts
@@ -4,28 +4,26 @@ import { TIMEOUTS } from '../../constants';
 import { logger } from '../logger';
 import { sanitizeCommandArgument, isCommandArgumentSafe } from '../security';
 import { KEYBOARD_SIMULATOR_PATH } from './paths';
-import { isCmux, isGhostty } from './app-detection';
+import { isCmux, isGhostty, isWezTerm } from './app-detection';
 
-// Both cmux (`CmuxInTx`) and Ghostty (`GhstInTx`) expose an `input text` AppleScript
-// command that pastes text directly into the focused terminal as if it were
-// a paste, without consulting the system clipboard. We use this instead of
-// `paste_from_clipboard` (cmux's prior path) or CGEvent Cmd+V (Ghostty's
-// prior path) because macOS NSPasteboard can retain image formats (TIFF/PNG/
-// AVIF…) after Electron's `clipboard.writeText('')`, causing the terminal
-// to receive stale image data — or nothing — when the user pastes a prompt
-// that contains an image path. Sending the text via `input text` sidesteps
-// the clipboard entirely.
+const WEZTERM_BINARY_PATH = '/Applications/WezTerm.app/Contents/MacOS/wezterm';
+
+// cmux (`CmuxPfAc`) and Ghostty (`GhstPfAc`) both expose `perform action`
+// with the `paste_from_clipboard` action string. We use this rather than
+// `input text` because `input text` does NOT wrap with bracketed paste
+// markers (`ESC[200~`/`ESC[201~`), causing TUI apps like Claude Code to
+// interpret embedded newlines as Enter and submit prematurely — chopping
+// off everything after the first newline. `paste_from_clipboard` is
+// equivalent to a real Cmd+V and goes through the terminal's standard
+// paste pipeline, which respects bracketed paste mode.
 //
-// We pass the user's text via osascript's `argv` rather than embedding it in
-// the script body so that backslashes, quotes, and newlines do not need to
-// be re-escaped by us — AppleScript receives them verbatim.
-const INPUT_TEXT_APPLESCRIPT = (appName: string): string =>
-  'on run argv\n' +
-  `  tell application "${appName}"\n` +
-  '    activate\n' +
-  '    input text (item 1 of argv) to focused terminal of selected tab of front window\n' +
-  '  end tell\n' +
-  'end run';
+// The image-residue issue that motivated bypassing the clipboard is now
+// handled by `clipboard.clear()` in paste-handler.ts before each paste.
+const PASTE_FROM_CLIPBOARD_APPLESCRIPT = (appName: string): string =>
+  `tell application "${appName}"\n` +
+  '  activate\n' +
+  '  perform action "paste_from_clipboard" on focused terminal of selected tab of front window\n' +
+  'end tell';
 
 export function pasteWithNativeTool(): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -75,17 +73,17 @@ export function pasteWithNativeTool(): Promise<void> {
   });
 }
 
-function inputTextToTerminal(targetApp: 'cmux' | 'Ghostty', text: string): Promise<void> {
+function pasteFromClipboardInTerminal(targetApp: 'cmux' | 'Ghostty'): Promise<void> {
   return new Promise((resolve, reject) => {
     const options = {
       timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
       killSignal: 'SIGTERM' as const
     };
 
-    const script = INPUT_TEXT_APPLESCRIPT(targetApp);
-    execFile('osascript', ['-e', script, '--', text], options, (error, _stdout, stderr) => {
+    const script = PASTE_FROM_CLIPBOARD_APPLESCRIPT(targetApp);
+    execFile('osascript', ['-e', script], options, (error, _stdout, stderr) => {
       if (error) {
-        logger.error(`${targetApp} AppleScript input text failed:`, {
+        logger.error(`${targetApp} AppleScript paste_from_clipboard failed:`, {
           error: error.message,
           code: error.code,
           signal: error.signal,
@@ -95,6 +93,41 @@ function inputTextToTerminal(targetApp: 'cmux' | 'Ghostty', text: string): Promi
         return;
       }
       resolve();
+    });
+  });
+}
+
+// `wezterm cli send-text` reads text from stdin and sends it to the active
+// pane. It uses bracketed paste when the pane has the mode enabled, which is
+// what Claude Code and other TUI apps need to keep embedded newlines from
+// being treated as Enter.
+function pasteToWezTerm(text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
+      killSignal: 'SIGTERM' as const
+    };
+
+    execFile('osascript', ['-e', 'tell application "WezTerm" to activate'], { timeout: 1000, killSignal: 'SIGTERM' as const }, (activateErr) => {
+      if (activateErr) {
+        logger.warn('WezTerm activate failed (continuing with paste):', activateErr.message);
+      }
+
+      const proc = execFile(WEZTERM_BINARY_PATH, ['cli', 'send-text'], options, (error, _stdout, stderr) => {
+        if (error) {
+          logger.error('WezTerm cli send-text failed:', {
+            error: error.message,
+            code: error.code,
+            signal: error.signal,
+            stderr,
+            executable: WEZTERM_BINARY_PATH
+          });
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+      proc.stdin?.end(text, 'utf8');
     });
   });
 }
@@ -120,16 +153,23 @@ export function activateAndPasteWithNativeTool(appInfo: AppInfo | string, text: 
       return;
     }
 
-    // cmux and Ghostty: route through AppleScript `input text` to bypass the
-    // system pasteboard. macOS retains image formats on NSPasteboard even after
-    // `clipboard.writeText('')`, which can cause Cmd+V / paste_from_clipboard to
-    // deliver the residual image instead of the prompt text.
+    // cmux/Ghostty: AppleScript `paste_from_clipboard` action runs through
+    // the terminal's standard paste pipeline and is wrapped in bracketed
+    // paste markers. WezTerm: `wezterm cli send-text` does the same via
+    // stdin. Both routes are required because direct CGEvent Cmd+V into
+    // these apps has been observed to skip bracketed paste, causing TUI
+    // apps (e.g. Claude Code) to interpret embedded newlines as Enter and
+    // truncate the paste at the first newline.
     if (isCmux(appInfo)) {
-      inputTextToTerminal('cmux', text).then(resolve).catch(reject);
+      pasteFromClipboardInTerminal('cmux').then(resolve).catch(reject);
       return;
     }
     if (isGhostty(appInfo)) {
-      inputTextToTerminal('Ghostty', text).then(resolve).catch(reject);
+      pasteFromClipboardInTerminal('Ghostty').then(resolve).catch(reject);
+      return;
+    }
+    if (isWezTerm(appInfo)) {
+      pasteToWezTerm(text).then(resolve).catch(reject);
       return;
     }
 

--- a/src/utils/native-tools/paste-operations.ts
+++ b/src/utils/native-tools/paste-operations.ts
@@ -4,23 +4,16 @@ import { TIMEOUTS } from '../../constants';
 import { logger } from '../logger';
 import { sanitizeCommandArgument, isCommandArgumentSafe } from '../security';
 import { KEYBOARD_SIMULATOR_PATH } from './paths';
-import { isCmux, isGhostty, isWezTerm } from './app-detection';
+import { isCmux } from './app-detection';
 
-const WEZTERM_BINARY_PATH = '/Applications/WezTerm.app/Contents/MacOS/wezterm';
-
-// cmux (`CmuxPfAc`) and Ghostty (`GhstPfAc`) both expose `perform action`
-// with the `paste_from_clipboard` action string. We use this rather than
-// `input text` because `input text` does NOT wrap with bracketed paste
-// markers (`ESC[200~`/`ESC[201~`), causing TUI apps like Claude Code to
-// interpret embedded newlines as Enter and submit prematurely — chopping
-// off everything after the first newline. `paste_from_clipboard` is
-// equivalent to a real Cmd+V and goes through the terminal's standard
-// paste pipeline, which respects bracketed paste mode.
-//
-// The image-residue issue that motivated bypassing the clipboard is now
-// handled by `clipboard.clear()` in paste-handler.ts before each paste.
-const PASTE_FROM_CLIPBOARD_APPLESCRIPT = (appName: string): string =>
-  `tell application "${appName}"\n` +
+// cmux embeds Ghostty as a subprocess and the parent NSApplication consumes
+// Cmd+V CGEvents before they reach the focused PTY. We bypass keyboard-
+// simulator entirely and route activation + paste through cmux's AppleScript
+// dictionary, which forwards `paste_from_clipboard` to Ghostty's native
+// action handler. (Ghostty/WezTerm don't need this — Cmd+V CGEvent reaches
+// their PTY directly.)
+const CMUX_PASTE_APPLESCRIPT =
+  'tell application "cmux"\n' +
   '  activate\n' +
   '  perform action "paste_from_clipboard" on focused terminal of selected tab of front window\n' +
   'end tell';
@@ -73,17 +66,16 @@ export function pasteWithNativeTool(): Promise<void> {
   });
 }
 
-function pasteFromClipboardInTerminal(targetApp: 'cmux' | 'Ghostty'): Promise<void> {
+function pasteFromClipboardCmux(): Promise<void> {
   return new Promise((resolve, reject) => {
     const options = {
       timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
       killSignal: 'SIGTERM' as const
     };
 
-    const script = PASTE_FROM_CLIPBOARD_APPLESCRIPT(targetApp);
-    execFile('osascript', ['-e', script], options, (error, _stdout, stderr) => {
+    execFile('osascript', ['-e', CMUX_PASTE_APPLESCRIPT], options, (error, _stdout, stderr) => {
       if (error) {
-        logger.error(`${targetApp} AppleScript paste_from_clipboard failed:`, {
+        logger.error('cmux AppleScript paste_from_clipboard failed:', {
           error: error.message,
           code: error.code,
           signal: error.signal,
@@ -93,41 +85,6 @@ function pasteFromClipboardInTerminal(targetApp: 'cmux' | 'Ghostty'): Promise<vo
         return;
       }
       resolve();
-    });
-  });
-}
-
-// `wezterm cli send-text` reads text from stdin and sends it to the active
-// pane. It uses bracketed paste when the pane has the mode enabled, which is
-// what Claude Code and other TUI apps need to keep embedded newlines from
-// being treated as Enter.
-function pasteToWezTerm(text: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const options = {
-      timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
-      killSignal: 'SIGTERM' as const
-    };
-
-    execFile('osascript', ['-e', 'tell application "WezTerm" to activate'], { timeout: 1000, killSignal: 'SIGTERM' as const }, (activateErr) => {
-      if (activateErr) {
-        logger.warn('WezTerm activate failed (continuing with paste):', activateErr.message);
-      }
-
-      const proc = execFile(WEZTERM_BINARY_PATH, ['cli', 'send-text'], options, (error, _stdout, stderr) => {
-        if (error) {
-          logger.error('WezTerm cli send-text failed:', {
-            error: error.message,
-            code: error.code,
-            signal: error.signal,
-            stderr,
-            executable: WEZTERM_BINARY_PATH
-          });
-          reject(error);
-          return;
-        }
-        resolve();
-      });
-      proc.stdin?.end(text, 'utf8');
     });
   });
 }
@@ -154,7 +111,7 @@ export function sendShiftEnterToFocusedApp(): Promise<void> {
   });
 }
 
-export function activateAndPasteWithNativeTool(appInfo: AppInfo | string, text: string): Promise<void> {
+export function activateAndPasteWithNativeTool(appInfo: AppInfo | string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (process.platform !== 'darwin') {
       reject(new Error('Native paste only supported on macOS'));
@@ -175,23 +132,12 @@ export function activateAndPasteWithNativeTool(appInfo: AppInfo | string, text: 
       return;
     }
 
-    // cmux/Ghostty: AppleScript `paste_from_clipboard` action runs through
-    // the terminal's standard paste pipeline and is wrapped in bracketed
-    // paste markers. WezTerm: `wezterm cli send-text` does the same via
-    // stdin. Both routes are required because direct CGEvent Cmd+V into
-    // these apps has been observed to skip bracketed paste, causing TUI
-    // apps (e.g. Claude Code) to interpret embedded newlines as Enter and
-    // truncate the paste at the first newline.
+    // cmux requires AppleScript `paste_from_clipboard` because Cmd+V CGEvent
+    // does not reach its embedded Ghostty PTY (parent NSApp consumes it).
+    // Ghostty/WezTerm work fine with the standard keyboard-simulator path
+    // below (same as iTerm2), so they fall through.
     if (isCmux(appInfo)) {
-      pasteFromClipboardInTerminal('cmux').then(resolve).catch(reject);
-      return;
-    }
-    if (isGhostty(appInfo)) {
-      pasteFromClipboardInTerminal('Ghostty').then(resolve).catch(reject);
-      return;
-    }
-    if (isWezTerm(appInfo)) {
-      pasteToWezTerm(text).then(resolve).catch(reject);
+      pasteFromClipboardCmux().then(resolve).catch(reject);
       return;
     }
 

--- a/src/utils/native-tools/paste-operations.ts
+++ b/src/utils/native-tools/paste-operations.ts
@@ -4,17 +4,28 @@ import { TIMEOUTS } from '../../constants';
 import { logger } from '../logger';
 import { sanitizeCommandArgument, isCommandArgumentSafe } from '../security';
 import { KEYBOARD_SIMULATOR_PATH } from './paths';
-import { isCmux } from './app-detection';
+import { isCmux, isGhostty } from './app-detection';
 
-// cmux embeds Ghostty as a subprocess and the parent NSApplication consumes
-// Cmd+V CGEvents before they reach the focused PTY. We bypass keyboard-simulator
-// entirely and route activation + paste through cmux's AppleScript dictionary,
-// which forwards `paste_from_clipboard` to Ghostty's native action handler.
-const CMUX_PASTE_APPLESCRIPT =
-  'tell application "cmux"\n' +
-  '  activate\n' +
-  '  perform action "paste_from_clipboard" on focused terminal of selected tab of front window\n' +
-  'end tell';
+// Both cmux (`CmuxInTx`) and Ghostty (`GhstInTx`) expose an `input text` AppleScript
+// command that pastes text directly into the focused terminal as if it were
+// a paste, without consulting the system clipboard. We use this instead of
+// `paste_from_clipboard` (cmux's prior path) or CGEvent Cmd+V (Ghostty's
+// prior path) because macOS NSPasteboard can retain image formats (TIFF/PNG/
+// AVIF…) after Electron's `clipboard.writeText('')`, causing the terminal
+// to receive stale image data — or nothing — when the user pastes a prompt
+// that contains an image path. Sending the text via `input text` sidesteps
+// the clipboard entirely.
+//
+// We pass the user's text via osascript's `argv` rather than embedding it in
+// the script body so that backslashes, quotes, and newlines do not need to
+// be re-escaped by us — AppleScript receives them verbatim.
+const INPUT_TEXT_APPLESCRIPT = (appName: string): string =>
+  'on run argv\n' +
+  `  tell application "${appName}"\n` +
+  '    activate\n' +
+  '    input text (item 1 of argv) to focused terminal of selected tab of front window\n' +
+  '  end tell\n' +
+  'end run';
 
 export function pasteWithNativeTool(): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -64,16 +75,17 @@ export function pasteWithNativeTool(): Promise<void> {
   });
 }
 
-function activateAndPasteCmux(): Promise<void> {
+function inputTextToTerminal(targetApp: 'cmux' | 'Ghostty', text: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const options = {
       timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
       killSignal: 'SIGTERM' as const
     };
 
-    execFile('osascript', ['-e', CMUX_PASTE_APPLESCRIPT], options, (error, stdout, stderr) => {
+    const script = INPUT_TEXT_APPLESCRIPT(targetApp);
+    execFile('osascript', ['-e', script, '--', text], options, (error, _stdout, stderr) => {
       if (error) {
-        logger.error('cmux AppleScript paste failed:', {
+        logger.error(`${targetApp} AppleScript input text failed:`, {
           error: error.message,
           code: error.code,
           signal: error.signal,
@@ -82,16 +94,12 @@ function activateAndPasteCmux(): Promise<void> {
         reject(error);
         return;
       }
-
-      if (stdout.trim() !== 'true') {
-        logger.warn('cmux AppleScript paste returned non-true:', { stdout, stderr });
-      }
       resolve();
     });
   });
 }
 
-export function activateAndPasteWithNativeTool(appInfo: AppInfo | string): Promise<void> {
+export function activateAndPasteWithNativeTool(appInfo: AppInfo | string, text: string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (process.platform !== 'darwin') {
       reject(new Error('Native paste only supported on macOS'));
@@ -112,8 +120,16 @@ export function activateAndPasteWithNativeTool(appInfo: AppInfo | string): Promi
       return;
     }
 
+    // cmux and Ghostty: route through AppleScript `input text` to bypass the
+    // system pasteboard. macOS retains image formats on NSPasteboard even after
+    // `clipboard.writeText('')`, which can cause Cmd+V / paste_from_clipboard to
+    // deliver the residual image instead of the prompt text.
     if (isCmux(appInfo)) {
-      activateAndPasteCmux().then(resolve).catch(reject);
+      inputTextToTerminal('cmux', text).then(resolve).catch(reject);
+      return;
+    }
+    if (isGhostty(appInfo)) {
+      inputTextToTerminal('Ghostty', text).then(resolve).catch(reject);
       return;
     }
 

--- a/src/utils/native-tools/paste-operations.ts
+++ b/src/utils/native-tools/paste-operations.ts
@@ -132,6 +132,28 @@ function pasteToWezTerm(text: string): Promise<void> {
   });
 }
 
+// Send a Shift+Enter keystroke to the focused app via System Events. Used to
+// produce a newline inside Claude Code's TUI input without firing the
+// Enter-as-submit handler (Claude Code reads pasted newlines as submit, but
+// honors Shift+Enter as a soft newline).
+export function sendShiftEnterToFocusedApp(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      timeout: TIMEOUTS.ACTIVATE_PASTE_TIMEOUT,
+      killSignal: 'SIGTERM' as const
+    };
+    const script = 'tell application "System Events" to keystroke return using shift down';
+    execFile('osascript', ['-e', script], options, (error, _stdout, stderr) => {
+      if (error) {
+        logger.error('Failed to send Shift+Enter:', { error: error.message, stderr });
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 export function activateAndPasteWithNativeTool(appInfo: AppInfo | string, text: string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (process.platform !== 'darwin') {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -77,7 +77,9 @@ vi.mock('electron', () => ({
     },
     clipboard: {
         writeText: vi.fn(),
-        readText: vi.fn(() => '')
+        readText: vi.fn(() => ''),
+        clear: vi.fn(),
+        readImage: vi.fn(() => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) }))
     }
 }));
 

--- a/tests/unit/app-detection-iterm.test.ts
+++ b/tests/unit/app-detection-iterm.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../src/utils/native-tools/paths', () => ({
   WINDOW_DETECTOR_PATH: '/mock/window-detector'
 }));
 
-import { isITerm2, isCmux, getITermSessionId } from '../../src/utils/native-tools/app-detection';
+import { isITerm2, isCmux, isGhostty, getITermSessionId } from '../../src/utils/native-tools/app-detection';
 
 describe('isITerm2', () => {
   it('should return true for AppInfo with iTerm2 bundleId', () => {
@@ -84,6 +84,32 @@ describe('isCmux', () => {
     expect(isCmux('Terminal')).toBe(false);
     expect(isCmux({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
     expect(isCmux({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
+  });
+});
+
+describe('isGhostty', () => {
+  it('should return true for AppInfo with Ghostty bundleId', () => {
+    expect(isGhostty({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(true);
+  });
+
+  it('should return false for AppInfo with cmux bundleId', () => {
+    expect(isGhostty({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
+  });
+
+  it('should return true for string "ghostty" (case-insensitive)', () => {
+    expect(isGhostty('ghostty')).toBe(true);
+    expect(isGhostty('Ghostty')).toBe(true);
+    expect(isGhostty('GHOSTTY')).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isGhostty(null)).toBe(false);
+  });
+
+  it('should return false for other terminals', () => {
+    expect(isGhostty('Terminal')).toBe(false);
+    expect(isGhostty({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
+    expect(isGhostty({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
   });
 });
 

--- a/tests/unit/app-detection-iterm.test.ts
+++ b/tests/unit/app-detection-iterm.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../src/utils/native-tools/paths', () => ({
   WINDOW_DETECTOR_PATH: '/mock/window-detector'
 }));
 
-import { isITerm2, isCmux, isGhostty, isWezTerm, getITermSessionId } from '../../src/utils/native-tools/app-detection';
+import { isITerm2, isCmux, getITermSessionId } from '../../src/utils/native-tools/app-detection';
 
 describe('isITerm2', () => {
   it('should return true for AppInfo with iTerm2 bundleId', () => {
@@ -84,54 +84,6 @@ describe('isCmux', () => {
     expect(isCmux('Terminal')).toBe(false);
     expect(isCmux({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
     expect(isCmux({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
-  });
-});
-
-describe('isGhostty', () => {
-  it('should return true for AppInfo with Ghostty bundleId', () => {
-    expect(isGhostty({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(true);
-  });
-
-  it('should return false for AppInfo with cmux bundleId', () => {
-    expect(isGhostty({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
-  });
-
-  it('should return true for string "ghostty" (case-insensitive)', () => {
-    expect(isGhostty('ghostty')).toBe(true);
-    expect(isGhostty('Ghostty')).toBe(true);
-    expect(isGhostty('GHOSTTY')).toBe(true);
-  });
-
-  it('should return false for null', () => {
-    expect(isGhostty(null)).toBe(false);
-  });
-
-  it('should return false for other terminals', () => {
-    expect(isGhostty('Terminal')).toBe(false);
-    expect(isGhostty({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
-    expect(isGhostty({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
-  });
-});
-
-describe('isWezTerm', () => {
-  it('should return true for AppInfo with WezTerm bundleId', () => {
-    expect(isWezTerm({ name: 'WezTerm', bundleId: 'com.github.wez.wezterm' })).toBe(true);
-  });
-
-  it('should return true for string "wezterm" (case-insensitive)', () => {
-    expect(isWezTerm('wezterm')).toBe(true);
-    expect(isWezTerm('WezTerm')).toBe(true);
-    expect(isWezTerm('WEZTERM')).toBe(true);
-  });
-
-  it('should return false for null', () => {
-    expect(isWezTerm(null)).toBe(false);
-  });
-
-  it('should return false for other terminals', () => {
-    expect(isWezTerm({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
-    expect(isWezTerm({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
-    expect(isWezTerm({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
   });
 });
 

--- a/tests/unit/app-detection-iterm.test.ts
+++ b/tests/unit/app-detection-iterm.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../src/utils/native-tools/paths', () => ({
   WINDOW_DETECTOR_PATH: '/mock/window-detector'
 }));
 
-import { isITerm2, isCmux, isGhostty, getITermSessionId } from '../../src/utils/native-tools/app-detection';
+import { isITerm2, isCmux, isGhostty, isWezTerm, getITermSessionId } from '../../src/utils/native-tools/app-detection';
 
 describe('isITerm2', () => {
   it('should return true for AppInfo with iTerm2 bundleId', () => {
@@ -110,6 +110,28 @@ describe('isGhostty', () => {
     expect(isGhostty('Terminal')).toBe(false);
     expect(isGhostty({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
     expect(isGhostty({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
+  });
+});
+
+describe('isWezTerm', () => {
+  it('should return true for AppInfo with WezTerm bundleId', () => {
+    expect(isWezTerm({ name: 'WezTerm', bundleId: 'com.github.wez.wezterm' })).toBe(true);
+  });
+
+  it('should return true for string "wezterm" (case-insensitive)', () => {
+    expect(isWezTerm('wezterm')).toBe(true);
+    expect(isWezTerm('WezTerm')).toBe(true);
+    expect(isWezTerm('WEZTERM')).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isWezTerm(null)).toBe(false);
+  });
+
+  it('should return false for other terminals', () => {
+    expect(isWezTerm({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
+    expect(isWezTerm({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
+    expect(isWezTerm({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
   });
 });
 

--- a/tests/unit/app-detection-iterm.test.ts
+++ b/tests/unit/app-detection-iterm.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../src/utils/native-tools/paths', () => ({
   WINDOW_DETECTOR_PATH: '/mock/window-detector'
 }));
 
-import { isITerm2, isCmux, getITermSessionId } from '../../src/utils/native-tools/app-detection';
+import { isITerm2, isCmux, isGhostty, isWezTerm, getITermSessionId } from '../../src/utils/native-tools/app-detection';
 
 describe('isITerm2', () => {
   it('should return true for AppInfo with iTerm2 bundleId', () => {
@@ -84,6 +84,36 @@ describe('isCmux', () => {
     expect(isCmux('Terminal')).toBe(false);
     expect(isCmux({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
     expect(isCmux({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
+  });
+});
+
+describe('isGhostty', () => {
+  it('returns true for Ghostty bundleId', () => {
+    expect(isGhostty({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(true);
+  });
+  it('returns true for the string "ghostty" (case-insensitive)', () => {
+    expect(isGhostty('ghostty')).toBe(true);
+    expect(isGhostty('GHOSTTY')).toBe(true);
+  });
+  it('returns false for null or unrelated terminals', () => {
+    expect(isGhostty(null)).toBe(false);
+    expect(isGhostty({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
+    expect(isGhostty({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' })).toBe(false);
+  });
+});
+
+describe('isWezTerm', () => {
+  it('returns true for WezTerm bundleId', () => {
+    expect(isWezTerm({ name: 'WezTerm', bundleId: 'com.github.wez.wezterm' })).toBe(true);
+  });
+  it('returns true for the string "wezterm" (case-insensitive)', () => {
+    expect(isWezTerm('wezterm')).toBe(true);
+    expect(isWezTerm('WEZTERM')).toBe(true);
+  });
+  it('returns false for null or unrelated terminals', () => {
+    expect(isWezTerm(null)).toBe(false);
+    expect(isWezTerm({ name: 'cmux', bundleId: 'com.cmuxterm.app' })).toBe(false);
+    expect(isWezTerm({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' })).toBe(false);
   });
 });
 

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -23,12 +23,10 @@ vi.mock('../../src/utils/utils', () => ({
 vi.mock('../../src/utils/native-tools/app-detection', () => ({
   isITerm2: vi.fn(() => false),
   isCmux: vi.fn(() => false),
-  isGhostty: vi.fn(() => false),
-  isWezTerm: vi.fn(() => false),
   getITermSessionId: vi.fn()
 }));
 
-import { splitTextByImagePaths, splitTextForClaudeCodeTerminal } from '../../src/handlers/paste-handler';
+import { splitTextByImagePaths, splitTextForCmuxTerminal } from '../../src/handlers/paste-handler';
 
 describe('splitTextByImagePaths', () => {
   it('returns single text segment when no image path is present', () => {
@@ -91,9 +89,9 @@ describe('splitTextByImagePaths', () => {
   });
 });
 
-describe('splitTextForClaudeCodeTerminal', () => {
+describe('splitTextForCmuxTerminal', () => {
   it('splits text + newline + image into three segments', () => {
-    const segments = splitTextForClaudeCodeTerminal('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
+    const segments = splitTextForCmuxTerminal('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
     expect(segments).toEqual([
       { type: 'text', content: 'テスト' },
       { type: 'newline', content: '' },
@@ -102,7 +100,7 @@ describe('splitTextForClaudeCodeTerminal', () => {
   });
 
   it('keeps multiple newlines as multiple newline segments', () => {
-    const segments = splitTextForClaudeCodeTerminal('a\n\nb');
+    const segments = splitTextForCmuxTerminal('a\n\nb');
     expect(segments).toEqual([
       { type: 'text', content: 'a' },
       { type: 'newline', content: '' },
@@ -112,12 +110,12 @@ describe('splitTextForClaudeCodeTerminal', () => {
   });
 
   it('handles a single image path with no surrounding text', () => {
-    const segments = splitTextForClaudeCodeTerminal('/Users/x/foo.png');
+    const segments = splitTextForCmuxTerminal('/Users/x/foo.png');
     expect(segments).toEqual([{ type: 'image', content: '/Users/x/foo.png' }]);
   });
 
   it('handles trailing newline by emitting only the newline segment', () => {
-    const segments = splitTextForClaudeCodeTerminal('hello\n');
+    const segments = splitTextForCmuxTerminal('hello\n');
     expect(segments).toEqual([
       { type: 'text', content: 'hello' },
       { type: 'newline', content: '' }
@@ -125,7 +123,7 @@ describe('splitTextForClaudeCodeTerminal', () => {
   });
 
   it('handles leading newline correctly', () => {
-    const segments = splitTextForClaudeCodeTerminal('\n/path.png');
+    const segments = splitTextForCmuxTerminal('\n/path.png');
     expect(segments).toEqual([
       { type: 'newline', content: '' },
       { type: 'image', content: '/path.png' }
@@ -133,7 +131,7 @@ describe('splitTextForClaudeCodeTerminal', () => {
   });
 
   it('intersperses newlines between image paths on separate lines', () => {
-    const segments = splitTextForClaudeCodeTerminal('text\n/a.png\nmore\n/b.jpg');
+    const segments = splitTextForCmuxTerminal('text\n/a.png\nmore\n/b.jpg');
     expect(segments).toEqual([
       { type: 'text', content: 'text' },
       { type: 'newline', content: '' },

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../src/utils/native-tools/app-detection', () => ({
   getITermSessionId: vi.fn()
 }));
 
-import { splitTextByImagePaths } from '../../src/handlers/paste-handler';
+import { splitTextByImagePaths, splitTextForClaudeCodeTerminal } from '../../src/handlers/paste-handler';
 
 describe('splitTextByImagePaths', () => {
   it('returns single text segment when no image path is present', () => {
@@ -88,5 +88,60 @@ describe('splitTextByImagePaths', () => {
   it('does not match non-image extensions', () => {
     const segments = splitTextByImagePaths('config.json and main.ts');
     expect(segments).toEqual([{ type: 'text', content: 'config.json and main.ts' }]);
+  });
+});
+
+describe('splitTextForClaudeCodeTerminal', () => {
+  it('splits text + newline + image into three segments', () => {
+    const segments = splitTextForClaudeCodeTerminal('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
+    expect(segments).toEqual([
+      { type: 'text', content: 'テスト' },
+      { type: 'newline', content: '' },
+      { type: 'image', content: '/Users/nkmr/.prompt-line/images/foo.png' }
+    ]);
+  });
+
+  it('keeps multiple newlines as multiple newline segments', () => {
+    const segments = splitTextForClaudeCodeTerminal('a\n\nb');
+    expect(segments).toEqual([
+      { type: 'text', content: 'a' },
+      { type: 'newline', content: '' },
+      { type: 'newline', content: '' },
+      { type: 'text', content: 'b' }
+    ]);
+  });
+
+  it('handles a single image path with no surrounding text', () => {
+    const segments = splitTextForClaudeCodeTerminal('/Users/x/foo.png');
+    expect(segments).toEqual([{ type: 'image', content: '/Users/x/foo.png' }]);
+  });
+
+  it('handles trailing newline by emitting only the newline segment', () => {
+    const segments = splitTextForClaudeCodeTerminal('hello\n');
+    expect(segments).toEqual([
+      { type: 'text', content: 'hello' },
+      { type: 'newline', content: '' }
+    ]);
+  });
+
+  it('handles leading newline correctly', () => {
+    const segments = splitTextForClaudeCodeTerminal('\n/path.png');
+    expect(segments).toEqual([
+      { type: 'newline', content: '' },
+      { type: 'image', content: '/path.png' }
+    ]);
+  });
+
+  it('intersperses newlines between image paths on separate lines', () => {
+    const segments = splitTextForClaudeCodeTerminal('text\n/a.png\nmore\n/b.jpg');
+    expect(segments).toEqual([
+      { type: 'text', content: 'text' },
+      { type: 'newline', content: '' },
+      { type: 'image', content: '/a.png' },
+      { type: 'newline', content: '' },
+      { type: 'text', content: 'more' },
+      { type: 'newline', content: '' },
+      { type: 'image', content: '/b.jpg' }
+    ]);
   });
 });

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), removeAllListeners: vi.fn() },
+  clipboard: { writeText: vi.fn(), readImage: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  app: { getApplicationInfoForProtocol: vi.fn(), getAppPath: vi.fn(() => '') }
+}));
+
+vi.mock('../../src/config/app-config', () => ({
+  default: { platform: { isMac: true }, paths: { imagesDir: '/tmp' }, timing: {} }
+}));
+
+vi.mock('../../src/utils/utils', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  pasteWithNativeTool: vi.fn(),
+  activateAndPasteWithNativeTool: vi.fn(),
+  sleep: vi.fn(() => Promise.resolve()),
+  checkAccessibilityPermission: vi.fn(),
+  SecureErrors: {}
+}));
+
+vi.mock('../../src/utils/native-tools/app-detection', () => ({
+  isITerm2: vi.fn(() => false),
+  isCmux: vi.fn(() => false),
+  isGhostty: vi.fn(() => false),
+  isWezTerm: vi.fn(() => false),
+  getITermSessionId: vi.fn()
+}));
+
+import { splitTextByImagePaths } from '../../src/handlers/paste-handler';
+
+describe('splitTextByImagePaths', () => {
+  it('returns single text segment when no image path is present', () => {
+    const segments = splitTextByImagePaths('hello world');
+    expect(segments).toEqual([{ type: 'text', content: 'hello world' }]);
+  });
+
+  it('extracts a single image path with surrounding text', () => {
+    const segments = splitTextByImagePaths('テスト\n/Users/nkmr/.prompt-line/images/20260503_191755.png');
+    expect(segments).toEqual([
+      { type: 'text', content: 'テスト\n' },
+      { type: 'image', content: '/Users/nkmr/.prompt-line/images/20260503_191755.png' }
+    ]);
+  });
+
+  it('extracts an image path at the start with trailing text', () => {
+    const segments = splitTextByImagePaths('/Users/me/img.png describe this');
+    expect(segments).toEqual([
+      { type: 'image', content: '/Users/me/img.png' },
+      { type: 'text', content: ' describe this' }
+    ]);
+  });
+
+  it('extracts multiple image paths', () => {
+    const segments = splitTextByImagePaths('see /a.png and /b.jpg too');
+    expect(segments).toEqual([
+      { type: 'text', content: 'see ' },
+      { type: 'image', content: '/a.png' },
+      { type: 'text', content: ' and ' },
+      { type: 'image', content: '/b.jpg' },
+      { type: 'text', content: ' too' }
+    ]);
+  });
+
+  it('returns the path-only case as a single image segment', () => {
+    const segments = splitTextByImagePaths('/Users/x/photo.jpeg');
+    expect(segments).toEqual([{ type: 'image', content: '/Users/x/photo.jpeg' }]);
+  });
+
+  it('matches relative @-prefixed paths used by Prompt Line', () => {
+    const segments = splitTextByImagePaths('look at @images/20260503_191755.png please');
+    expect(segments).toEqual([
+      { type: 'text', content: 'look at ' },
+      { type: 'image', content: '@images/20260503_191755.png' },
+      { type: 'text', content: ' please' }
+    ]);
+  });
+
+  it('supports png/jpg/jpeg/gif/webp extensions', () => {
+    expect(splitTextByImagePaths('a.png')).toHaveLength(1);
+    expect(splitTextByImagePaths('a.jpg')).toHaveLength(1);
+    expect(splitTextByImagePaths('a.jpeg')).toHaveLength(1);
+    expect(splitTextByImagePaths('a.gif')).toHaveLength(1);
+    expect(splitTextByImagePaths('a.webp')).toHaveLength(1);
+  });
+
+  it('does not match non-image extensions', () => {
+    const segments = splitTextByImagePaths('config.json and main.ts');
+    expect(segments).toEqual([{ type: 'text', content: 'config.json and main.ts' }]);
+  });
+});

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -23,10 +23,12 @@ vi.mock('../../src/utils/utils', () => ({
 vi.mock('../../src/utils/native-tools/app-detection', () => ({
   isITerm2: vi.fn(() => false),
   isCmux: vi.fn(() => false),
+  isGhostty: vi.fn(() => false),
+  isWezTerm: vi.fn(() => false),
   getITermSessionId: vi.fn()
 }));
 
-import { splitTextByImagePaths, splitTextForCmuxTerminal } from '../../src/handlers/paste-handler';
+import { splitTextByImagePaths, splitTextForClaudeCodeTerminal } from '../../src/handlers/paste-handler';
 
 describe('splitTextByImagePaths', () => {
   it('returns single text segment when no image path is present', () => {
@@ -89,9 +91,9 @@ describe('splitTextByImagePaths', () => {
   });
 });
 
-describe('splitTextForCmuxTerminal', () => {
+describe('splitTextForClaudeCodeTerminal', () => {
   it('splits text + newline + image into three segments', () => {
-    const segments = splitTextForCmuxTerminal('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
+    const segments = splitTextForClaudeCodeTerminal('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
     expect(segments).toEqual([
       { type: 'text', content: 'テスト' },
       { type: 'newline', content: '' },
@@ -100,7 +102,7 @@ describe('splitTextForCmuxTerminal', () => {
   });
 
   it('keeps multiple newlines as multiple newline segments', () => {
-    const segments = splitTextForCmuxTerminal('a\n\nb');
+    const segments = splitTextForClaudeCodeTerminal('a\n\nb');
     expect(segments).toEqual([
       { type: 'text', content: 'a' },
       { type: 'newline', content: '' },
@@ -110,12 +112,12 @@ describe('splitTextForCmuxTerminal', () => {
   });
 
   it('handles a single image path with no surrounding text', () => {
-    const segments = splitTextForCmuxTerminal('/Users/x/foo.png');
+    const segments = splitTextForClaudeCodeTerminal('/Users/x/foo.png');
     expect(segments).toEqual([{ type: 'image', content: '/Users/x/foo.png' }]);
   });
 
   it('handles trailing newline by emitting only the newline segment', () => {
-    const segments = splitTextForCmuxTerminal('hello\n');
+    const segments = splitTextForClaudeCodeTerminal('hello\n');
     expect(segments).toEqual([
       { type: 'text', content: 'hello' },
       { type: 'newline', content: '' }
@@ -123,7 +125,7 @@ describe('splitTextForCmuxTerminal', () => {
   });
 
   it('handles leading newline correctly', () => {
-    const segments = splitTextForCmuxTerminal('\n/path.png');
+    const segments = splitTextForClaudeCodeTerminal('\n/path.png');
     expect(segments).toEqual([
       { type: 'newline', content: '' },
       { type: 'image', content: '/path.png' }
@@ -131,7 +133,7 @@ describe('splitTextForCmuxTerminal', () => {
   });
 
   it('intersperses newlines between image paths on separate lines', () => {
-    const segments = splitTextForCmuxTerminal('text\n/a.png\nmore\n/b.jpg');
+    const segments = splitTextForClaudeCodeTerminal('text\n/a.png\nmore\n/b.jpg');
     expect(segments).toEqual([
       { type: 'text', content: 'text' },
       { type: 'newline', content: '' },

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -89,6 +89,33 @@ describe('splitTextByImagePaths', () => {
     const segments = splitTextByImagePaths('config.json and main.ts');
     expect(segments).toEqual([{ type: 'text', content: 'config.json and main.ts' }]);
   });
+
+  it('captures absolute paths that contain spaces', () => {
+    const segments = splitTextByImagePaths('see /Users/me/My Pictures/foo.png please');
+    expect(segments).toEqual([
+      { type: 'text', content: 'see ' },
+      { type: 'image', content: '/Users/me/My Pictures/foo.png' },
+      { type: 'text', content: ' please' }
+    ]);
+  });
+
+  it('captures @-prefixed relative paths that contain spaces', () => {
+    const segments = splitTextByImagePaths('テスト @My Images/20260503_191755.png');
+    expect(segments).toEqual([
+      { type: 'text', content: 'テスト ' },
+      { type: 'image', content: '@My Images/20260503_191755.png' },
+      { type: 'text', content: '' }
+    ].filter(s => s.content.length > 0));
+  });
+
+  it('does not greedily swallow trailing prose after a path with spaces', () => {
+    const segments = splitTextByImagePaths('これは /foo.png のテストです');
+    expect(segments).toEqual([
+      { type: 'text', content: 'これは ' },
+      { type: 'image', content: '/foo.png' },
+      { type: 'text', content: ' のテストです' }
+    ]);
+  });
 });
 
 describe('splitTextByImagePaths — newlines stay inside text segments', () => {

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../src/utils/native-tools/app-detection', () => ({
   getITermSessionId: vi.fn()
 }));
 
-import { splitTextByImagePaths, splitTextForClaudeCodeTerminal } from '../../src/handlers/paste-handler';
+import { splitTextByImagePaths } from '../../src/handlers/paste-handler';
 
 describe('splitTextByImagePaths', () => {
   it('returns single text segment when no image path is present', () => {
@@ -91,56 +91,26 @@ describe('splitTextByImagePaths', () => {
   });
 });
 
-describe('splitTextForClaudeCodeTerminal', () => {
-  it('splits text + newline + image into three segments', () => {
-    const segments = splitTextForClaudeCodeTerminal('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
+describe('splitTextByImagePaths — newlines stay inside text segments', () => {
+  it('keeps newline-bearing prefix as one text segment, then image', () => {
+    const segments = splitTextByImagePaths('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
     expect(segments).toEqual([
-      { type: 'text', content: 'テスト' },
-      { type: 'newline', content: '' },
+      { type: 'text', content: 'テスト\n' },
       { type: 'image', content: '/Users/nkmr/.prompt-line/images/foo.png' }
     ]);
   });
 
-  it('keeps multiple newlines as multiple newline segments', () => {
-    const segments = splitTextForClaudeCodeTerminal('a\n\nb');
-    expect(segments).toEqual([
-      { type: 'text', content: 'a' },
-      { type: 'newline', content: '' },
-      { type: 'newline', content: '' },
-      { type: 'text', content: 'b' }
-    ]);
+  it('keeps multi-line text without image paths as a single text segment', () => {
+    const segments = splitTextByImagePaths('line1\nline2\nline3');
+    expect(segments).toEqual([{ type: 'text', content: 'line1\nline2\nline3' }]);
   });
 
-  it('handles a single image path with no surrounding text', () => {
-    const segments = splitTextForClaudeCodeTerminal('/Users/x/foo.png');
-    expect(segments).toEqual([{ type: 'image', content: '/Users/x/foo.png' }]);
-  });
-
-  it('handles trailing newline by emitting only the newline segment', () => {
-    const segments = splitTextForClaudeCodeTerminal('hello\n');
+  it('splits text/image/text-with-newlines correctly', () => {
+    const segments = splitTextByImagePaths('describe /a.png\nthen do X\nthen /b.jpg');
     expect(segments).toEqual([
-      { type: 'text', content: 'hello' },
-      { type: 'newline', content: '' }
-    ]);
-  });
-
-  it('handles leading newline correctly', () => {
-    const segments = splitTextForClaudeCodeTerminal('\n/path.png');
-    expect(segments).toEqual([
-      { type: 'newline', content: '' },
-      { type: 'image', content: '/path.png' }
-    ]);
-  });
-
-  it('intersperses newlines between image paths on separate lines', () => {
-    const segments = splitTextForClaudeCodeTerminal('text\n/a.png\nmore\n/b.jpg');
-    expect(segments).toEqual([
-      { type: 'text', content: 'text' },
-      { type: 'newline', content: '' },
+      { type: 'text', content: 'describe ' },
       { type: 'image', content: '/a.png' },
-      { type: 'newline', content: '' },
-      { type: 'text', content: 'more' },
-      { type: 'newline', content: '' },
+      { type: 'text', content: '\nthen do X\nthen ' },
       { type: 'image', content: '/b.jpg' }
     ]);
   });

--- a/tests/unit/paste-operations-cmux.test.ts
+++ b/tests/unit/paste-operations-cmux.test.ts
@@ -30,35 +30,57 @@ const ORIGINAL_PLATFORM = process.platform;
 
 import { activateAndPasteWithNativeTool } from '../../src/utils/native-tools/paste-operations';
 
-describe('activateAndPasteWithNativeTool — cmux dispatch', () => {
+describe('activateAndPasteWithNativeTool — cmux/Ghostty input text dispatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.defineProperty(process, 'platform', { value: 'darwin' });
   });
 
-  it('routes cmux paste through a single osascript call combining activate + paste_from_clipboard', async () => {
+  it('routes cmux paste through osascript input text with text passed via argv', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
-      cb(null, 'true\n', '');
+      cb(null, '', '');
     });
 
-    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' });
+    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'hello\nworld');
 
     expect(mockExecFile).toHaveBeenCalledTimes(1);
     const [cmd, args] = mockExecFile.mock.calls[0]!;
     expect(cmd).toBe('osascript');
     expect(args[0]).toBe('-e');
     expect(args[1]).toContain('tell application "cmux"');
-    expect(args[1]).toContain('activate');
-    expect(args[1]).toContain('perform action "paste_from_clipboard"');
+    expect(args[1]).toContain('input text (item 1 of argv)');
     expect(args[1]).toContain('focused terminal of selected tab of front window');
+    // text is passed verbatim through argv (after `--`) so newlines/quotes do
+    // not need to be re-escaped by us
+    expect(args[2]).toBe('--');
+    expect(args[3]).toBe('hello\nworld');
   });
 
-  it('does NOT invoke keyboard-simulator for cmux (avoids ineffective Cmd+V)', async () => {
+  it('routes Ghostty paste through osascript input text with text passed via argv', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
-      cb(null, 'true\n', '');
+      cb(null, '', '');
     });
 
-    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' });
+    await activateAndPasteWithNativeTool(
+      { name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' },
+      'テスト\n/Users/nkmr/.prompt-line/images/foo.png'
+    );
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const [cmd, args] = mockExecFile.mock.calls[0]!;
+    expect(cmd).toBe('osascript');
+    expect(args[1]).toContain('tell application "Ghostty"');
+    expect(args[1]).toContain('input text (item 1 of argv)');
+    expect(args[3]).toBe('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
+  });
+
+  it('does NOT invoke keyboard-simulator for cmux/Ghostty (avoids ineffective Cmd+V)', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, '', '');
+    });
+
+    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'x');
+    await activateAndPasteWithNativeTool({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }, 'y');
 
     const usedKeyboardSimulator = mockExecFile.mock.calls.some(
       ([cmd]) => cmd === '/mock/keyboard-simulator'
@@ -66,27 +88,27 @@ describe('activateAndPasteWithNativeTool — cmux dispatch', () => {
     expect(usedKeyboardSimulator).toBe(false);
   });
 
-  it('rejects when AppleScript paste fails', async () => {
+  it('rejects when AppleScript input text fails', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(new Error('osascript failed'), '', 'cmux not running');
     });
 
     await expect(
-      activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' })
+      activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'x')
     ).rejects.toThrow('osascript failed');
   });
 
-  it('falls through to standard activate-and-paste-bundle for non-cmux apps', async () => {
+  it('falls through to keyboard-simulator activate-and-paste-bundle for non-cmux/Ghostty apps', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, JSON.stringify({ success: true }), '');
     });
 
-    await activateAndPasteWithNativeTool({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' });
+    await activateAndPasteWithNativeTool({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' }, 'x');
 
     expect(mockExecFile).toHaveBeenCalledTimes(1);
     const firstCall = mockExecFile.mock.calls[0]!;
     expect(firstCall[0]).toBe('/mock/keyboard-simulator');
-    expect(firstCall[1]).toEqual(['activate-and-paste-bundle', 'com.mitchellh.ghostty']);
+    expect(firstCall[1]).toEqual(['activate-and-paste-bundle', 'com.googlecode.iterm2']);
   });
 
   afterAll(() => {

--- a/tests/unit/paste-operations-cmux.test.ts
+++ b/tests/unit/paste-operations-cmux.test.ts
@@ -30,13 +30,13 @@ const ORIGINAL_PLATFORM = process.platform;
 
 import { activateAndPasteWithNativeTool } from '../../src/utils/native-tools/paste-operations';
 
-describe('activateAndPasteWithNativeTool — cmux/Ghostty input text dispatch', () => {
+describe('activateAndPasteWithNativeTool — terminal paste dispatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.defineProperty(process, 'platform', { value: 'darwin' });
   });
 
-  it('routes cmux paste through osascript input text with text passed via argv', async () => {
+  it('routes cmux paste through osascript paste_from_clipboard (bracketed paste via terminal pipeline)', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, '', '');
     });
@@ -48,15 +48,11 @@ describe('activateAndPasteWithNativeTool — cmux/Ghostty input text dispatch', 
     expect(cmd).toBe('osascript');
     expect(args[0]).toBe('-e');
     expect(args[1]).toContain('tell application "cmux"');
-    expect(args[1]).toContain('input text (item 1 of argv)');
+    expect(args[1]).toContain('perform action "paste_from_clipboard"');
     expect(args[1]).toContain('focused terminal of selected tab of front window');
-    // text is passed verbatim through argv (after `--`) so newlines/quotes do
-    // not need to be re-escaped by us
-    expect(args[2]).toBe('--');
-    expect(args[3]).toBe('hello\nworld');
   });
 
-  it('routes Ghostty paste through osascript input text with text passed via argv', async () => {
+  it('routes Ghostty paste through osascript paste_from_clipboard', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, '', '');
     });
@@ -70,17 +66,45 @@ describe('activateAndPasteWithNativeTool — cmux/Ghostty input text dispatch', 
     const [cmd, args] = mockExecFile.mock.calls[0]!;
     expect(cmd).toBe('osascript');
     expect(args[1]).toContain('tell application "Ghostty"');
-    expect(args[1]).toContain('input text (item 1 of argv)');
-    expect(args[3]).toBe('テスト\n/Users/nkmr/.prompt-line/images/foo.png');
+    expect(args[1]).toContain('perform action "paste_from_clipboard"');
   });
 
-  it('does NOT invoke keyboard-simulator for cmux/Ghostty (avoids ineffective Cmd+V)', async () => {
+  it('routes WezTerm paste through `wezterm cli send-text` with text on stdin', async () => {
+    const fakeStdin = { end: vi.fn() };
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      // First call: osascript activate (returns success)
+      // Second call: wezterm cli send-text (returns success)
+      cb(null, '', '');
+      return { stdin: fakeStdin };
+    });
+
+    await activateAndPasteWithNativeTool(
+      { name: 'WezTerm', bundleId: 'com.github.wez.wezterm' },
+      'テスト\n/Users/nkmr/.prompt-line/images/foo.png'
+    );
+
+    // Two execFile calls: activate, then wezterm cli send-text
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+    const activateCall = mockExecFile.mock.calls[0]!;
+    expect(activateCall[0]).toBe('osascript');
+    expect(activateCall[1][1]).toContain('WezTerm');
+
+    const sendTextCall = mockExecFile.mock.calls[1]!;
+    expect(sendTextCall[0]).toBe('/Applications/WezTerm.app/Contents/MacOS/wezterm');
+    expect(sendTextCall[1]).toEqual(['cli', 'send-text']);
+    expect(fakeStdin.end).toHaveBeenCalledWith('テスト\n/Users/nkmr/.prompt-line/images/foo.png', 'utf8');
+  });
+
+  it('does NOT invoke keyboard-simulator for cmux/Ghostty/WezTerm', async () => {
+    const fakeStdin = { end: vi.fn() };
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, '', '');
+      return { stdin: fakeStdin };
     });
 
     await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'x');
     await activateAndPasteWithNativeTool({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }, 'y');
+    await activateAndPasteWithNativeTool({ name: 'WezTerm', bundleId: 'com.github.wez.wezterm' }, 'z');
 
     const usedKeyboardSimulator = mockExecFile.mock.calls.some(
       ([cmd]) => cmd === '/mock/keyboard-simulator'
@@ -88,7 +112,7 @@ describe('activateAndPasteWithNativeTool — cmux/Ghostty input text dispatch', 
     expect(usedKeyboardSimulator).toBe(false);
   });
 
-  it('rejects when AppleScript input text fails', async () => {
+  it('rejects when AppleScript paste_from_clipboard fails', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(new Error('osascript failed'), '', 'cmux not running');
     });
@@ -98,7 +122,7 @@ describe('activateAndPasteWithNativeTool — cmux/Ghostty input text dispatch', 
     ).rejects.toThrow('osascript failed');
   });
 
-  it('falls through to keyboard-simulator activate-and-paste-bundle for non-cmux/Ghostty apps', async () => {
+  it('falls through to keyboard-simulator activate-and-paste-bundle for non-special apps', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, JSON.stringify({ success: true }), '');
     });

--- a/tests/unit/paste-operations-cmux.test.ts
+++ b/tests/unit/paste-operations-cmux.test.ts
@@ -41,7 +41,7 @@ describe('activateAndPasteWithNativeTool — terminal paste dispatch', () => {
       cb(null, '', '');
     });
 
-    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'hello\nworld');
+    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' });
 
     expect(mockExecFile).toHaveBeenCalledTimes(1);
     const [cmd, args] = mockExecFile.mock.calls[0]!;
@@ -52,59 +52,12 @@ describe('activateAndPasteWithNativeTool — terminal paste dispatch', () => {
     expect(args[1]).toContain('focused terminal of selected tab of front window');
   });
 
-  it('routes Ghostty paste through osascript paste_from_clipboard', async () => {
+  it('does NOT invoke keyboard-simulator for cmux (avoids ineffective Cmd+V)', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, '', '');
     });
 
-    await activateAndPasteWithNativeTool(
-      { name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' },
-      'テスト\n/Users/nkmr/.prompt-line/images/foo.png'
-    );
-
-    expect(mockExecFile).toHaveBeenCalledTimes(1);
-    const [cmd, args] = mockExecFile.mock.calls[0]!;
-    expect(cmd).toBe('osascript');
-    expect(args[1]).toContain('tell application "Ghostty"');
-    expect(args[1]).toContain('perform action "paste_from_clipboard"');
-  });
-
-  it('routes WezTerm paste through `wezterm cli send-text` with text on stdin', async () => {
-    const fakeStdin = { end: vi.fn() };
-    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
-      // First call: osascript activate (returns success)
-      // Second call: wezterm cli send-text (returns success)
-      cb(null, '', '');
-      return { stdin: fakeStdin };
-    });
-
-    await activateAndPasteWithNativeTool(
-      { name: 'WezTerm', bundleId: 'com.github.wez.wezterm' },
-      'テスト\n/Users/nkmr/.prompt-line/images/foo.png'
-    );
-
-    // Two execFile calls: activate, then wezterm cli send-text
-    expect(mockExecFile).toHaveBeenCalledTimes(2);
-    const activateCall = mockExecFile.mock.calls[0]!;
-    expect(activateCall[0]).toBe('osascript');
-    expect(activateCall[1][1]).toContain('WezTerm');
-
-    const sendTextCall = mockExecFile.mock.calls[1]!;
-    expect(sendTextCall[0]).toBe('/Applications/WezTerm.app/Contents/MacOS/wezterm');
-    expect(sendTextCall[1]).toEqual(['cli', 'send-text']);
-    expect(fakeStdin.end).toHaveBeenCalledWith('テスト\n/Users/nkmr/.prompt-line/images/foo.png', 'utf8');
-  });
-
-  it('does NOT invoke keyboard-simulator for cmux/Ghostty/WezTerm', async () => {
-    const fakeStdin = { end: vi.fn() };
-    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
-      cb(null, '', '');
-      return { stdin: fakeStdin };
-    });
-
-    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'x');
-    await activateAndPasteWithNativeTool({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' }, 'y');
-    await activateAndPasteWithNativeTool({ name: 'WezTerm', bundleId: 'com.github.wez.wezterm' }, 'z');
+    await activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' });
 
     const usedKeyboardSimulator = mockExecFile.mock.calls.some(
       ([cmd]) => cmd === '/mock/keyboard-simulator'
@@ -118,16 +71,42 @@ describe('activateAndPasteWithNativeTool — terminal paste dispatch', () => {
     });
 
     await expect(
-      activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' }, 'x')
+      activateAndPasteWithNativeTool({ name: 'cmux', bundleId: 'com.cmuxterm.app' })
     ).rejects.toThrow('osascript failed');
   });
 
-  it('falls through to keyboard-simulator activate-and-paste-bundle for non-special apps', async () => {
+  it('routes Ghostty through keyboard-simulator (same path as iTerm2)', async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, JSON.stringify({ success: true }), '');
     });
 
-    await activateAndPasteWithNativeTool({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' }, 'x');
+    await activateAndPasteWithNativeTool({ name: 'Ghostty', bundleId: 'com.mitchellh.ghostty' });
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const firstCall = mockExecFile.mock.calls[0]!;
+    expect(firstCall[0]).toBe('/mock/keyboard-simulator');
+    expect(firstCall[1]).toEqual(['activate-and-paste-bundle', 'com.mitchellh.ghostty']);
+  });
+
+  it('routes WezTerm through keyboard-simulator (same path as iTerm2)', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, JSON.stringify({ success: true }), '');
+    });
+
+    await activateAndPasteWithNativeTool({ name: 'WezTerm', bundleId: 'com.github.wez.wezterm' });
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const firstCall = mockExecFile.mock.calls[0]!;
+    expect(firstCall[0]).toBe('/mock/keyboard-simulator');
+    expect(firstCall[1]).toEqual(['activate-and-paste-bundle', 'com.github.wez.wezterm']);
+  });
+
+  it('falls through to keyboard-simulator activate-and-paste-bundle for non-cmux apps', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, JSON.stringify({ success: true }), '');
+    });
+
+    await activateAndPasteWithNativeTool({ name: 'iTerm2', bundleId: 'com.googlecode.iterm2' });
 
     expect(mockExecFile).toHaveBeenCalledTimes(1);
     const firstCall = mockExecFile.mock.calls[0]!;

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -610,7 +610,7 @@ describe('Utils', () => {
                 const dangerousAppName = 'App;rm -rf /';
 
                 await expect(
-                    activateAndPasteWithNativeTool(dangerousAppName)
+                    activateAndPasteWithNativeTool(dangerousAppName, '')
                 ).rejects.toThrow('App name contains unsafe characters');
 
                 Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -631,7 +631,7 @@ describe('Utils', () => {
                 };
 
                 await expect(
-                    activateAndPasteWithNativeTool(dangerousAppInfo)
+                    activateAndPasteWithNativeTool(dangerousAppInfo, '')
                 ).rejects.toThrow('Bundle ID contains unsafe characters');
 
                 Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -644,7 +644,7 @@ describe('Utils', () => {
                 const emptyAfterSanitization = ';|`$(){}[]<>"\'\\*?~^';
 
                 await expect(
-                    activateAndPasteWithNativeTool(emptyAfterSanitization)
+                    activateAndPasteWithNativeTool(emptyAfterSanitization, '')
                 ).rejects.toThrow('App name contains unsafe characters');
 
                 Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -666,7 +666,7 @@ describe('Utils', () => {
                 };
 
                 await expect(
-                    activateAndPasteWithNativeTool(safeAppInfo)
+                    activateAndPasteWithNativeTool(safeAppInfo, '')
                 ).resolves.toBeUndefined();
 
                 // Verify that execFile was called with the correct arguments

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -610,7 +610,7 @@ describe('Utils', () => {
                 const dangerousAppName = 'App;rm -rf /';
 
                 await expect(
-                    activateAndPasteWithNativeTool(dangerousAppName, '')
+                    activateAndPasteWithNativeTool(dangerousAppName)
                 ).rejects.toThrow('App name contains unsafe characters');
 
                 Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -631,7 +631,7 @@ describe('Utils', () => {
                 };
 
                 await expect(
-                    activateAndPasteWithNativeTool(dangerousAppInfo, '')
+                    activateAndPasteWithNativeTool(dangerousAppInfo)
                 ).rejects.toThrow('Bundle ID contains unsafe characters');
 
                 Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -644,7 +644,7 @@ describe('Utils', () => {
                 const emptyAfterSanitization = ';|`$(){}[]<>"\'\\*?~^';
 
                 await expect(
-                    activateAndPasteWithNativeTool(emptyAfterSanitization, '')
+                    activateAndPasteWithNativeTool(emptyAfterSanitization)
                 ).rejects.toThrow('App name contains unsafe characters');
 
                 Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -666,7 +666,7 @@ describe('Utils', () => {
                 };
 
                 await expect(
-                    activateAndPasteWithNativeTool(safeAppInfo, '')
+                    activateAndPasteWithNativeTool(safeAppInfo)
                 ).resolves.toBeUndefined();
 
                 // Verify that execFile was called with the correct arguments


### PR DESCRIPTION
## Summary

Pasting a prompt that contained an image path (e.g. `テスト\n/Users/.../images/foo.png`) from Prompt Line into a Claude Code TUI session running in cmux, Ghostty, or WezTerm was dropping either the surrounding text or the image path itself. iTerm2 was unaffected.

Two distinct underlying issues:

1. **macOS NSPasteboard image residue.** `clipboard.writeText('')` only rewrites the text type and leaves image formats (TIFF/PNG/AVIF…) on the pasteboard, so a subsequent paste could deliver stale image data instead of the new prompt text. Fixed by switching to `clipboard.clear()` (which calls `[NSPasteboard clearContents]`) in both `setClipboardAsync` and after image save in `handlePasteImage`.

2. **Claude Code drops content when text and an image path arrive in the same paste.** Empirically, when paste data contains both an image path and surrounding text, Claude Code's path → `[Image #N]` conversion drops the surrounding text. Reproducible on cmux, Ghostty, and WezTerm; not reproducible on iTerm2 (likely due to subtle differences in how each terminal chunks/timed bracketed paste output). Fixed by splitting the paste at image-path boundaries and pasting each segment separately so each path arrives as its own paste and is converted in isolation.

cmux additionally cannot use `keyboard-simulator` Cmd+V CGEvent (parent NSApp consumes the event before the embedded Ghostty PTY sees it), so cmux still routes through AppleScript `paste_from_clipboard`. Ghostty/WezTerm use the same Cmd+V CGEvent path as iTerm2.

## Changes

- `setClipboardAsync` and `handlePasteImage`: replace `clipboard.writeText('')` with `clipboard.clear()` to wipe all pasteboard types
- `splitTextByImagePaths`: helper that splits a paste string at image-path (`png|jpg|jpeg|gif|webp`) boundaries; newlines stay inside text segments because pasted newlines work fine on Claude Code — only the path-bearing portion needs isolation
- `pasteSegments`: paste each segment with a fresh clipboard write and a small inter-segment delay so Claude Code does not merge consecutive pastes
- New detectors `isGhostty` / `isWezTerm` so the segmented-paste workaround can target only the affected terminals (cmux/Ghostty/WezTerm)
- cmux paste path retained: AppleScript `perform action \"paste_from_clipboard\"` (Cmd+V CGEvent does not reach cmux's embedded Ghostty PTY)
- Log paste target's `appName` and `bundleId` to aid future diagnosis
- Tighter inter-segment sleeps (`CLIPBOARD_SETTLE_DELAY_MS = 10ms`, `SEGMENT_PASTE_DELAY_MS = 40ms`) to keep the segmented path responsive

## Test plan

- [x] Unit tests added for `splitTextByImagePaths`, `isGhostty`, `isWezTerm`, and the cmux/Ghostty/WezTerm dispatch paths
- [x] Full suite: 1369 passed, 1 skipped
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (no errors)
- [x] Manual E2E on cmux + Claude Code: prompt with text + image path arrives intact, image path becomes `[Image #N]`
- [x] Manual E2E on Ghostty + Claude Code: same result
- [x] Manual E2E on WezTerm + Claude Code: same result
- [x] Manual E2E on iTerm2 + Claude Code: unchanged (single-paste fast path)
- [x] Multi-line text without an image path on cmux/Ghostty/WezTerm: still pastes in a single Cmd+V (no per-line segmentation overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)