### PR TITLE
chore(deps): upgrade electron to 43.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ These can be extended with plugins. See: [Plugin Guide](docs/en/plugins.md) | [p
 
 ### System Requirements
 
-- macOS 10.14 or later
-- Node.js 20 or later
+- macOS 12 (Monterey) or later
+- Node.js 20.19 or later
 - [pnpm](https://pnpm.io/installation)
 - Xcode Command Line Tools or Xcode (for compiling native tools)
 - [fd](https://github.com/sharkdp/fd) and [rg (ripgrep)](https://github.com/BurntSushi/ripgrep) (for file search and symbol search features)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@typescript-eslint/parser": "^8.69.0",
     "@vitest/coverage-v8": "^4.1.11",
     "@vitest/eslint-plugin": "^1.6.27",
-    "electron": "^39.8.10",
+    "electron": "^43.6.0",
     "electron-builder": "26.15.3",
     "eslint": "^10.10.0",
     "globals": "^16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^1.6.27
         version: 1.6.27(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.5.4))(eslint@10.10.0(jiti@2.7.0))(typescript@5.5.4))(eslint@10.10.0(jiti@2.7.0))(typescript@5.5.4)(vitest@4.1.11)
       electron:
-        specifier: ^39.8.10
-        version: 39.8.10
+        specifier: ^43.6.0
+        version: 43.6.0
       electron-builder:
         specifier: 26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -330,6 +330,10 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@electron-internal/extract-zip@1.0.5':
+    resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@4.3.0':
     resolution: {integrity: sha512-k/FFC/NQoTykGBi/Ga4L4KorsAKDdkK0LfNVG90eUG6vPVpJaL3iR9V1ZLbzBAF3QpojK5DcaGOdQOheKZv4JQ==}
     engines: {node: '>=22.12.0'}
@@ -339,13 +343,13 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
-
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
+
+  '@electron/get@5.1.0':
+    resolution: {integrity: sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
@@ -1396,17 +1400,14 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
-  '@types/node@22.20.1':
-    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.69.0':
     resolution: {integrity: sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==}
@@ -1917,9 +1918,9 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@39.8.10:
-    resolution: {integrity: sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==}
-    engines: {node: '>= 12.20.55'}
+  electron@43.6.0:
+    resolution: {integrity: sha512-DqVKYV+FXheMSLTxcMQ+NCo78BDgpnToSyIzXctlUtbP3lRGEuoo1P+C2n/90rJ7TvHgzP0bpP9fbbXxp4noIg==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emoji-regex@10.6.0:
@@ -1942,6 +1943,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -2040,11 +2045,6 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
-
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2816,9 +2816,6 @@ packages:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3287,9 +3284,16 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -3522,10 +3526,6 @@ packages:
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
-    engines: {node: '>=12'}
-
-  yauzl@3.4.0:
-    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yn@3.1.1:
@@ -3826,6 +3826,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@electron-internal/extract-zip@1.0.5': {}
+
   '@electron/asar@4.3.0':
     dependencies:
       glob: 13.0.6
@@ -3837,7 +3839,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -3851,17 +3853,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0':
+  '@electron/get@5.1.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.8.5
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 4.1.3
+      undici: 7.29.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4713,20 +4714,15 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.20.1':
+  '@types/node@24.13.3':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.18.2
 
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 20.19.43
 
   '@types/sarif@2.1.7': {}
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 20.19.43
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.5.4))(eslint@10.10.0(jiti@2.7.0))(typescript@5.5.4)':
     dependencies:
@@ -5347,11 +5343,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@39.8.10:
+  electron@43.6.0:
     dependencies:
-      '@electron/get': 2.0.3
-      '@types/node': 22.20.1
-      extract-zip: 2.0.1
+      '@electron-internal/extract-zip': 1.0.5
+      '@electron/get': 5.1.0
+      '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5371,6 +5367,8 @@ snapshots:
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   err-code@2.0.3: {}
 
@@ -5526,16 +5524,6 @@ snapshots:
   expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 3.4.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -6322,8 +6310,6 @@ snapshots:
 
   pe-library@0.4.1: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -6820,7 +6806,12 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.18.2: {}
+
   undici@6.28.0: {}
+
+  undici@7.29.1:
+    optional: true
 
   unicorn-magic@0.3.0: {}
 
@@ -6988,10 +6979,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@3.4.0:
-    dependencies:
-      pend: 1.2.0
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
Closes the last open Dependabot alert (GHSA-jmr9-qjv8-65gv, high).

## Why

`extract-zip` has **no patched release** — 2.0.1 is the newest version published — so the alert
cannot be fixed by a lockfile bump. Electron 40+ replaces it with
`@electron-internal/extract-zip`, which makes upgrading Electron the only available fix.

Separately, **Electron 39 reached end of life on 2026-05-05**. Electron supports the latest three
stable majors, which today means 42, 43 and 44.

## Why 43 and not 44

| Major | EOL | Verdict |
|---|---|---|
| 40, 41 | 2026-06-30 / 2026-08-25 | already EOL — no better than staying on 39 |
| 42 | 2026-10-20 | supported, but EOL in ~6 weeks |
| **43** | **2027-01-05** | **fixes the alert with no code change** |
| 44 | 2027-03-02 | requires a clipboard rewrite (below) |

Electron 44 rearchitects the `clipboard` module around the W3C Clipboard API. `clipboard.readImage()`,
`writeImage()`, `availableFormats()`, `readBuffer()`/`writeBuffer()` and the rest are **removed**, and
`writeText()` becomes async. Confirmed by installing 44 here: `pnpm run typecheck` fails with

```
src/handlers/paste-handler.ts(320,31): error TS2339: Property 'readImage' does not exist on type 'Clipboard'.
```

and `setClipboardAsync` would additionally need `await`, since it currently resolves and triggers
Cmd+V without waiting for the write to land — a paste race. For an app whose whole job is pasting,
that migration deserves its own PR with real clipboard testing (including whether a macOS TIFF
pasteboard entry surfaces as `image/png` through the new `ClipboardItem` API). 43 is the version
that closes the security alert *today* without that risk.

## What changed

`package.json`, one line: `"electron": "^39.8.10"` → `"^43.6.0"`, plus the lockfile.

A second commit corrects the README's System Requirements. **Both lines were already wrong before
this branch**, so this is a documentation fix rather than a consequence of the upgrade:

- `macOS 10.14 or later` → `macOS 12 (Monterey) or later`. Electron 39 — the version shipped until
  now — already states "macOS (Monterey and up)" in its README, exactly as 43 does, so the
  documented baseline has been stale for a while and this upgrade does not move it.
- `Node.js 20 or later` → `Node.js 20.19 or later`, matching the `engines.node` raised to
  `>=20.19.0` when eslint went to 10.x.

**No application code changed.** Every breaking change in 40→43 was checked against this codebase
and none applies:

- **40 / 44 — clipboard removed from the renderer**: already compliant. `preload.ts` deliberately
  withholds clipboard access ("No direct clipboard access is exposed to the renderer for security
  reasons") and the renderer uses `navigator.clipboard.writeText`, which is the documented
  migration target.
- **42 — `electron` no longer downloads its binary via `postinstall`**: a no-op here, because the
  `compile` script already invokes `node node_modules/electron/install.js` explicitly.
- **43 — `nativeImage.toBitmap()` sRGB normalisation**: `toBitmap` / `getBitmap` are unused.
- **43 — Linux frameless corner rounding / WCO layout**: Linux-only; this is a macOS-only app.
- **43 — dialog `defaultPath` now defaults to Downloads**: the only `dialog` use is `showMessageBox`.
- **42 — macOS notifications via `UNNotification`; OSR scale factor**: Electron's `Notification` is
  unused (renderer-side DOM only) and `offscreen` is `false`.

`pnpm-workspace.yaml` still carries `allowBuilds: electron: true`, which became a no-op in 42. It is
harmless, so it is left alone rather than widening this diff.

## Verification

- **`pnpm audit` → "No known vulnerabilities found"**, down from the one remaining extract-zip
  finding. `extract-zip` is gone from the lockfile entirely.
- `pnpm run lint` → 0 errors, 1212 warnings (identical to before — no new warnings).
- `pnpm run typecheck` → clean.
- `pnpm test` → 1457 passed, 1 skipped.
- `CODE_SIGN_IDENTITY=- pnpm run build` → full build through electron-builder 26.15.3 including
  `afterPack` / `afterSign` and DMG creation.
- Runtime smoke test on the isolated instance: window paints, text entry works, `@` switches into
  file-search mode. Only two benign warnings in the log (a second-instance guard and the expected
  `active-text-field` → `active-window-center` position fallback).

### The three things automated checks do not cover

All three were verified by hand on this branch rather than deferred:

**Image paste (`clipboard.readImage`)** — the one clipboard call that 44 would break, so the one
most worth proving on 43. A 64×64 solid `rgb(220,40,40)` PNG was placed on the real pasteboard, the
`paste-image` IPC invoked through the isolated instance, and the written file decoded: 64×64,
color type 2, first pixel exactly `(220, 40, 40)`, mode `-rw-------`. The user's clipboard was saved
beforehand and restored byte-for-byte afterwards (216 bytes, same type list).

**Global shortcut and tray icon** — the isolated instance skips both by design, so a non-isolated
instance was started with its own `PROMPT_LINE_DATA_DIR` and `--user-data-dir`, and a settings file
binding `main` to `Control+Alt+Shift+F9` so it could not contend with the running app's
`Cmd+Shift+Space`. Both `registerShortcuts()` and `createTray()` throw on failure and both run
before `Prompt Line initialized successfully` is logged; that line appeared with zero `[ERROR]`
entries and no exception on stdout, so both succeeded. The instance was then terminated.

Not exercised: actually pressing the hotkey and pasting into another application, which needs a real
key event and Accessibility permission for a dev build.

## Follow-up

Electron 44 (and the clipboard migration) remains open.

Electron 44 would raise the macOS baseline again, from Monterey to Ventura, so the README line this
PR just corrected will need revisiting with that upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsZU8ejNqt8wWYbo6NgAVD
