### PR TITLE
fix(custom-search): resolve {latest} by semver and prefer newer version on duplicates

### DIFF
--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -1,6 +1,6 @@
 import { IpcMainInvokeEvent, BrowserWindow } from 'electron';
 import { logger } from '../utils/utils';
-import type CustomSearchLoader from '../managers/custom-search-loader';
+import CustomSearchLoader from '../managers/custom-search-loader';
 import type SettingsManager from '../managers/settings-manager';
 import type PluginManager from '../managers/plugin-manager';
 import type DirectoryManager from '../managers/directory-manager';
@@ -12,6 +12,18 @@ import pluginLoader from '../lib/plugin-loader';
 import { agentSkillCacheManager } from '../managers/agent-skill-cache-manager';
 import type { IPCResult } from '../types';
 import { getEnhancedEnv } from '../utils/shell-env';
+
+const VERSION_PATH_RE = /\/(\d+(?:\.\d+)+)\//;
+
+/** Returns true when `candidate` has a strictly newer semver in its filePath than `incumbent`.
+ *  When either path lacks a version, defaults to true so the later-iterated entry wins
+ *  (preserves prior settings-order behavior for non-versioned sources). */
+export function isNewerByPathVersion(candidate: string | undefined, incumbent: string | undefined): boolean {
+  const newVer = candidate?.match(VERSION_PATH_RE)?.[1];
+  const oldVer = incumbent?.match(VERSION_PATH_RE)?.[1];
+  if (!newVer || !oldVer) return true;
+  return CustomSearchLoader.compareSemver(newVer, oldVer) > 0;
+}
 
 /**
  * CustomSearchHandler manages all IPC handlers related to MD search functionality.
@@ -206,9 +218,14 @@ class CustomSearchHandler {
         commandMap.set(key, cmd);
       }
 
-      // Add custom commands (same name with different source or label is kept)
+      // Add custom commands (same name with different source or label is kept).
+      // When the same key collides (e.g., two plugin caches expose the same
+      // skill with the same label), keep the candidate whose filePath has the
+      // newer semver — without this, settings order silently picked the loser.
       for (const cmd of userCommands) {
         const key = `${cmd.name}:${cmd.source || ''}:${cmd.label || ''}`;
+        const existing = commandMap.get(key);
+        if (existing && !isNewerByPathVersion(cmd.filePath, existing.filePath)) continue;
         commandMap.set(key, cmd);
       }
 

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -1670,7 +1670,7 @@ class CustomSearchLoader extends EventEmitter {
    * Non-numeric names return 0 so the caller can fall back to mtime.
    */
   private static readonly SEMVER_RE = /^\d+(?:\.\d+)*$/;
