### PR TITLE
fix(plugins): replace broken `pnpm link` with `pnpm add -g .`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,9 @@ prompt-line-plugin help                          # Show help
 
 **Source resolution for `github.com/...`:** `gh repo clone` → `git clone`
 
-**Global CLI setup** — run `pnpm link` in the project directory to install `prompt-line-plugin` globally:
+**Global CLI setup** — run `pnpm add -g .` in the project directory to install `prompt-line-plugin` globally (pnpm 11+ requires this; bare `pnpm link` no longer works):
 ```bash
-pnpm link
+pnpm add -g .
 prompt-line-plugin install github.com/nkmr-jp/prompt-line-plugins
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Plugins are YAML files that add agent skills (`/`), custom search (`@prefix:`), 
 
 ```bash
 # Global CLI setup (run once in the prompt-line project directory)
-pnpm link
+pnpm add -g .
 
 # Install plugins
 prompt-line-plugin install github.com/nkmr-jp/prompt-line-plugins

--- a/README_ja.md
+++ b/README_ja.md
@@ -155,7 +155,7 @@ pnpm run migrate-settings        # 設定ファイルを最新のデフォルト
 
 ```bash
 # グローバルCLIセットアップ（prompt-lineプロジェクトディレクトリで一度だけ実行）
-pnpm link
+pnpm add -g .
 
 # プラグインのインストール
 prompt-line-plugin install github.com/nkmr-jp/prompt-line-plugins

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -7,7 +7,7 @@ Plugins are YAML files that add agent skills (`/`), custom search (`@prefix:`), 
 Run the following once in the prompt-line project directory to install `prompt-line-plugin` command globally:
 
 ```bash
-pnpm link
+pnpm add -g .
 ```
 
 This makes the `prompt-line-plugin` command available from any directory.

--- a/docs/ja/plugins.md
+++ b/docs/ja/plugins.md
@@ -7,7 +7,7 @@
 prompt-lineプロジェクトディレクトリで以下を一度実行して、`prompt-line-plugin` コマンドをグローバルにインストールします：
 
 ```bash
-pnpm link
+pnpm add -g .
 ```
 
 これにより、任意のディレクトリから `prompt-line-plugin` コマンドが使えるようになります。

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -100,6 +100,6 @@ if (wasRunning) {
 }
 
 console.log(`\n📌 To install plugins:`);
-console.log(`   pnpm link`);
+console.log(`   pnpm add -g .`);
 console.log(`   prompt-line-plugin install github.com/nkmr-jp/prompt-line-plugins`);
 console.log(`   See: docs/en/plugins.md`);

--- a/scripts/plugin-help.ts
+++ b/scripts/plugin-help.ts
@@ -38,7 +38,7 @@ ${bold('Examples:')}
 ${bold('Global CLI Setup')} ${dim('(Optional)')}${bold(':')}
   Run the following in the prompt-line project directory to install the CLI globally:
 
-    ${dim('$')} ${cyan('pnpm link')}
+    ${dim('$')} ${cyan('pnpm add -g .')}
 
   Then use from anywhere:
     ${dim('$')} ${cyan('prompt-line-plugin install github.com/nkmr-jp/prompt-line-plugins')}


### PR DESCRIPTION
## Summary

pnpm 11 requires a `<dir>` argument for `pnpm link`, so the bare `pnpm link` we documented for global CLI setup now fails:

```
[ERR_PNPM_LINK_BAD_PARAMS] You must provide a parameter. Usage: pnpm link <dir>
```

This replaces every `pnpm link` reference with `pnpm add -g .`.

## Why `pnpm add -g .`

I verified the alternatives:

- `pnpm link .` / `pnpm link --global .` → pollute the manifest with a self-referencing `prompt-line: "link:"` entry in `package.json` and `pnpm-workspace.yaml`.
- `pnpm add -g .` → **no manifest changes**, and installs the CLI globally as a **live symlink** to the local source (changes are reflected immediately, same as the old `pnpm link` behavior).

## Changes

- Docs: `CLAUDE.md`, `README.md`, `README_ja.md`, `docs/en/plugins.md`, `docs/ja/plugins.md`
- Code: `scripts/install.js` (post-`install-app` message), `scripts/plugin-help.ts` (`prompt-line-plugin help` output)

## Test

From a clean state:

1. `pnpm remove -g prompt-line` → command gone
2. `pnpm add -g .` → `+ prompt-line <- .../prompt-line` (git status stays clean)
3. `prompt-line-plugin help` runs from any directory
4. Global store symlinks back to the local working dir (live link confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)