### PR TITLE
fix(paste): fix ReDoS and boundary bugs in image-path backtick wrapping

### DIFF
--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -42,10 +42,25 @@ const MAX_PASTE_TEXT_LENGTH_BYTES = 1024 * 1024; // 1MB limit for paste text
 //       character, so a sentence like `これは /foo.png のテスト` only
 //       captures `/foo.png`.
 //   (b) `<non-whitespace>.<ext>` — a plain filename or path without spaces.
-const IMAGE_PATH_REGEX = /([/@][^\n]*?\S\.(?:png|jpg|jpeg|gif|webp)|\S+\.(?:png|jpg|jpeg|gif|webp))/gi;
+// The leading `(?<=^|\s)` / trailing `(?=\s|$)` anchors require a match to
+// start and end at whitespace/string boundaries. Two reasons:
+//   1. Correctness: without a trailing boundary, the extension could match
+//      as a mere substring of a longer token (`readme.pngx`, `image.png.bak`),
+//      corrupting text that isn't actually an image path.
+//   2. Performance: without the leading boundary, `\S+\.(?:ext)` is retried
+//      from every character offset inside a long non-matching run (e.g. a
+//      pasted base64 blob or minified JS with no whitespace), causing
+//      quadratic-time backtracking — a multi-minute UI freeze is reachable
+//      at the paste-text size limit. Anchoring the match to only start at a
+//      token boundary bounds backtracking to each token's own length.
+const IMAGE_PATH_REGEX = /(?<=^|\s)(?:[/@][^\n]*?\S\.(?:png|jpg|jpeg|gif|webp)|\S+\.(?:png|jpg|jpeg|gif|webp))(?=\s|$)/gi;
 
 export function wrapImagePathsInBackticks(text: string): string {
-  return text.replace(IMAGE_PATH_REGEX, (match) => `\`${match}\``);
+  return text.replace(IMAGE_PATH_REGEX, (match, offset: number) => {
+    // Don't double-wrap a path the user already quoted in backticks themselves.
+    const alreadyQuoted = text[offset - 1] === '`' && text[offset + match.length] === '`';
+    return alreadyQuoted ? match : `\`${match}\``;
+  });
 }
 
 // cmux/Ghostty/WezTerm + Claude Code triggers an image-path-dropped-when-
@@ -187,6 +202,11 @@ class PasteHandler {
       if (validationError) return validationError;
 
       const directory = this.directoryManager.getDirectory() || undefined;
+      // Note: this also wraps a screenshot path inserted by handlePasteImage
+      // (e.g. `@images/<timestamp>.png`), so on cmux/Ghostty/WezTerm it now
+      // arrives as literal backtick-quoted text instead of auto-converting to
+      // a Claude Code `[Image #N]` attachment the way it used to (and still
+      // does on iTerm2). Intentional tradeoff of the fix above.
       const clipboardText =
         config.platform.isMac && isClaudeCodeAffectedTerminal(previousApp)
           ? wrapImagePathsInBackticks(text)

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -312,9 +312,10 @@ describe('IPCHandlers', () => {
             expect(mockHistoryManager.addToHistory).not.toHaveBeenCalled();
         });
 
-        describe('image path backtick-wrapping (issue#3)', () => {
+        describe('image path backtick-wrapping', () => {
             const textWithImagePath = 'この画像を見て /Users/me/screenshot.png お願いします';
             const wrappedText = 'この画像を見て `/Users/me/screenshot.png` お願いします';
+            const plainText = 'この画像は関係ない普通のテキストです';
 
             beforeEach(() => {
                 (clipboard.writeText as Mock).mockImplementation(() => {});
@@ -352,6 +353,45 @@ describe('IPCHandlers', () => {
                     expect(clipboard.writeText).toHaveBeenCalledWith(textWithImagePath);
                 }
             );
+
+            test('leaves text with no image path unmodified when pasted into an affected terminal', async () => {
+                const handler = getHandler('paste-text');
+                mockWindowManager.getPreviousApp.mockReturnValue('Ghostty');
+
+                const result = await handler!(null, plainText);
+
+                expect(result.success).toBe(true);
+                expect(clipboard.writeText).toHaveBeenCalledWith(plainText);
+            });
+
+            test('wraps image paths when previousApp is a real AppInfo object (not just a plain string)', async () => {
+                const handler = getHandler('paste-text');
+                mockWindowManager.getPreviousApp.mockReturnValue({
+                    name: 'Ghostty',
+                    bundleId: 'com.mitchellh.ghostty'
+                });
+
+                const result = await handler!(null, textWithImagePath);
+
+                expect(result.success).toBe(true);
+                expect(clipboard.writeText).toHaveBeenCalledWith(wrappedText);
+                expect(mockHistoryManager.addToHistory).toHaveBeenCalledWith(
+                    textWithImagePath, 'Ghostty', undefined, undefined
+                );
+            });
+
+            test('leaves text unwrapped when previousApp is an AppInfo object for an unaffected terminal', async () => {
+                const handler = getHandler('paste-text');
+                mockWindowManager.getPreviousApp.mockReturnValue({
+                    name: 'iTerm2',
+                    bundleId: 'com.googlecode.iterm2'
+                });
+
+                const result = await handler!(null, textWithImagePath);
+
+                expect(result.success).toBe(true);
+                expect(clipboard.writeText).toHaveBeenCalledWith(textWithImagePath);
+            });
         });
     });
 

--- a/tests/unit/paste-handler-split.test.ts
+++ b/tests/unit/paste-handler-split.test.ts
@@ -111,3 +111,28 @@ describe('wrapImagePathsInBackticks — newlines are preserved', () => {
     );
   });
 });
