### PR TITLE
feat(dev): add per-worktree isolated headless verification instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ How the isolation works (`scripts/isolated-instance.js`):
 - `PROMPT_LINE_DATA_DIR=~/.prompt-line-isolated/<worktree>/data` — its own history, drafts, settings, log, plugins and cache. On first start, `settings.yaml`, `plugins/` and `custom-search/` are **copied** (never symlinked) from `~/.prompt-line` so verification runs against a realistic config; pass `--no-seed` for a pristine one.
 - Its own Electron `--user-data-dir`, so it gets its own single-instance lock and runs alongside the installed app.
 - `PROMPT_LINE_ISOLATED=1` — no global shortcut (no fight over `Cmd+Shift+Space`), no tray icon, no native warmup, and the window is never shown or focused. The renderer still paints offscreen, so CDP screenshots show the real UI.
-- CDP port derived from the worktree directory name (9300–9399), so parallel worktrees never collide.
+- CDP port derived from the worktree directory name (9300–9399), so parallel worktrees never collide. Two checkouts whose directories share a name are rejected (the state file records `repoRoot`) — set `PROMPT_LINE_INSTANCE_ID` to give one of them a distinct id.
+- The CDP-driven commands (`type`, `clear`, `eval`, `screenshot`) need **Node 22+** (global `WebSocket`); `start`/`stop`/`status`/`show`/`logs` run on the version in `engines`.
 
 Do **not** use `pnpm run install-app` to verify a worktree — it replaces `/Applications/Prompt Line.app` and quits the app the user is running.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,29 @@ pnpm run reset-accessibility      # Reset accessibility permissions for Prompt L
 - `pnpm start` sets `LOG_LEVEL=debug` automatically. Packaged apps always use INFO level.
 - Logs: `~/.prompt-line/app.log` (use `tail -f ~/.prompt-line/app.log` for real-time monitoring)
 
