### PR TITLE
docs(settings): document symlinkScanRoots for file search

### DIFF
--- a/docs/en/settings.md
+++ b/docs/en/settings.md
@@ -100,7 +100,30 @@ fileSearch:
   #fdPath: null             # Custom path to fd (null = auto-detect)
   includePatterns: []       # Force include even if in .gitignore (e.g., ["*.log", "dist/**"])
   excludePatterns: []       # Additional excludes (e.g., ["node_modules", "*.min.js"])
+  symlinkScanRoots: []      # Reverse-lookup symlink aliases (see below)
 ```
+
+### Symlink Alias Recovery (`symlinkScanRoots`)
+
+When you work inside a symlinked project directory (e.g. `~/ghq/github.com/foo/vault` pointing to an iCloud Obsidian vault), macOS canonicalizes the CWD to the real path before user-space code sees it. Without this setting, file search results show the real path (`~/Library/Mobile Documents/.../vault`) instead of the symlink path you actually `cd`'d into.
+
+Configure scan roots — parent directories that contain symlinks, or the symlinks themselves — to recover the user-facing alias:
+
+```yaml
+fileSearch:
+  symlinkScanRoots:
+    - "~/ghq"                                  # Walks ~/ghq/<host>/<user>/<repo> for symlinks
+    - "~/projects"                             # Walks ~/projects for symlinks
+    - "~/ghq/github.com/foo/vault"             # OK to specify a known symlink directly
+```
+
+How it works:
+- On first lookup, scans each root up to 5 levels deep for symbolic links and builds an in-memory map `realpath → alias`.
+- When a detected CWD's realpath matches (or lives under) a known target, the alias is substituted before the file search runs.
+- Cache TTL is 5 minutes; a 1.5-second scan budget protects window-show from slow filesystems. Noise directories (`node_modules`, `.git`, `dist`, `target`, etc.) are skipped.
+- Disabled when empty (default).
+
+Tip: `~/ghq` covers the common case of `ghq`-managed symlinks. If your symlinks live elsewhere (e.g. you maintain a manual `~/links/` directory), add that as a scan root instead. Specifying the symlink path itself also works.
 
 ## Symbol Search
 

--- a/docs/ja/settings.md
+++ b/docs/ja/settings.md
@@ -100,7 +100,30 @@ fileSearch:
   #fdPath: null             # fd のカスタムパス（null = 自動検出）
   includePatterns: []       # .gitignore でも強制的に含める（例: ["*.log", "dist/**"]）
   excludePatterns: []       # 追加の除外パターン（例: ["node_modules", "*.min.js"]）
+  symlinkScanRoots: []      # シンボリックリンクの逆引き（下記参照）
 ```
+
+### シンボリックリンクのエイリアス復元（`symlinkScanRoots`）
+
+シンボリックリンク経由でプロジェクトディレクトリを開いている場合（例: `~/ghq/github.com/foo/vault` が iCloud Obsidian の vault を指している）、macOS はユーザー空間に渡す前に CWD を実体パス（realpath）に正規化します。この設定を有効にしないと、ファイル検索結果はあなたが `cd` した symlink パスではなく、実体側のパス（`~/Library/Mobile Documents/.../vault`）で表示されます。
+
+スキャンルート（シンボリックリンクを含む親ディレクトリ、または symlink そのもの）を設定することで、ユーザー視点のエイリアスを復元できます:
+
+```yaml
+fileSearch:
+  symlinkScanRoots:
+    - "~/ghq"                                  # ~/ghq/<host>/<user>/<repo> 配下の symlink を探索
+    - "~/projects"                             # ~/projects 配下の symlink を探索
+    - "~/ghq/github.com/foo/vault"             # symlink そのものを直接指定してもよい
+```
+
+動作:
+- 初回ルックアップ時に各ルートを最大 5 階層スキャンし、`realpath → エイリアス` のマップをメモリ上に構築します。
+- 検出された CWD の realpath が既知のターゲットに一致（またはその配下にある）場合、ファイル検索の前に symlink パスへ置換されます。
+- キャッシュ TTL は 5 分。1.5 秒のスキャン予算でウィンドウ表示が遅延しないよう保護されます。ノイズディレクトリ（`node_modules`、`.git`、`dist`、`target` 等）は自動で除外されます。
+- 空（デフォルト）の場合は機能無効。
+
+ヒント: `~/ghq` は `ghq` 管理の symlink の一般的なケースをカバーします。`~/links/` のような手動管理ディレクトリに symlink がある場合は、それをスキャンルートとして指定してください。symlink パスを直接書いてもよいです。
 
 ## シンボル検索
 


### PR DESCRIPTION
## Summary

- Documents the new `fileSearch.symlinkScanRoots` setting introduced in #396.
- Explains why it's needed (macOS canonicalizes CWD to realpath before user-space code sees it), how to configure scan roots (parent dirs or the symlink itself), and the relevant runtime behavior (5-level walk, 5-min TTL, 1.5s scan budget, noise-dir skip).
- Both `docs/en/settings.md` and `docs/ja/settings.md` updated symmetrically.

## Test plan

- [x] `docs/en/settings.md` renders correctly (verified manually)
- [x] `docs/ja/settings.md` renders correctly (verified manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)