+
+describe('wrapImagePathsInBackticks — boundary correctness', () => {
+  it('does not match an image extension that is a mere substring of a longer token', () => {
+    expect(wrapImagePathsInBackticks('readme.pngx')).toBe('readme.pngx');
+  });
+
+  it('does not match an image extension followed by another extension', () => {
+    expect(wrapImagePathsInBackticks('image.png.bak')).toBe('image.png.bak');
+  });
+
+  it('does not double-wrap a path the user already quoted in backticks', () => {
+    expect(
+      wrapImagePathsInBackticks('As discussed, `/Users/me/screenshot.png` was already generated')
+    ).toBe('As discussed, `/Users/me/screenshot.png` was already generated');
+  });
+});
+
+describe('wrapImagePathsInBackticks — performance safety', () => {
+  it('stays fast on a long non-matching, whitespace-free paste (no catastrophic backtracking)', () => {
+    const pathological = 'a'.repeat(1024 * 1024); // 1MB, at the paste size limit
+    const start = Date.now();
+    expect(wrapImagePathsInBackticks(pathological)).toBe(pathological);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
## Summary

A multi-perspective, multi-agent review of the recently-merged backtick-wrap paste fix (7 sub-agents across correctness/regression/security/test-coverage lenses, findings adversarially verified by 3 independent skeptics each) found two real bugs in `IMAGE_PATH_REGEX`:

- **Catastrophic backtracking (high severity)**: pasting a long, whitespace-free, non-image string (e.g. a copied JWT, base64 blob, or minified JS) into cmux/Ghostty/WezTerm caused quadratic-time regex backtracking, freezing the whole Electron main process. Measured ~7s at 100K chars; extrapolated to several minutes at the app's own 1MB paste limit. Fixed by anchoring matches to whitespace/string boundaries so backtracking is bounded to each token's own length — benchmarked 1MB of pathological input at ~6ms after the fix.
- **Substring corruption (medium severity)**: without a trailing boundary, the regex matched an image extension appearing mid-token (`readme.pngx`, `image.png.bak`), inserting backticks into unrelated text.

Also fixes a minor double-wrap (a path the user already wrapped in backticks themselves no longer gets wrapped again), and documents via code comment an already-intentional behavior change: Prompt Line's own screenshot-paste feature no longer auto-converts to a Claude Code image attachment on cmux/Ghostty/WezTerm, since the inserted path now also gets backtick-wrapped.

All existing test cases pass unchanged with the new regex (verified by hand-tracing + running each one).

**Considered but not fixed**: re-validating the 1MB size limit after wrapping (wrapping can add ~2 bytes per matched path). Skipped as negligible in practice — `clipboard.writeText` has no hard size ceiling this would trip.

## Test plan
- [x] New regression tests for substring-boundary corruction, double-wrap prevention, and a performance-safety test (1MB pathological input completes in <500ms)
- [x] New integration tests: `previousApp` passed as a real `AppInfo` object (not just a plain string), and plain text with no image path on an affected terminal — both previously untested gaps
- [x] Full test suite (1407 tests), typecheck, lint, and `pnpm run compile` all pass