### PR TITLE
fix(settings): preserve additionalPaths from user settings during merge

### DIFF
--- a/src/managers/settings-manager.ts
+++ b/src/managers/settings-manager.ts
@@ -331,6 +331,10 @@ class SettingsManager extends EventEmitter {
       result.imagesDirectory = userSettings.imagesDirectory;
     }
 
+    // Handle additionalPaths (user setting replaces default entirely)
+    const resolvedAdditionalPaths = userSettings.additionalPaths ?? this.defaultSettings.additionalPaths;
+    if (resolvedAdditionalPaths) result.additionalPaths = resolvedAdditionalPaths;
+
     // Handle legacy settings (mdSearch) for backward compatibility
     if (userSettings.mdSearch && userSettings.mdSearch.length > 0) {
       this.resolveLegacyMdSearch(result, userSettings.mdSearch);

--- a/tests/unit/settings-manager.test.ts
+++ b/tests/unit/settings-manager.test.ts
@@ -401,6 +401,20 @@ window:
       expect(settings.fileSearch?.excludePatterns).toEqual([]);
     });
 
+    it('should preserve additionalPaths from user settings during merge', async () => {
+      // Regression: mergeWithDefaults previously omitted additionalPaths from
+      // its field-by-field rebuild, silently dropping user-supplied PATH entries
+      // and breaking "run=" shortcuts for tools outside the default PATH.
+      const userPaths = [
+        '/Users/test/Library/Application Support/JetBrains/Toolbox/scripts',
+        '~/bin'
+      ];
+
+      await settingsManager.updateSettings({ additionalPaths: userPaths });
+
+      expect(settingsManager.getAdditionalPaths()).toEqual(userPaths);
+    });
+
     it('should deep merge symbolSearch with defaults', async () => {
       // User only specifies timeout, should get maxSymbols from defaults
       const userSettings: Partial<UserSettings> = {


### PR DESCRIPTION
## Summary

- `mergeWithDefaults()` in `SettingsManager` rebuilds the result object field-by-field but had silently omitted `additionalPaths`, so user-supplied PATH entries in `settings.yaml` were dropped during merge.
- As a result, `run=` shortcuts could not locate tools that live outside the default PATH augmented by `getEnhancedEnv()` — e.g. JetBrains Toolbox shell scripts (`~/Library/Application Support/JetBrains/Toolbox/scripts/{land,idea,pycharm,...}`).
- Restores the field with the same "user setting replaces default entirely" semantics already used for `plugins`, `customSearch`, and `fileOpener.directories`.

## Repro before the fix

1. Set in `~/.prompt-line/settings.yaml`:
   ```yaml
   additionalPaths:
     - "/Users/<you>/Library/Application Support/JetBrains/Toolbox/scripts"
   shortcuts:
     Cmd+Shift+L: "run=land {projectdir}"
   ```
2. Press `Cmd+Shift+L` → `app.log` reports `/bin/sh: land: command not found`, even though `land` works in a terminal.

After the fix, the shortcut launches GoLand as expected.

## Test plan

- [x] Added regression unit test in `tests/unit/settings-manager.test.ts` asserting user-supplied `additionalPaths` survive `mergeWithDefaults()`.
- [x] `pnpm test` — 1382 tests pass (1 skipped), no regressions.
- [x] `pnpm run typecheck` — clean.
- [x] Manual: built with `pnpm run install-app`, reproduced the failing shortcut, then verified `Cmd+Shift+L` launches GoLand and `app.log` no longer logs `command not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)