### PR TITLE
fix(plugins): preserve commands with distinct triggers

### DIFF
--- a/src/handlers/custom-search-handler.ts
+++ b/src/handlers/custom-search-handler.ts
@@ -25,6 +25,11 @@ export function isNewerByPathVersion(candidate: string | undefined, incumbent: s
   return CustomSearchLoader.compareSemver(newVer, oldVer) > 0;
 }
 
+export function getAgentSkillDedupKey(skill: AgentSkillItem): string {
+  const triggers = [...(skill.triggers ?? ['/'])].sort().join(',');
+  return `${skill.name}:${skill.source || ''}:${skill.label || ''}:${triggers}`;
+}
+
 /**
  * CustomSearchHandler manages all IPC handlers related to MD search functionality.
  * This includes slash commands, agents, and search configuration.
@@ -214,16 +219,16 @@ class CustomSearchHandler {
 
       // Add agent built-in first
       for (const cmd of agentBuiltIn) {
-        const key = `${cmd.name}:${cmd.source || ''}:${cmd.label || ''}`;
+        const key = getAgentSkillDedupKey(cmd);
         commandMap.set(key, cmd);
       }
 
-      // Add custom commands (same name with different source or label is kept).
+      // Add custom commands (same name with a different source, label, or trigger is kept).
       // When the same key collides (e.g., two plugin caches expose the same
       // skill with the same label), keep the candidate whose filePath has the
       // newer semver — without this, settings order silently picked the loser.
       for (const cmd of userCommands) {
-        const key = `${cmd.name}:${cmd.source || ''}:${cmd.label || ''}`;
+        const key = getAgentSkillDedupKey(cmd);
         const existing = commandMap.get(key);
         if (existing && !isNewerByPathVersion(cmd.filePath, existing.filePath)) continue;
         commandMap.set(key, cmd);

--- a/tests/unit/custom-search-handler-dedup.test.ts
+++ b/tests/unit/custom-search-handler-dedup.test.ts
@@ -16,7 +16,35 @@ vi.mock('../../src/utils/utils', () => ({
 }));
 vi.mock('../../src/utils/shell-env', () => ({ getEnhancedEnv: vi.fn(() => ({})) }));
 
-import { isNewerByPathVersion } from '../../src/handlers/custom-search-handler';
+import { getAgentSkillDedupKey, isNewerByPathVersion } from '../../src/handlers/custom-search-handler';
+
+describe('getAgentSkillDedupKey', () => {
+  test('keeps same-name Claude and Codex skills distinct by trigger', () => {
+    const common = {
+      name: 'issue',
+      description: 'Create an issue',
+      filePath: '/cache/issues-site/issue/1.0.0/skills/issue/SKILL.md',
+      source: 'custom',
+      label: 'issues-site / issue',
+    };
+
+    expect(getAgentSkillDedupKey({ ...common, triggers: ['/'] }))
+      .not.toBe(getAgentSkillDedupKey({ ...common, triggers: ['$'] }));
+  });
+
+  test('normalizes missing slash trigger and trigger order', () => {
+    const common = {
+      name: 'issue',
+      description: 'Create an issue',
+      filePath: '/cache/issues-site/issue/1.0.0/skills/issue/SKILL.md',
+    };
+
+    expect(getAgentSkillDedupKey(common))
+      .toBe(getAgentSkillDedupKey({ ...common, triggers: ['/'] }));
+    expect(getAgentSkillDedupKey({ ...common, triggers: ['$', '/'] }))
+      .toBe(getAgentSkillDedupKey({ ...common, triggers: ['/', '$'] }));
+  });
+});
 
 describe('isNewerByPathVersion', () => {
   test('returns true when candidate path has higher semver than incumbent', () => {


### PR DESCRIPTION
## Summary

- keep same-name plugin skills separate when they use different trigger prefixes
- prevent a newer Codex `$` skill from replacing the corresponding Claude Code `/` skill
- add regression coverage for trigger-aware deduplication

## Verification

- `pnpm run pre-push`
- isolated Prompt Line with real installed plugin caches: `/issue` shows all six issues-site commands

## Packaged app verification

- built and code-signed the packaged arm64 app and DMG
- launched the packaged app with isolated app data and confirmed it loaded from `app.asar`
- verified `/issue` displays all six issues-site commands