### PR TITLE
docs: document that main is now branch-protected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ fix(window): resolve positioning issue on multi-monitor setups
 - **Target Branch**: Create PRs against `develop` if it exists, otherwise against `main`
 - **Language**: Write all PR titles and descriptions in English
 - **Merge Strategy**: **Squash and merge** for feature PRs into `develop`. Use **regular merge commit** (no squash) when merging `develop` into `main`.
+- **`main` is branch-protected** (public repo): direct pushes are disabled, even for admins. All changes to `main` must go through a PR with the `test` CI check passing. Never attempt `git push` directly to `main` — create a branch, push it, and open a PR with `gh pr create` instead.
 
 ### Release Process
 Uses [Release Please](https://github.com/googleapis/release-please) for automated releases. Config: `release-please-config.json`, manifest: `.release-please-manifest.json`, workflow: `.github/workflows/release-please.yml`.


### PR DESCRIPTION
## Summary
- `main` now requires PRs (direct pushes disabled, including for admins) since this is a public repo
- Documents the new workflow in CLAUDE.md so future work doesn't attempt a direct push to `main`

## Test plan
- [x] typecheck / lint / full test suite pass (pre-push hook)