-  private static compareSemver(a: string, b: string): number {
+  static compareSemver(a: string, b: string): number {
     if (!CustomSearchLoader.SEMVER_RE.test(a) || !CustomSearchLoader.SEMVER_RE.test(b)) return 0;
     const aParts = a.split('.').map(Number);
     const bParts = b.split('.').map(Number);

--- a/src/managers/custom-search-loader.ts
+++ b/src/managers/custom-search-loader.ts
@@ -1634,27 +1634,52 @@ class CustomSearchLoader extends EventEmitter {
     return dirs;
   }
 
-  /** Find the most recently modified subdirectory */
+  /**
+   * Find the latest subdirectory.
+   * Prefers semver order (e.g., 1.2.0 > 1.0.0) since plugin caches use semver names;
+   * falls back to mtime when names are not comparable (or tied) so non-versioned
+   * directories still work.
+   */
   private async findLatestSubdir(parentDir: string): Promise<string | null> {
     try {
       const entries = await fs.readdir(parentDir, { withFileTypes: true });
-      let latestDir = '';
-      let latestMtime = -1;
+      const candidates: { name: string; fullPath: string; mtimeMs: number }[] = [];
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         const fullPath = path.join(parentDir, entry.name);
         try {
           const stat = await fs.stat(fullPath);
-          if (stat.mtimeMs > latestMtime) {
-            latestMtime = stat.mtimeMs;
-            latestDir = fullPath;
-          }
+          candidates.push({ name: entry.name, fullPath, mtimeMs: stat.mtimeMs });
         } catch { /* skip */ }
       }
-      return latestDir || null;
+      if (candidates.length === 0) return null;
+      candidates.sort((a, b) => {
+        const semverDiff = CustomSearchLoader.compareSemver(b.name, a.name);
+        if (semverDiff !== 0) return semverDiff;
+        return b.mtimeMs - a.mtimeMs;
+      });
+      return candidates[0]?.fullPath ?? null;
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Compare two directory names as semver-like dotted numeric versions.
+   * Returns >0 if a is newer, <0 if b is newer, 0 if equal or non-comparable.
+   * Non-numeric names return 0 so the caller can fall back to mtime.
+   */
+  private static readonly SEMVER_RE = /^\d+(?:\.\d+)*$/;
+  private static compareSemver(a: string, b: string): number {
+    if (!CustomSearchLoader.SEMVER_RE.test(a) || !CustomSearchLoader.SEMVER_RE.test(b)) return 0;
+    const aParts = a.split('.').map(Number);
+    const bParts = b.split('.').map(Number);
+    const len = Math.max(aParts.length, bParts.length);
+    for (let i = 0; i < len; i++) {
+      const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+      if (diff !== 0) return diff;
+    }
+    return 0;
   }
 
   /**

--- a/tests/unit/custom-search-handler-dedup.test.ts
+++ b/tests/unit/custom-search-handler-dedup.test.ts
@@ -1,0 +1,52 @@
+// Stub electron / preload deps that custom-search-handler imports at module
+// load time. The dedup helper itself is pure, but ESM evaluation pulls these in.
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  BrowserWindow: class {},
+}));
+vi.mock('child_process', () => ({ exec: vi.fn() }));
+vi.mock('../../src/lib/plugin-loader', () => ({
+  default: { searchAgentBuiltIn: vi.fn(), searchLegacyAgentBuiltIn: vi.fn(), searchAllLocalAgentBuiltIn: vi.fn() },
+}));
+vi.mock('../../src/managers/agent-skill-cache-manager', () => ({
+  agentSkillCacheManager: { invalidate: vi.fn() },
+}));
+vi.mock('../../src/utils/utils', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../../src/utils/shell-env', () => ({ getEnhancedEnv: vi.fn(() => ({})) }));
+
+import { isNewerByPathVersion } from '../../src/handlers/custom-search-handler';
+
+describe('isNewerByPathVersion', () => {
+  test('returns true when candidate path has higher semver than incumbent', () => {
+    const candidate = '/Users/x/.claude/plugins/cache/agent-plugins/finance/1.2.0/skills/jpx-explorer/SKILL.md';
+    const incumbent = '/Users/x/.codex/plugins/cache/agent-plugins/finance/1.0.0/skills/jpx-explorer/SKILL.md';
+    expect(isNewerByPathVersion(candidate, incumbent)).toBe(true);
+  });
+
+  test('returns false when candidate path has lower semver than incumbent', () => {
+    const candidate = '/Users/x/.codex/plugins/cache/agent-plugins/finance/1.0.0/skills/jpx-explorer/SKILL.md';
+    const incumbent = '/Users/x/.claude/plugins/cache/agent-plugins/finance/1.2.0/skills/jpx-explorer/SKILL.md';
+    expect(isNewerByPathVersion(candidate, incumbent)).toBe(false);
+  });
+
+  test('returns false when versions are equal (incumbent stays)', () => {
+    const candidate = '/cache/foo/1.0.0/SKILL.md';
+    const incumbent = '/cache/bar/1.0.0/SKILL.md';
+    expect(isNewerByPathVersion(candidate, incumbent)).toBe(false);
+  });
+
+  test('falls back to true when candidate path lacks a version (preserves previous order)', () => {
+    expect(isNewerByPathVersion('/no/version/here.md', '/cache/foo/1.0.0/SKILL.md')).toBe(true);
+  });
+
+  test('falls back to true when incumbent path lacks a version', () => {
+    expect(isNewerByPathVersion('/cache/foo/1.0.0/SKILL.md', '/no/version/here.md')).toBe(true);
+  });
+
+  test('handles undefined paths gracefully', () => {
+    expect(isNewerByPathVersion(undefined, '/cache/foo/1.0.0/SKILL.md')).toBe(true);
+    expect(isNewerByPathVersion('/cache/foo/1.0.0/SKILL.md', undefined)).toBe(true);
+  });
+});

--- a/tests/unit/custom-search-loader.test.ts
+++ b/tests/unit/custom-search-loader.test.ts
@@ -781,6 +781,84 @@ describe('CustomSearchLoader', () => {
       expect(items).toHaveLength(2);
       expect(items.map(i => i.name).sort()).toEqual(['new-cmd', 'old-cmd']);
     });
+
+    describe('{latest} token resolution', () => {
+      // Builds a fake plugin cache layout: /cache/<plugin>/<version>/SKILL.md
+      // Caller supplies version dir entries (with optional mtime) so we can
+      // assert semver wins even when mtimes are equal or favor the older dir.
+      function setupVersionedPluginMocks(versionDirs: { name: string; mtimeMs: number }[]) {
+        mockedFs.readdir.mockImplementation((dir) => {
+          const dirStr = String(dir);
+          if (dirStr === '/cache') {
+            return Promise.resolve([createDirent('finance', false)] as any);
+          }
+          if (dirStr === '/cache/finance') {
+            return Promise.resolve(versionDirs.map(v => createDirent(v.name, false)) as any);
+          }
+          if (versionDirs.some(v => dirStr === `/cache/finance/${v.name}`)) {
+            return Promise.resolve([createDirent('SKILL.md', true)] as any);
+          }
+          return Promise.resolve([] as any);
+        });
+        mockedFs.stat.mockImplementation((p) => {
+          const pStr = String(p);
+          const match = versionDirs.find(v => pStr === `/cache/finance/${v.name}`);
+          if (match) {
+            return Promise.resolve({ isDirectory: () => true, mtimeMs: match.mtimeMs } as any);
+          }
+          return Promise.resolve({ isDirectory: () => true, mtimeMs: 0 } as any);
+        });
+        mockedFs.readFile.mockImplementation(((filePath: any) =>
+          Promise.resolve(`---\ndescription: From ${String(filePath)}\n---\n`)) as any);
+      }
+
+      function makeLoader() {
+        return new CustomSearchLoader([
+          {
+            name: '{pathdir:1}',
+            type: 'command',
+            description: '{frontmatter@description}',
+            sourcePath: '/cache/*/{latest}/SKILL.md',
+          },
+        ]);
+      }
+
+      test('should pick the highest semver version when mtimes are equal', async () => {
+        setupVersionedPluginMocks([
+          { name: '1.0.0', mtimeMs: 1000 },
+          { name: '1.2.0', mtimeMs: 1000 },
+        ]);
+
+        const items = await makeLoader().getItems('command');
+
+        expect(items).toHaveLength(1);
+        expect(items[0]?.description).toContain('/cache/finance/1.2.0/SKILL.md');
+      });
+
+      test('should pick the highest semver version even when older dir has newer mtime', async () => {
+        setupVersionedPluginMocks([
+          { name: '1.0.0', mtimeMs: 9999 }, // newer mtime but older version
+          { name: '1.2.0', mtimeMs: 1000 },
+        ]);
+
+        const items = await makeLoader().getItems('command');
+
+        expect(items).toHaveLength(1);
+        expect(items[0]?.description).toContain('/cache/finance/1.2.0/SKILL.md');
+      });
+
+      test('should fall back to mtime when directory names are not semver', async () => {
+        setupVersionedPluginMocks([
+          { name: 'abc123', mtimeMs: 1000 },
+          { name: 'def456', mtimeMs: 9999 },
+        ]);
+
+        const items = await makeLoader().getItems('command');
+
+        expect(items).toHaveLength(1);
+        expect(items[0]?.description).toContain('/cache/finance/def456/SKILL.md');
+      });
+    });
   });
 
   describe('excludeIf', () => {


### PR DESCRIPTION
## Summary

- `findLatestSubdir` previously picked plugin-cache version directories purely by mtime. When two version dirs share the same mtime (e.g. `finance/1.0.0` and `finance/1.2.0`), `fs.readdir` order silently decided the winner — sometimes the older `1.0.0`. Now sort candidates by semver descending and fall back to mtime for non-semver names.
- `handleGetAgentSkills` deduplicated by `name:source:label`. When the same skill (e.g. `finance/jpx-explorer`) is exposed by both `~/.claude/.../1.2.0` and `~/.codex/.../1.0.0`, settings order silently decided the winner — the older `1.0.0` clobbered the newer `1.2.0` because it was iterated last. On collisions, compare the semver embedded in `filePath` and keep the newer one (falls back to prior order when either path has no version).
- Promoted `CustomSearchLoader.compareSemver` from `private static` to `public static` so the handler can reuse it.

## Test plan

- [x] `pnpm test tests/unit/custom-search-loader.test.ts` — 154 passed (3 new cases for `{latest}` token resolution: semver wins on tied mtime, semver wins even with older-mtime advantage, mtime fallback for non-semver names).
- [x] `pnpm test tests/unit/custom-search-handler-dedup.test.ts` — 6 new cases for `isNewerByPathVersion` (newer/older/equal semver, missing version on either side, undefined paths).
- [x] `pnpm run typecheck` — passes.
- [x] `pnpm run pre-push` — 1381 tests passed.
- [x] Live verification with the packaged app via Chrome DevTools Protocol: `electronAPI.agentSkills.get()` now returns `finance` skills from `~/.claude/.../finance/1.2.0/...` (8/8). Before this change, all 8 came from `~/.codex/.../finance/1.0.0/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)