+### Isolated Verification Instance (per worktree)
+Verify the checkout you are working in without disturbing the Prompt Line the user keeps running.
+
+```bash
+pnpm run isolated start              # Compile if needed, then launch headless in the background
+pnpm run isolated show               # Run the real show flow (renderer gets history/draft/settings)
+pnpm run isolated type "@"           # Type into the input, as a user would
+pnpm run isolated clear              # Empty the input
+pnpm run isolated eval "<js>"        # Evaluate JavaScript in the renderer
+pnpm run isolated screenshot out.png # Capture the offscreen window
+pnpm run isolated logs -n 40         # Tail this instance's app.log
+pnpm run isolated status
+pnpm run isolated stop               # `clean` also deletes the instance's data directory
+```
+
+How the isolation works (`scripts/isolated-instance.js`):
+- `PROMPT_LINE_DATA_DIR=~/.prompt-line-isolated/<worktree>/data` — its own history, drafts, settings, log, plugins and cache. On first start, `settings.yaml`, `plugins/` and `custom-search/` are **copied** (never symlinked) from `~/.prompt-line` so verification runs against a realistic config; pass `--no-seed` for a pristine one.
+- Its own Electron `--user-data-dir`, so it gets its own single-instance lock and runs alongside the installed app.
+- `PROMPT_LINE_ISOLATED=1` — no global shortcut (no fight over `Cmd+Shift+Space`), no tray icon, no native warmup, and the window is never shown or focused. The renderer still paints offscreen, so CDP screenshots show the real UI.
+- CDP port derived from the worktree directory name (9300–9399), so parallel worktrees never collide.
+
+Do **not** use `pnpm run install-app` to verify a worktree — it replaces `/Applications/Prompt Line.app` and quits the app the user is running.
+
 ### Testing
 ```bash
 pnpm test                    # Run all tests

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "node scripts/generate-git-info.js && tsc --noEmit",
     "build": "pnpm run compile && node scripts/build.js",
     "install-app": "pnpm run setup-codesign && pnpm run compile && node scripts/install.js",
+    "isolated": "node scripts/isolated-instance.js",
     "clean": "rm -rf dist/mac* dist/*.dmg dist/*.zip dist/*.blockmap",
     "clean:cache": "rm -rf node_modules/.cache ~/Library/Caches/electron-builder ~/Library/Caches/electron",
     "clean:full": "pnpm run clean && pnpm run clean:cache && rm -rf dist/",

--- a/scripts/isolated-instance.js
+++ b/scripts/isolated-instance.js
@@ -34,11 +34,19 @@ const ROOT_DIR = path.join(os.homedir(), '.prompt-line-isolated');
 const PORT_RANGE_START = 9300;
 const PORT_RANGE_SIZE = 100;
 const START_TIMEOUT_MS = 30000;
+const STOP_TIMEOUT_MS = 10000;
 /** Copied into a fresh data directory so verification sees a realistic setup. */
 const SEED_ENTRIES = ['settings.yaml', 'plugins', 'custom-search'];
+/** An id becomes a directory name that `clean` deletes — keep it a plain segment. */
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 function instanceId() {
-  return process.env.PROMPT_LINE_INSTANCE_ID || path.basename(REPO_ROOT);
+  const override = process.env.PROMPT_LINE_INSTANCE_ID;
+  if (!override) return path.basename(REPO_ROOT);
+  if (!ID_PATTERN.test(override)) {
+    throw new Error(`Invalid PROMPT_LINE_INSTANCE_ID: ${override} (allowed: letters, digits, . _ -)`);
+  }
+  return override;
 }
 
 function paths() {
@@ -54,13 +62,37 @@ function paths() {
   };
 }
 
+/**
+ * State of the instance for this checkout. Two worktrees whose directories
+ * happen to share a name would otherwise resolve to the same data directory
+ * and CDP port — refuse rather than drive (or report on) the other one.
+ */
 function readState() {
   const { stateFile } = paths();
+  let state;
   try {
-    return JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   } catch {
     return null;
   }
+  if (state.repoRoot && state.repoRoot !== REPO_ROOT) {
+    throw new Error(
+      `Instance "${state.id}" belongs to ${state.repoRoot}.\n` +
+      'Set PROMPT_LINE_INSTANCE_ID to a distinct id for this checkout.'
+    );
+  }
+  return state;
+}
+
+function waitForExit(pid) {
+  const deadline = Date.now() + STOP_TIMEOUT_MS;
+  return (async () => {
+    while (Date.now() < deadline) {
+      if (!isAlive(pid)) return true;
+      await new Promise(r => setTimeout(r, 100));
+    }
+    return false;
+  })();
 }
 
 function isAlive(pid) {
@@ -146,6 +178,11 @@ async function waitForCdp(port, pid) {
 
 /** Minimal CDP client over the page target — no dependencies, no browser needed. */
 async function withPage(port, fn) {
+  if (typeof WebSocket === 'undefined') {
+    // Global WebSocket is only enabled by default from Node 22 on.
+    throw new Error(`CDP commands need Node 22 or newer (running ${process.version})`);
+  }
+
   const targets = await cdpTargets(port);
   const page = targets.find(t => t.type === 'page');
   if (!page) throw new Error('no page target — is the instance running?');
@@ -216,6 +253,8 @@ async function start(args) {
     if (build.status !== 0) throw new Error('compile failed');
   }
 
+  // 0700: the seeded copy carries the user's real settings and plugins.
+  fs.mkdirSync(ROOT_DIR, { recursive: true, mode: 0o700 });
   fs.mkdirSync(dataDir, { recursive: true });
   fs.mkdirSync(electronDir, { recursive: true });
   if (!args.includes('--no-seed')) seedDataDir(dataDir);
@@ -228,8 +267,9 @@ async function start(args) {
     { cwd: REPO_ROOT, env: instanceEnv(dataDir), detached: true, stdio: ['ignore', out, out] }
   );
   child.unref();
+  fs.closeSync(out);
 
-  const state = { id, pid: child.pid, port, repoRoot: REPO_ROOT, dataDir, startedAt: new Date().toISOString() };
+  const state ={ id, pid: child.pid, port, repoRoot: REPO_ROOT, dataDir, startedAt: new Date().toISOString() };
   fs.mkdirSync(home, { recursive: true });
   fs.writeFileSync(stateFile, `${JSON.stringify(state, null, 2)}\n`);
 
@@ -239,13 +279,22 @@ async function start(args) {
   console.log(`  stdout: ${stdoutLog}`);
 }
 
-function stop() {
+/** Stops and waits: `start` and `clean` must never race a dying instance. */
+async function stop() {
+  const { stateFile } = paths();
   const state = readState();
   if (!state || !isAlive(state.pid)) {
+    fs.rmSync(stateFile, { force: true });
     console.log('Not running');
     return;
   }
+
   process.kill(state.pid, 'SIGTERM');
+  if (!await waitForExit(state.pid)) {
+    process.kill(state.pid, 'SIGKILL');
+    await waitForExit(state.pid);
+  }
+  fs.rmSync(stateFile, { force: true });
   console.log(`Stopped pid ${state.pid}`);
 }
 
@@ -274,16 +323,41 @@ function status() {
 function show() {
   const { dataDir, electronDir } = paths();
   requireRunning();
-  spawnSync(electronBin(), [REPO_ROOT, `--user-data-dir=${electronDir}`], {
+  const result = spawnSync(electronBin(), [REPO_ROOT, `--user-data-dir=${electronDir}`], {
     cwd: REPO_ROOT,
     env: instanceEnv(dataDir),
     stdio: 'ignore'
   });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`show trigger exited with ${result.status ?? result.signal}`);
+  }
 }
 
 async function typeText(port, text) {
-  await evaluate(port, `document.querySelector('textarea')?.focus(), true`);
+  // Without a focused textarea Input.insertText succeeds but goes nowhere.
+  const focused = await evaluate(port, `(() => {
+    const el = document.querySelector('textarea');
+    el?.focus();
+    return !!el;
+  })()`);
+  if (!focused) {
+    throw new Error('no input to type into — run `pnpm run isolated show` first');
+  }
   await withPage(port, send => send('Input.insertText', { text }));
+}
+
+async function clearInput(port) {
+  const cleared = await evaluate(port, `(() => {
+    const el = document.querySelector('textarea');
+    if (!el) return false;
+    el.value = '';
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    return true;
+  })()`);
+  if (!cleared) {
+    throw new Error('no input to clear — run `pnpm run isolated show` first');
+  }
 }
 
 async function screenshot(port, file) {
@@ -300,6 +374,9 @@ function logs(args) {
   const { dataDir } = paths();
   const index = args.indexOf('-n');
   const lines = index >= 0 ? args[index + 1] : '40';
+  if (!/^\d+$/.test(lines || '')) {
+    throw new Error(`-n needs a line count (got: ${lines ?? 'nothing'})`);
+  }
   const logFile = path.join(dataDir, 'app.log');
   if (!fs.existsSync(logFile)) {
     console.log(`No log yet: ${logFile}`);
@@ -308,9 +385,9 @@ function logs(args) {
   process.stdout.write(execFileSync('tail', ['-n', lines, logFile], { encoding: 'utf8' }));
 }
 
-function clean() {
+async function clean() {
   const { home } = paths();
-  stop();
+  await stop();
   fs.rmSync(home, { recursive: true, force: true });
   console.log(`Removed ${home}`);
 }
@@ -330,12 +407,7 @@ async function main() {
     case 'type':
       return typeText(requireRunning().port, args.join(' '));
     case 'clear':
-      return evaluate(requireRunning().port, `
-        const el = document.querySelector('textarea');
-        el.value = '';
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-        true;
-      `).then(() => undefined);
+      return clearInput(requireRunning().port);
     case 'eval': {
       const value = await evaluate(requireRunning().port, args.join(' '));
       console.log(typeof value === 'string' ? value : JSON.stringify(value, null, 2));

--- a/scripts/isolated-instance.js
+++ b/scripts/isolated-instance.js
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * Run this checkout of Prompt Line as an isolated, headless instance.
+ *
+ * Every git worktree gets its own instance: its own data directory
+ * (`PROMPT_LINE_DATA_DIR`), its own Electron userData directory (so it does not
+ * collide with the single-instance lock of the app the user keeps running), and
+ * its own CDP port. The instance registers no global shortcut and no tray icon,
+ * and never shows a window or takes focus (`PROMPT_LINE_ISOLATED=1`) — the UI is
+ * driven and screenshotted over CDP instead.
+ *
+ * Usage: pnpm run isolated <command>
+ *   start [--rebuild] [--no-seed]  Launch the instance in the background
+ *   stop                           Quit the instance
+ *   status                         Print instance id, port, pid, data directory
+ *   show                           Run the show flow (renderer gets history/draft/settings)
+ *   type <text>                    Type text into the input, as a user would
+ *   clear                          Empty the input
+ *   eval <js>                      Evaluate JavaScript in the renderer, print the result
+ *   screenshot [file]              Capture the (offscreen) window to a PNG
+ *   logs [-n <lines>]              Tail the instance's app.log
+ *   clean                          Stop the instance and delete its data directory
+ */
+
+const { spawn, spawnSync, execFileSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const ROOT_DIR = path.join(os.homedir(), '.prompt-line-isolated');
+const PORT_RANGE_START = 9300;
+const PORT_RANGE_SIZE = 100;
+const START_TIMEOUT_MS = 30000;
+/** Copied into a fresh data directory so verification sees a realistic setup. */
+const SEED_ENTRIES = ['settings.yaml', 'plugins', 'custom-search'];
+
+function instanceId() {
+  return process.env.PROMPT_LINE_INSTANCE_ID || path.basename(REPO_ROOT);
+}
+
+function paths() {
+  const id = instanceId();
+  const home = path.join(ROOT_DIR, id);
+  return {
+    id,
+    home,
+    dataDir: path.join(home, 'data'),
+    electronDir: path.join(home, 'electron'),
+    stateFile: path.join(home, 'instance.json'),
+    stdoutLog: path.join(home, 'stdout.log')
+  };
+}
+
+function readState() {
+  const { stateFile } = paths();
+  try {
+    return JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function isAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPortFree(port) {
+  return new Promise(resolve => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => server.close(() => resolve(true)));
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+/**
+ * Deterministic per-instance port so the same worktree keeps the same port
+ * across restarts; scans upward when another instance already took it.
+ */
+async function pickPort(id) {
+  const digest = crypto.createHash('sha1').update(id).digest();
+  const base = PORT_RANGE_START + (digest.readUInt16BE(0) % PORT_RANGE_SIZE);
+  for (let i = 0; i < PORT_RANGE_SIZE; i++) {
+    const port = PORT_RANGE_START + ((base - PORT_RANGE_START + i) % PORT_RANGE_SIZE);
+    if (await isPortFree(port)) return port;
+  }
+  throw new Error(`No free port in ${PORT_RANGE_START}-${PORT_RANGE_START + PORT_RANGE_SIZE - 1}`);
+}
+
+function electronBin() {
+  const bin = path.join(REPO_ROOT, 'node_modules', '.bin', 'electron');
+  if (!fs.existsSync(bin)) {
+    throw new Error('electron not found — run `pnpm install` first');
+  }
+  return bin;
+}
+
+function instanceEnv(dataDir) {
+  return {
+    ...process.env,
+    PROMPT_LINE_DATA_DIR: dataDir,
+    PROMPT_LINE_ISOLATED: '1',
+    LOG_LEVEL: process.env.LOG_LEVEL || 'debug'
+  };
+}
+
+function seedDataDir(dataDir) {
+  const source = path.join(os.homedir(), '.prompt-line');
+  for (const entry of SEED_ENTRIES) {
+    const from = path.join(source, entry);
+    const to = path.join(dataDir, entry);
+    if (!fs.existsSync(from) || fs.existsSync(to)) continue;
+    // Copy — never symlink: the instance must not write back into ~/.prompt-line.
+    fs.cpSync(from, to, { recursive: true, dereference: true });
+  }
+}
+
+async function cdpTargets(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+  return res.json();
+}
+
+async function waitForCdp(port, pid) {
+  const deadline = Date.now() + START_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) throw new Error('instance exited during startup — see stdout.log');
+    try {
+      const targets = await cdpTargets(port);
+      if (targets.some(t => t.type === 'page')) return;
+    } catch {
+      // not listening yet
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  throw new Error(`CDP did not come up on port ${port} within ${START_TIMEOUT_MS}ms`);
+}
+
+/** Minimal CDP client over the page target — no dependencies, no browser needed. */
+async function withPage(port, fn) {
+  const targets = await cdpTargets(port);
+  const page = targets.find(t => t.type === 'page');
+  if (!page) throw new Error('no page target — is the instance running?');
+
+  const ws = new WebSocket(page.webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    ws.onopen = resolve;
+    ws.onerror = () => reject(new Error('failed to connect to CDP'));
+  });
+
+  let nextId = 1;
+  const send = (method, params = {}) => new Promise((resolve, reject) => {
+    const id = nextId++;
+    const timer = setTimeout(() => reject(new Error(`${method} timed out`)), 15000);
+    const onMessage = event => {
+      const msg = JSON.parse(event.data);
+      if (msg.id !== id) return;
+      clearTimeout(timer);
+      ws.removeEventListener('message', onMessage);
+      if (msg.error) reject(new Error(`${method}: ${JSON.stringify(msg.error)}`));
+      else resolve(msg.result);
+    };
+    ws.addEventListener('message', onMessage);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+
+  try {
+    return await fn(send);
+  } finally {
+    ws.close();
+  }
+}
+
+async function evaluate(port, expression) {
+  return withPage(port, async send => {
+    const result = await send('Runtime.evaluate', {
+      expression,
+      awaitPromise: true,
+      returnByValue: true
+    });
+    if (result.exceptionDetails) {
+      throw new Error(result.exceptionDetails.exception?.description || 'evaluation failed');
+    }
+    return result.result.value;
+  });
+}
+
+function requireRunning() {
+  const state = readState();
+  if (!state || !isAlive(state.pid)) {
+    throw new Error('instance is not running — run `pnpm run isolated start` first');
+  }
+  return state;
+}
+
+async function start(args) {
+  const { id, home, dataDir, electronDir, stateFile, stdoutLog } = paths();
+
+  const existing = readState();
+  if (existing && isAlive(existing.pid)) {
+    console.log(`Already running: pid ${existing.pid}, CDP port ${existing.port}`);
+    return;
+  }
+
+  if (args.includes('--rebuild') || !fs.existsSync(path.join(REPO_ROOT, 'dist', 'main.js'))) {
+    console.log('Compiling...');
+    const build = spawnSync('pnpm', ['run', 'compile'], { cwd: REPO_ROOT, stdio: 'inherit' });
+    if (build.status !== 0) throw new Error('compile failed');
+  }
+
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(electronDir, { recursive: true });
+  if (!args.includes('--no-seed')) seedDataDir(dataDir);
+
+  const port = await pickPort(id);
+  const out = fs.openSync(stdoutLog, 'a');
+  const child = spawn(
+    electronBin(),
+    [REPO_ROOT, `--user-data-dir=${electronDir}`, `--remote-debugging-port=${port}`],
+    { cwd: REPO_ROOT, env: instanceEnv(dataDir), detached: true, stdio: ['ignore', out, out] }
+  );
+  child.unref();
+
+  const state = { id, pid: child.pid, port, repoRoot: REPO_ROOT, dataDir, startedAt: new Date().toISOString() };
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(stateFile, `${JSON.stringify(state, null, 2)}\n`);
+
+  await waitForCdp(port, child.pid);
+  console.log(`Started ${id}: pid ${child.pid}, CDP port ${port}`);
+  console.log(`  data:   ${dataDir}`);
+  console.log(`  stdout: ${stdoutLog}`);
+}
+
+function stop() {
+  const state = readState();
+  if (!state || !isAlive(state.pid)) {
+    console.log('Not running');
+    return;
+  }
+  process.kill(state.pid, 'SIGTERM');
+  console.log(`Stopped pid ${state.pid}`);
+}
+
+function status() {
+  const { id, dataDir, stdoutLog } = paths();
+  const state = readState();
+  const running = state ? isAlive(state.pid) : false;
+  console.log(`instance: ${id}`);
+  console.log(`running:  ${running}`);
+  if (state) {
+    console.log(`pid:      ${state.pid}`);
+    console.log(`port:     ${state.port}`);
+    console.log(`started:  ${state.startedAt}`);
+  }
+  console.log(`data:     ${dataDir}`);
+  console.log(`stdout:   ${stdoutLog}`);
+  if (!running) process.exitCode = 1;
+}
+
+/**
+ * Trigger the real show flow. Launching a second process against the same
+ * userData directory hits Electron's `second-instance` event, so the running
+ * instance composes the same window data as the global shortcut would — while
+ * staying headless because of PROMPT_LINE_ISOLATED.
+ */
+function show() {
+  const { dataDir, electronDir } = paths();
+  requireRunning();
+  spawnSync(electronBin(), [REPO_ROOT, `--user-data-dir=${electronDir}`], {
+    cwd: REPO_ROOT,
+    env: instanceEnv(dataDir),
+    stdio: 'ignore'
+  });
+}
+
+async function typeText(port, text) {
+  await evaluate(port, `document.querySelector('textarea')?.focus(), true`);
+  await withPage(port, send => send('Input.insertText', { text }));
+}
+
+async function screenshot(port, file) {
+  const target = path.resolve(file || path.join(os.tmpdir(), `prompt-line-${instanceId()}.png`));
+  const data = await withPage(port, async send => {
+    const shot = await send('Page.captureScreenshot', { format: 'png' });
+    return shot.data;
+  });
+  fs.writeFileSync(target, Buffer.from(data, 'base64'));
+  console.log(target);
+}
+
+function logs(args) {
+  const { dataDir } = paths();
+  const index = args.indexOf('-n');
+  const lines = index >= 0 ? args[index + 1] : '40';
+  const logFile = path.join(dataDir, 'app.log');
+  if (!fs.existsSync(logFile)) {
+    console.log(`No log yet: ${logFile}`);
+    return;
+  }
+  process.stdout.write(execFileSync('tail', ['-n', lines, logFile], { encoding: 'utf8' }));
+}
+
+function clean() {
+  const { home } = paths();
+  stop();
+  fs.rmSync(home, { recursive: true, force: true });
+  console.log(`Removed ${home}`);
+}
+
+async function main() {
+  const [command = 'status', ...args] = process.argv.slice(2);
+
+  switch (command) {
+    case 'start':
+      return start(args);
+    case 'stop':
+      return stop();
+    case 'status':
+      return status();
+    case 'show':
+      return show();
+    case 'type':
+      return typeText(requireRunning().port, args.join(' '));
+    case 'clear':
+      return evaluate(requireRunning().port, `
+        const el = document.querySelector('textarea');
+        el.value = '';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        true;
+      `).then(() => undefined);
+    case 'eval': {
+      const value = await evaluate(requireRunning().port, args.join(' '));
+      console.log(typeof value === 'string' ? value : JSON.stringify(value, null, 2));
+      return;
+    }
+    case 'screenshot':
+      return screenshot(requireRunning().port, args[0]);
+    case 'logs':
+      return logs(args);
+    case 'clean':
+      return clean();
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.error('Usage: pnpm run isolated <start|stop|status|show|type|clear|eval|screenshot|logs|clean>');
+      process.exitCode = 2;
+  }
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/src/config/CLAUDE.md
+++ b/src/config/CLAUDE.md
@@ -33,7 +33,9 @@ default-settings.ts (Single Source of Truth)
 - `pnpm start` sets `LOG_LEVEL=debug` automatically
 
 ### Path management
-- All data stored under `~/.prompt-line/` (based on `os.homedir()`)
+- All data stored under `~/.prompt-line/` (`resolveUserDataDir()`)
+- `PROMPT_LINE_DATA_DIR` overrides that directory (used by `pnpm run isolated` so a worktree instance never touches the running app's data). `settings-manager.ts` and `logger.ts` resolve their paths through the same helper
+- `isIsolatedInstance()` (`PROMPT_LINE_ISOLATED=1`) marks a headless verification instance: no global shortcut, no tray, window never shown or focused
 - Getter-based lazy path generation
 - `pluginsDir`: `~/.prompt-line/plugins/`
 

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -21,6 +21,36 @@ import gitInfo from '../generated/git-info.json';
 // Import shared default settings (single source of truth)
 import { defaultSettings } from './default-settings';
 
+/**
+ * Resolve the directory holding history, drafts, settings, logs and plugins.
+ *
+ * Defaults to `~/.prompt-line`. `PROMPT_LINE_DATA_DIR` overrides it so an
+ * isolated instance (typically one launched from a git worktree by
+ * `pnpm run isolated`) never touches the data of the app the user runs daily.
+ */
+export function resolveUserDataDir(): string {
+  const override = process.env.PROMPT_LINE_DATA_DIR?.trim();
+  if (!override) {
+    return path.join(os.homedir(), '.prompt-line');
+  }
+  if (override === '~') {
+    return os.homedir();
+  }
+  const expanded = override.startsWith('~/')
+    ? path.join(os.homedir(), override.slice(2))
+    : override;
+  return path.resolve(expanded);
+}
+
+/**
+ * True when this process runs as an isolated verification instance
+ * (`PROMPT_LINE_ISOLATED=1`). Such an instance must never compete with the
+ * user's running app: no global shortcut, no tray icon, no window activation.
+ */
+export function isIsolatedInstance(): boolean {
+  return process.env.PROMPT_LINE_ISOLATED === '1';
+}
+
 function buildVersionDisplay(version: string): string {
   if (!gitInfo.hash) return version;
 
@@ -82,7 +112,7 @@ class AppConfigClass {
     // Use shared default settings for shortcuts
     this.shortcuts = { ...defaultSettings.shortcuts };
 
-    const userDataDir = path.join(os.homedir(), '.prompt-line');
+    const userDataDir = resolveUserDataDir();
     this.paths = {
       userDataDir,
       get historyFile() {

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -2,7 +2,7 @@ import { ipcMain, clipboard, IpcMainInvokeEvent, dialog } from 'electron';
 import { promises as fs } from 'fs';
 import { execFile } from 'child_process';
 import path from 'path';
-import config from '../config/app-config';
+import config, { isIsolatedInstance } from '../config/app-config';
 import {
   logger,
   pasteWithNativeTool,
@@ -143,6 +143,13 @@ class PasteHandler {
    * keyboard-simulator Cmd+V CGEvent.
    */
   private async executePasteOperation(previousApp: AppInfo | string | null): Promise<PasteResult> {
+    // Pasting means activating whatever app is in front of the user and sending
+    // it Cmd+V. An isolated verification instance must never do that.
+    if (isIsolatedInstance()) {
+      logger.info('Isolated instance: skipping native paste');
+      return { success: true, warning: 'Isolated instance: native paste skipped' };
+    }
+
     if (previousApp && config.platform.isMac) {
       await activateAndPasteWithNativeTool(previousApp);
       return { success: true };
@@ -347,6 +354,12 @@ class PasteHandler {
   }
 
   private async setClipboardAsync(text: string): Promise<void> {
+    // The system clipboard is shared with everything the user is doing.
+    if (isIsolatedInstance()) {
+      logger.debug('Isolated instance: skipping clipboard write');
+      return;
+    }
+
     return new Promise((resolve) => {
       try {
         // Clear all pasteboard types before writing text. clipboard.writeText
@@ -373,6 +386,12 @@ class PasteHandler {
   }
 
   private showAccessibilityWarning(bundleId: string): void {
+    // A modal from a background verification instance would steal the screen.
+    if (isIsolatedInstance()) {
+      logger.warn('Isolated instance: accessibility permission missing', { bundleId });
+      return;
+    }
+
     dialog.showMessageBox({
       type: 'warning',
       title: 'Accessibility Permission Required',

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ if (process.platform === 'darwin') {
   process.noDeprecation = true;
 }
 
-import config from './config/app-config';
+import config, { isIsolatedInstance } from './config/app-config';
 import WindowManager from './managers/window';
 import HistoryManager from './managers/history-manager';
 import DraftManager from './managers/draft-manager';
@@ -66,6 +66,9 @@ class PromptLineApp {
   private startNativeWarmup(): void {
     if (process.platform !== 'darwin') return;
     if (process.env.PROMPT_LINE_DISABLE_NATIVE_WARMUP === '1') return;
+    // Isolated instances run in the background for verification only; keeping
+    // Swift tools warm is the running app's job.
+    if (isIsolatedInstance()) return;
     if (this.nativeWarmupTimer) return;
     const opts = { timeout: 2000 };
     this.nativeWarmupTimer = setInterval(() => {
@@ -284,6 +287,14 @@ class PromptLineApp {
   }
 
   private registerShortcuts(): void {
+    // An isolated instance must not fight the user's running app for the
+    // global hotkey (registration would fail and abort startup anyway).
+    // Use `pnpm run isolated show` to open its window instead.
+    if (isIsolatedInstance()) {
+      logger.info('Isolated instance: skipping global shortcut registration');
+      return;
+    }
+
     try {
       const settings = this.settingsManager?.getSettings();
       const mainShortcut = settings?.shortcuts.main || config.shortcuts.main;
@@ -354,6 +365,12 @@ class PromptLineApp {
   }
 
   private createTray(): void {
+    // A second tray icon would be indistinguishable from the user's own app.
+    if (isIsolatedInstance()) {
+      logger.info('Isolated instance: skipping tray icon');
+      return;
+    }
+
     try {
       const icon = this.createTrayIcon();
       this.tray = new Tray(icon);
@@ -634,15 +651,11 @@ class PromptLineApp {
 
 const promptLineApp = new PromptLineApp();
 
-app.whenReady().then(async () => {
-  try {
-    await promptLineApp.initialize();
-  } catch (error) {
-    logger.error('Application failed to start:', error);
-    app.quit();
-  }
-});
-
+// Claim the lock before anything else runs: a second launch must exit without
+// initializing, so it never touches the data directory of the instance that
+// already owns it. The lock is keyed on Electron's userData path, so an
+// isolated instance (launched with its own --user-data-dir) gets its own lock
+// and can run alongside the app the user keeps open.
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
@@ -652,6 +665,15 @@ if (!gotTheLock) {
   app.on('second-instance', async () => {
     logger.info('Second instance detected, showing main window');
     await promptLineApp.showInputWindow();
+  });
+
+  app.whenReady().then(async () => {
+    try {
+      await promptLineApp.initialize();
+    } catch (error) {
+      logger.error('Application failed to start:', error);
+      app.quit();
+    }
   });
 }
 

--- a/src/managers/settings-manager.ts
+++ b/src/managers/settings-manager.ts
@@ -1,11 +1,11 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import os from 'os';
 import * as yaml from 'js-yaml';
 import { EventEmitter } from 'events';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { logger } from '../utils/utils';
 import { defaultSettings as sharedDefaultSettings } from '../config/default-settings';
+import { resolveUserDataDir } from '../config/app-config';
 import { generateSettingsYaml } from '../config/settings-yaml-generator';
 import pluginLoader from '../lib/plugin-loader';
 import type {
@@ -32,7 +32,7 @@ class SettingsManager extends EventEmitter {
   constructor() {
     super();
     // Always use .yaml — legacy .yml is read as fallback during init, then migrated
-    this.settingsFile = path.join(os.homedir(), '.prompt-line', 'settings.yaml');
+    this.settingsFile = path.join(resolveUserDataDir(), 'settings.yaml');
 
     // Use shared default settings from config/default-settings.ts
     this.defaultSettings = sharedDefaultSettings;

--- a/src/managers/window/native-tool-executor.ts
+++ b/src/managers/window/native-tool-executor.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'child_process';
 import { logger, KEYBOARD_SIMULATOR_PATH } from '../../utils/utils';
-import config from '../../config/app-config';
+import config, { isIsolatedInstance } from '../../config/app-config';
 import type { AppInfo } from '../../types';
 import { TIMEOUTS } from '../../constants';
 
@@ -21,6 +21,13 @@ class NativeToolExecutor {
   async focusPreviousApp(): Promise<boolean> {
     try {
       if (!this.previousApp || !config.platform.isMac) {
+        return false;
+      }
+
+      // An isolated instance records whatever app the user happens to have in
+      // front; activating it would yank their focus around mid-verification.
+      if (isIsolatedInstance()) {
+        logger.debug('Isolated instance: skipping focus of previous app');
         return false;
       }
 

--- a/src/managers/window/window-manager.ts
+++ b/src/managers/window/window-manager.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from 'electron';
-import config from '../../config/app-config';
+import config, { isIsolatedInstance } from '../../config/app-config';
 import { getCurrentApp, logger, mark, setFlag } from '../../utils/utils';
 import type { PerfTrace } from '../../utils/utils';
 import DesktopSpaceManager from '../desktop-space-manager';
@@ -359,9 +359,7 @@ class WindowManager {
               mark(trace, 'did-finish-load');
               this.inputWindow.webContents.send('window-shown', windowData);
               mark(trace, 'shown-sent');
-              this.inputWindow.show();
-              mark(trace, 'show-called');
-              this.inputWindow.focus();
+              this.revealWindow(trace);
             }
           } catch (err) {
             logger.warn('Error in did-finish-load handler:', err);
@@ -371,8 +369,7 @@ class WindowManager {
         const showFallback = (reason: string): void => {
           if (this.inputWindow && !this.inputWindow.isDestroyed()) {
             try {
-              this.inputWindow.show();
-              this.inputWindow.focus();
+              this.revealWindow();
             } catch (err) {
               logger.warn(`Fallback show after ${reason} failed:`, err);
             }
@@ -398,10 +395,29 @@ class WindowManager {
       setFlag(trace, 'displayPath', 'show-immediate');
       this.inputWindow!.webContents.send('window-shown', windowData);
       mark(trace, 'shown-sent');
-      this.inputWindow!.show();
-      mark(trace, 'show-called');
-      this.inputWindow!.focus();
+      this.revealWindow(trace);
     }
+  }
+
+  /**
+   * Bring the window on screen and give it keyboard focus.
+   *
+   * An isolated verification instance (PROMPT_LINE_ISOLATED=1) stays headless:
+   * the renderer still receives `window-shown` and paints, so CDP can drive and
+   * screenshot it, but no window appears and the user's focus is never stolen.
+   * @private
+   */
+  private revealWindow(trace?: PerfTrace): void {
+    if (!this.inputWindow || this.inputWindow.isDestroyed()) return;
+
+    if (isIsolatedInstance()) {
+      setFlag(trace, 'headless', true);
+      return;
+    }
+
+    this.inputWindow.show();
+    mark(trace, 'show-called');
+    this.inputWindow.focus();
   }
 
   /**

--- a/src/managers/window/window-manager.ts
+++ b/src/managers/window/window-manager.ts
@@ -408,7 +408,10 @@ class WindowManager {
    * @private
    */
   private revealWindow(trace?: PerfTrace): void {
-    if (!this.inputWindow || this.inputWindow.isDestroyed()) return;
+    if (!this.inputWindow || this.inputWindow.isDestroyed()) {
+      logger.warn('Cannot reveal input window: no live window');
+      return;
+    }
 
     if (isIsolatedInstance()) {
       setFlag(trace, 'headless', true);
@@ -439,6 +442,7 @@ class WindowManager {
    */
   focusWindow(): void {
     try {
+      if (isIsolatedInstance()) return;
       if (this.inputWindow) {
         this.inputWindow.focus();
       }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,8 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import os from 'os';
 import type { LogLevel } from '../types';
-import config from "../config/app-config";
+import config, { resolveUserDataDir } from "../config/app-config";
 
 // Sensitive information patterns for masking
 const SENSITIVE_PATTERNS = [
@@ -57,7 +56,7 @@ class Logger {
 
   constructor() {
     // Initialize with defaults to avoid circular dependency
-    this.logFile = path.join(os.homedir(), '.prompt-line', 'app.log');
+    this.logFile = path.join(resolveUserDataDir(), 'app.log');
 
     // Set actual config values after initialization if available
     this.initializeConfig();

--- a/tests/unit/app-config-data-dir.test.ts
+++ b/tests/unit/app-config-data-dir.test.ts
@@ -1,0 +1,75 @@
+import os from 'os';
+import path from 'path';
+import { resolveUserDataDir, isIsolatedInstance } from '../../src/config/app-config';
+
+describe('resolveUserDataDir', () => {
+  const originalDataDir = process.env.PROMPT_LINE_DATA_DIR;
+  const originalIsolated = process.env.PROMPT_LINE_ISOLATED;
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env.PROMPT_LINE_DATA_DIR;
+    else process.env.PROMPT_LINE_DATA_DIR = originalDataDir;
+
+    if (originalIsolated === undefined) delete process.env.PROMPT_LINE_ISOLATED;
+    else process.env.PROMPT_LINE_ISOLATED = originalIsolated;
+  });
+
+  test('defaults to ~/.prompt-line', () => {
+    delete process.env.PROMPT_LINE_DATA_DIR;
+
+    expect(resolveUserDataDir()).toBe(path.join(os.homedir(), '.prompt-line'));
+  });
+
+  test('falls back to the default when the override is blank', () => {
+    process.env.PROMPT_LINE_DATA_DIR = '   ';
+
+    expect(resolveUserDataDir()).toBe(path.join(os.homedir(), '.prompt-line'));
+  });
+
+  test('honors an absolute override', () => {
+    process.env.PROMPT_LINE_DATA_DIR = '/tmp/prompt-line-isolated/data';
+
+    expect(resolveUserDataDir()).toBe('/tmp/prompt-line-isolated/data');
+  });
+
+  test('expands a leading ~', () => {
+    process.env.PROMPT_LINE_DATA_DIR = '~/.prompt-line-isolated/wt/data';
+
+    expect(resolveUserDataDir()).toBe(path.join(os.homedir(), '.prompt-line-isolated/wt/data'));
+  });
+
+  test('resolves a relative override to an absolute path', () => {
+    process.env.PROMPT_LINE_DATA_DIR = './isolated-data';
+
+    expect(resolveUserDataDir()).toBe(path.resolve('./isolated-data'));
+  });
+
+  test('does not treat ~name as a home-relative path', () => {
+    process.env.PROMPT_LINE_DATA_DIR = '/tmp/~backup/data';
+
+    expect(resolveUserDataDir()).toBe('/tmp/~backup/data');
+  });
+});
+
+describe('isIsolatedInstance', () => {
+  const original = process.env.PROMPT_LINE_ISOLATED;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.PROMPT_LINE_ISOLATED;
+    else process.env.PROMPT_LINE_ISOLATED = original;
+  });
+
+  test('is false by default', () => {
+    delete process.env.PROMPT_LINE_ISOLATED;
+
+    expect(isIsolatedInstance()).toBe(false);
+  });
+
+  test('is true only for an exact "1"', () => {
+    process.env.PROMPT_LINE_ISOLATED = '1';
+    expect(isIsolatedInstance()).toBe(true);
+
+    process.env.PROMPT_LINE_ISOLATED = 'true';
+    expect(isIsolatedInstance()).toBe(false);
+  });
+});

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -126,7 +126,12 @@ vi.mock('../../src/config/app-config', () => {
             return config[key];
         })
     };
-    return { ...configObj, default: configObj };
+    return {
+        ...configObj,
+        default: configObj,
+        resolveUserDataDir: vi.fn(() => '/test/.prompt-line'),
+        isIsolatedInstance: vi.fn(() => false)
+    };
 });
 
 const { logger, pasteWithNativeTool, activateAndPasteWithNativeTool } = utils as any;

--- a/tests/unit/paste-handler-isolated.test.ts
+++ b/tests/unit/paste-handler-isolated.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const isIsolatedInstance = vi.fn(() => false);
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), removeAllListeners: vi.fn() },
+  clipboard: { writeText: vi.fn(), readImage: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn(() => Promise.resolve({ response: 1 })) },
+  app: { getApplicationInfoForProtocol: vi.fn(), getAppPath: vi.fn(() => '') }
+}));
+
+vi.mock('../../src/config/app-config', () => ({
+  default: {
+    platform: { isMac: true },
+    paths: { imagesDir: '/tmp' },
+    timing: { windowHideDelay: 1, appFocusDelay: 1 }
+  },
+  isIsolatedInstance: () => isIsolatedInstance()
+}));
+
+vi.mock('../../src/utils/utils', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  pasteWithNativeTool: vi.fn(),
+  activateAndPasteWithNativeTool: vi.fn(),
+  sleep: vi.fn(() => Promise.resolve()),
+  checkAccessibilityPermission: vi.fn(),
+  SecureErrors: { OPERATION_FAILED: 'failed', PERMISSION_DENIED: 'denied' }
+}));
+
+vi.mock('../../src/utils/native-tools/app-detection', () => ({
+  isITerm2: vi.fn(() => false),
+  isCmux: vi.fn(() => false),
+  isGhostty: vi.fn(() => false),
+  isWezTerm: vi.fn(() => false),
+  getITermSessionId: vi.fn()
+}));
+
+import { clipboard } from 'electron';
+import { activateAndPasteWithNativeTool, pasteWithNativeTool } from '../../src/utils/utils';
+import PasteHandler from '../../src/handlers/paste-handler';
+
+/**
+ * The isolated verification instance must never touch anything the user shares
+ * with their running app: the system clipboard, or the frontmost application.
+ */
+describe('PasteHandler in an isolated instance', () => {
+  const previousApp = { name: 'Terminal', bundleId: 'com.apple.Terminal' };
+  let handler: PasteHandler;
+  let hideInputWindow: ReturnType<typeof vi.fn>;
+  let addToHistory: ReturnType<typeof vi.fn>;
+  let clearDraft: ReturnType<typeof vi.fn>;
+
+  const paste = (text: string): Promise<unknown> =>
+    (handler as unknown as {
+      handlePasteText: (event: unknown, text: string) => Promise<unknown>;
+    }).handlePasteText({}, text);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isIsolatedInstance.mockReturnValue(false);
+
+    hideInputWindow = vi.fn(() => Promise.resolve());
+    addToHistory = vi.fn(() => Promise.resolve());
+    clearDraft = vi.fn(() => Promise.resolve());
+
+    handler = new PasteHandler(
+      {
+        getPreviousApp: vi.fn(() => previousApp),
+        hideInputWindow,
+        focusPreviousApp: vi.fn(() => Promise.resolve(true))
+      } as never,
+      { addToHistory } as never,
+      { clearDraft } as never,
+      { getDirectory: vi.fn(() => '/tmp') } as never,
+      { getSettings: vi.fn(() => ({})) } as never
+    );
+  });
+
+  it('writes the clipboard and pastes natively when not isolated', async () => {
+    const result = await paste('hello');
+
+    expect(result).toEqual({ success: true });
+    expect(clipboard.writeText).toHaveBeenCalledWith('hello');
+    expect(activateAndPasteWithNativeTool).toHaveBeenCalledWith(previousApp);
+  });
+
+  it('skips the clipboard and the native paste when isolated', async () => {
+    isIsolatedInstance.mockReturnValue(true);
+
+    const result = await paste('hello');
+
+    expect(result).toEqual({ success: true, warning: 'Isolated instance: native paste skipped' });
+    expect(clipboard.clear).not.toHaveBeenCalled();
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+    expect(activateAndPasteWithNativeTool).not.toHaveBeenCalled();
+    expect(pasteWithNativeTool).not.toHaveBeenCalled();
+  });
+
+  it('still records history and clears the draft when isolated', async () => {
+    isIsolatedInstance.mockReturnValue(true);
+
+    await paste('hello');
+
+    expect(addToHistory).toHaveBeenCalled();
+    expect(clearDraft).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/window-manager.test.ts
+++ b/tests/unit/window-manager.test.ts
@@ -62,7 +62,12 @@ vi.mock('../../src/config/app-config', () => {
         },
         getInputHtmlPath: vi.fn(() => '/test/input.html')
     };
-    return { ...configMock, default: configMock };
+    return {
+        ...configMock,
+        default: configMock,
+        resolveUserDataDir: vi.fn(() => '/test/.prompt-line'),
+        isIsolatedInstance: vi.fn(() => false)
+    };
 });
 
 // Fix getCurrentApp to return string for consistency
@@ -95,7 +100,8 @@ describe('WindowManager', () => {
                 send: vi.fn(),
                 on: vi.fn(),
                 isLoading: vi.fn(() => false),
-                once: vi.fn()
+                once: vi.fn(),
+                removeListener: vi.fn()
             }
         };
         
@@ -247,6 +253,41 @@ describe('WindowManager', () => {
             // Should still try to show window
             expect(mockWindow.show).toHaveBeenCalled();
             // Note: logger.error might be called asynchronously
+        });
+
+        describe('isolated instance (headless)', () => {
+            beforeEach(() => {
+                (appConfig.isIsolatedInstance as Mock).mockReturnValue(true);
+            });
+
+            afterEach(() => {
+                (appConfig.isIsolatedInstance as Mock).mockReturnValue(false);
+            });
+
+            test('should render the window data without showing or focusing', async () => {
+                mockWindow.webContents.isLoading.mockReturnValue(false);
+
+                await windowManager.showInputWindow({ history: [], draft: 'test draft' });
+
+                expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+                    'window-shown',
+                    expect.objectContaining({ draft: 'test draft' })
+                );
+                expect(mockWindow.show).not.toHaveBeenCalled();
+                expect(mockWindow.focus).not.toHaveBeenCalled();
+            });
+
+            test('should stay hidden when the renderer fails to load', async () => {
+                mockWindow.webContents.isLoading.mockReturnValue(true);
+                mockWindow.webContents.once.mockImplementation((event: string, handler: () => void) => {
+                    if (event === 'did-fail-load') setTimeout(handler, 0);
+                });
+
+                await windowManager.showInputWindow();
+
+                expect(mockWindow.show).not.toHaveBeenCalled();
+                expect(mockWindow.focus).not.toHaveBeenCalled();
+            });
         });
     });
 


### PR DESCRIPTION
## Problem

Verifying a change made in a git worktree had no safe path: `pnpm run install-app` replaces
`/Applications/Prompt Line.app` and quits the instance the user keeps running, and `pnpm start`
fights the running app for the `Cmd+Shift+Space` global shortcut and shares `~/.prompt-line`
(history, drafts, settings, log).

## Solution

A per-worktree isolated instance that runs **headless in the background**:

```bash
pnpm run isolated start              # launch this checkout headless
pnpm run isolated show               # run the real show flow
pnpm run isolated type "/rel"        # type, as a user would
pnpm run isolated screenshot out.png # capture the offscreen window
pnpm run isolated logs -n 40
pnpm run isolated stop               # `clean` also deletes the instance data
```

Three layers of isolation:

1. **Data** — `PROMPT_LINE_DATA_DIR` overrides the user data directory
   (`resolveUserDataDir()` in `src/config/app-config.ts`, also used by `settings-manager.ts`
   and `logger.ts`). The launcher points it at `~/.prompt-line-isolated/<worktree>/data`
   and seeds it by **copying** `settings.yaml`, `plugins/` and `custom-search/` on first
   start, so verification runs against a realistic config without ever writing back.
2. **Process** — its own Electron `--user-data-dir`, so it gets its own single-instance lock
   and runs alongside the installed app. The lock is now claimed before `whenReady` is
   registered, so a second launch exits without initializing.
3. **Behavior** — `PROMPT_LINE_ISOLATED=1` (`isIsolatedInstance()`): no global shortcut,
   no tray icon, no native warmup, and `revealWindow()` never shows or focuses the window.

The renderer still paints offscreen, so `Page.captureScreenshot` over CDP returns the real UI
while nothing appears on screen and focus is never stolen. The CDP port is derived from the
worktree directory name (9300–9399), so parallel worktrees never collide.

## Verification

- `pnpm run pre-push` (lint + typecheck + 1417 tests) passes.
- New unit tests: `resolveUserDataDir()` / `isIsolatedInstance()`, and window-manager tests
  asserting the isolated instance sends `window-shown` but never calls `show()` / `focus()`.
- End-to-end on this worktree while the installed app kept running: started the instance,
  ran `show`, typed `/rel`, captured the slash-command suggestion list, restarted it, and
  confirmed `~/.prompt-line` was never written to and no window ever appeared.

Closes issue 6 (issues repo).
