### PR TITLE
fix(paste): preserve PNG metadata and handle clipboard failures

### DIFF
--- a/src/handlers/CLAUDE.md
+++ b/src/handlers/CLAUDE.md
@@ -40,3 +40,7 @@ Central communication bridge between main and renderer processes. 9 specialized 
 ### Clipboard image storage
 - Image-data clipboard items are validated as decodable PNGs and saved byte-for-byte, preserving embedded color metadata without PNG re-encoding.
 - Finder file URLs still use NativeImage conversion to PNG because the source file may be JPEG or another supported format.
+
+### Clipboard write failures
+- Text paste waits up to 2 seconds for the Electron clipboard write. Rejection or timeout returns the existing secure failure response and keeps the window and saved draft available.
+- The timeout does not cancel Electron's write or interrupt synchronous main-thread work. A late completion can still update the clipboard, but cannot resume hiding the window or native paste.

--- a/src/handlers/CLAUDE.md
+++ b/src/handlers/CLAUDE.md
@@ -36,3 +36,7 @@ Central communication bridge between main and renderer processes. 9 specialized 
 - Subscribes to `plugins-changed` event from PluginManager
 - Subscribes to `source-changed` event from CustomSearchLoader (JSONL/individual file changes)
 - Both events invalidate cache and notify renderer via `custom-search-updated` push channel
+
+### Clipboard image storage
+- Image-data clipboard items are validated as decodable PNGs and saved byte-for-byte, preserving embedded color metadata without PNG re-encoding.
+- Finder file URLs still use NativeImage conversion to PNG because the source file may be JPEG or another supported format.

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -28,6 +28,7 @@ interface PasteResult {
 
 // Constants
 const MAX_PASTE_TEXT_LENGTH_BYTES = 1024 * 1024; // 1MB limit for paste text
+const CLIPBOARD_WRITE_TIMEOUT_MS = 2000;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 // Image paths trigger a Claude Code paste bug on cmux/Ghostty/WezTerm (not
@@ -226,10 +227,11 @@ class PasteHandler {
           const itermSessionId = isITerm2(previousApp) ? await getITermSessionId() : undefined;
           await this.historyManager.addToHistory(text, appName, directory, itermSessionId);
         })(),
-        this.draftManager.clearDraft(),
         this.setClipboardAsync(clipboardText),
       ]);
 
+      // Preserve the saved draft if writing the clipboard fails or times out.
+      await this.draftManager.clearDraft();
       await this.windowManager.hideInputWindow();
       await sleep(Math.max(config.timing.windowHideDelay, 5));
 
@@ -475,7 +477,18 @@ class PasteHandler {
     // and fires Cmd+V immediately after this resolves, so reporting success on
     // a failed write would paste nothing while telling the user it worked; the
     // Promise.all in handlePasteText turns a throw into OPERATION_FAILED.
-    await clipboard.writeText(text);
+    // This bounds an unresolved Promise, not a synchronous main-thread block.
+    // Electron exposes no cancellation: a late write may still update the
+    // clipboard, but must never resume the failed paste operation.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('Clipboard write timed out')), CLIPBOARD_WRITE_TIMEOUT_MS);
+      });
+      await Promise.race([clipboard.writeText(text), timeout]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async getPreviousAppAsync(): Promise<AppInfo | string | null> {

--- a/src/handlers/paste-handler.ts
+++ b/src/handlers/paste-handler.ts
@@ -1,5 +1,5 @@
 import { ipcMain, clipboard, nativeImage, IpcMainInvokeEvent, dialog } from 'electron';
-import type { NativeImage, ClipboardItem } from 'electron';
+import type { ClipboardItem } from 'electron';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
 import { execFile } from 'child_process';
@@ -28,6 +28,7 @@ interface PasteResult {
 
 // Constants
 const MAX_PASTE_TEXT_LENGTH_BYTES = 1024 * 1024; // 1MB limit for paste text
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 // Image paths trigger a Claude Code paste bug on cmux/Ghostty/WezTerm (not
 // reproducible on iTerm2): a paste containing an image path converts that
@@ -320,7 +321,7 @@ class PasteHandler {
   }
 
   /**
-   * Read the clipboard image as a NativeImage.
+   * Read the clipboard image as PNG bytes, preserving image-data metadata.
    *
    * Electron 44 replaced the synchronous clipboard with the W3C-modelled API,
    * so `clipboard.readImage()` is gone. Two pasteboard shapes carry an image
@@ -336,19 +337,19 @@ class PasteHandler {
    *   image — so the file URL has to be followed here to keep Finder paste
    *   working.
    */
-  private async readClipboardImage(): Promise<NativeImage | null> {
+  private async readClipboardImage(): Promise<Buffer | null> {
     const items = await clipboard.read();
     logger.debug('Clipboard items read', { types: items.map(item => item.types) });
 
     for (const item of items) {
-      const image = await this.decodeClipboardItem(item);
-      if (image) return image;
+      const buffer = await this.readClipboardItem(item);
+      if (buffer) return buffer;
     }
     return null;
   }
 
-  /** Decode one clipboard entry, preferring image data over a file reference. */
-  private async decodeClipboardItem(item: ClipboardItem): Promise<NativeImage | null> {
+  /** Read one clipboard entry, preferring image data over a file reference. */
+  private async readClipboardItem(item: ClipboardItem): Promise<Buffer | null> {
     try {
       if (item.types.includes('image/png')) {
         const blob = (await item.getType('image/png')) as Blob;
@@ -359,8 +360,12 @@ class PasteHandler {
         if (buffer.length === 0) {
           logger.warn('Clipboard advertised image/png but returned no bytes; the pasteboard changed mid-read');
         } else {
-          const image = nativeImage.createFromBuffer(buffer);
-          if (!image.isEmpty()) return image;
+          // Decode only to validate: re-encoding drops PNG color metadata and
+          // blocks the main process. Keep the original bytes, and do not retain
+          // the decoded bitmap across the filesystem awaits below. The signature
+          // also rejects JPEG data mislabeled as PNG (createFromBuffer accepts it).
+          if (buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE) &&
+              !nativeImage.createFromBuffer(buffer).isEmpty()) return buffer;
           logger.warn('Clipboard image/png could not be decoded', { bytes: buffer.length });
         }
       }
@@ -376,7 +381,7 @@ class PasteHandler {
   }
 
   /** Follow a `text/uri-list` file URL, as readImage() did before Electron 44. */
-  private async readImageFromFileUrl(item: ClipboardItem): Promise<NativeImage | null> {
+  private async readImageFromFileUrl(item: ClipboardItem): Promise<Buffer | null> {
     const blob = (await item.getType('text/uri-list')) as Blob;
     const uri = Buffer.from(await blob.arrayBuffer())
       .toString('utf8')
@@ -399,7 +404,9 @@ class PasteHandler {
       logger.debug('Clipboard file URL does not point at an image', { filePath });
       return null;
     }
-    return image;
+    // File URLs may point at JPEGs or other supported formats. Convert these
+    // to match the generated .png filename, preserving the existing behavior.
+    return image.toPNG();
   }
 
   private async handlePasteImage(_event: IpcMainInvokeEvent): Promise<{ success: boolean; error?: string; path?: string; relativePath?: string }> {
@@ -413,8 +420,8 @@ class PasteHandler {
     try {
       logger.info('Paste image requested');
 
-      const image = await this.readClipboardImage();
-      if (!image) {
+      const buffer = await this.readClipboardImage();
+      if (!buffer) {
         return { success: false, error: 'No image in clipboard' };
       }
 
@@ -431,7 +438,6 @@ class PasteHandler {
         return { success: false, error: pathValidation.error || 'Invalid file path' };
       }
 
-      const buffer = image.toPNG();
       await fs.writeFile(pathValidation.normalizedPath, buffer, { mode: 0o600 });
       // Use clear() not writeText('') — writeText only replaces the text type,
       // leaving image formats (TIFF/PNG/AVIF…) on NSPasteboard. Stale image

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -403,10 +403,13 @@ export class PromptLineRenderer {
                   mtimeMs: Date.now()
                 });
               }
+            } else if (!result.success && result.error !== 'No image in clipboard') {
+              this.domManager.showError('Image paste failed: ' + (result.error || 'Operation failed'));
             }
             // If no image, the default text paste behavior is preserved
           } catch (error) {
             rendererLogger.error('Error handling image paste:', error);
+            this.domManager.showError('Image paste failed: Operation failed');
           }
         }, 0);
         return;

--- a/tests/unit/paste-handler-clipboard-image.test.ts
+++ b/tests/unit/paste-handler-clipboard-image.test.ts
@@ -78,6 +78,12 @@ function item(payloads: Record<string, Buffer | Error>) {
   };
 }
 
+// The decoder is mocked, but the PNG signature check runs against these bytes.
+const png = (payload = 'png') => Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from(payload)
+]);
+
 function image(empty: boolean, png = Buffer.from('encoded')) {
   return { isEmpty: () => empty, toPNG: () => png };
 }
@@ -111,18 +117,21 @@ describe('paste-image via the Electron 44 clipboard API', () => {
   });
 
   describe('image data on the pasteboard', () => {
-    it('decodes an image/png item, writes it 0600 and clears the pasteboard', async () => {
-      clipboardRead.mockResolvedValue([item({ 'image/png': Buffer.from('the-png') })]);
-      createFromBuffer.mockReturnValue(image(false, Buffer.from('encoded')));
+    it('preserves the original PNG bytes, writes them 0600 and clears the pasteboard', async () => {
+      const original = png('original color metadata');
+      const toPNG = vi.fn(() => Buffer.from('re-encoded without metadata'));
+      clipboardRead.mockResolvedValue([item({ 'image/png': original })]);
+      createFromBuffer.mockReturnValue({ isEmpty: () => false, toPNG });
 
       const result = await pasteImage();
 
       expect(result.success).toBe(true);
-      expect(Buffer.from(createFromBuffer.mock.calls[0]![0] as Buffer).toString()).toBe('the-png');
+      expect(createFromBuffer).toHaveBeenCalledWith(original);
+      expect(toPNG).not.toHaveBeenCalled();
 
       const [written, data, options] = writeFile.mock.calls[0] as unknown as [string, Buffer, { mode: number }];
       expect(written).toBe('/tmp/images/' + written.split('/').pop());
-      expect(data.toString()).toBe('encoded');
+      expect(data).toEqual(original);
       expect(options.mode).toBe(0o600);
       expect(result.path).toBe(written);
 
@@ -133,7 +142,7 @@ describe('paste-image via the Electron 44 clipboard API', () => {
     });
 
     it('returns a relative path when imagesDirectory is relative to the project', async () => {
-      clipboardRead.mockResolvedValue([item({ 'image/png': Buffer.from('png') })]);
+      clipboardRead.mockResolvedValue([item({ 'image/png': png() })]);
       createFromBuffer.mockReturnValue(image(false));
 
       const result = await pasteImage({ imagesDirectory: 'screenshots' });
@@ -147,7 +156,7 @@ describe('paste-image via the Electron 44 clipboard API', () => {
     // carry a trailing slash. Comparing a normalize()d dir against dirname()
     // would then reject every paste.
     it('accepts an imagesDirectory written with a trailing slash', async () => {
-      clipboardRead.mockResolvedValue([item({ 'image/png': Buffer.from('png') })]);
+      clipboardRead.mockResolvedValue([item({ 'image/png': png() })]);
       createFromBuffer.mockReturnValue(image(false));
 
       const result = await pasteImage({ imagesDirectory: 'screenshots/' });
@@ -217,7 +226,7 @@ describe('paste-image via the Electron 44 clipboard API', () => {
 
     it('falls back to the file URL when the png in the same item fails to decode', async () => {
       clipboardRead.mockResolvedValue([
-        item({ 'image/png': Buffer.from('broken'), 'text/uri-list': Buffer.from('file:///Users/me/a.png') })
+        item({ 'image/png': png('broken'), 'text/uri-list': Buffer.from('file:///Users/me/a.png') })
       ]);
       createFromBuffer.mockReturnValue(image(true));
       createFromPath.mockReturnValue(image(false));
@@ -228,6 +237,34 @@ describe('paste-image via the Electron 44 clipboard API', () => {
   });
 
   describe('failure handling', () => {
+    it('rejects non-PNG data even if the native decoder could accept it', async () => {
+      clipboardRead.mockResolvedValue([item({ 'image/png': Buffer.from('JPEG data') })]);
+      createFromBuffer.mockReturnValue(image(false));
+
+      await expect(pasteImage()).resolves.toMatchObject({ success: false, error: 'No image in clipboard' });
+      expect(createFromBuffer).not.toHaveBeenCalled();
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(clipboardClear).not.toHaveBeenCalled();
+    });
+
+    it('rejects PNG-signature data that cannot be decoded', async () => {
+      clipboardRead.mockResolvedValue([item({ 'image/png': png('truncated') })]);
+      createFromBuffer.mockReturnValue(image(true));
+
+      await expect(pasteImage()).resolves.toMatchObject({ success: false, error: 'No image in clipboard' });
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(clipboardClear).not.toHaveBeenCalled();
+    });
+
+    it('preserves the clipboard when saving the original PNG fails', async () => {
+      clipboardRead.mockResolvedValue([item({ 'image/png': png() })]);
+      createFromBuffer.mockReturnValue(image(false));
+      writeFile.mockRejectedValue(new Error('private filesystem detail'));
+
+      await expect(pasteImage()).resolves.toMatchObject({ success: false, error: 'Operation failed' });
+      expect(clipboardClear).not.toHaveBeenCalled();
+    });
+
     it('reports no image when the clipboard is empty', async () => {
       clipboardRead.mockResolvedValue([]);
 
@@ -255,7 +292,7 @@ describe('paste-image via the Electron 44 clipboard API', () => {
     it('keeps scanning after one item throws', async () => {
       clipboardRead.mockResolvedValue([
         item({ 'image/png': new Error("The type 'image/png' was not found in the ClipboardItem") }),
-        item({ 'image/png': Buffer.from('good') })
+        item({ 'image/png': png('good') })
       ]);
       createFromBuffer.mockReturnValue(image(false));
 

--- a/tests/unit/paste-handler-isolated.test.ts
+++ b/tests/unit/paste-handler-isolated.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 const isIsolatedInstance = vi.fn(() => false);
 
@@ -57,6 +57,7 @@ describe('PasteHandler in an isolated instance', () => {
     }).handlePasteText({}, text);
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     // clearAllMocks does not drop implementations, so a test that makes the
     // clipboard write reject or hang would leak into the next one.
@@ -80,6 +81,10 @@ describe('PasteHandler in an isolated instance', () => {
     );
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   // Electron 44 made writeText async, and the window is hidden and Cmd+V fired
   // as soon as this resolves. Without the await the paste races the write, and
   // nothing else in the suite notices: every other test hands back a mock that
@@ -101,12 +106,15 @@ describe('PasteHandler in an isolated instance', () => {
     await Promise.resolve();
 
     expect(written).toEqual([]);
+    expect(clearDraft).not.toHaveBeenCalled();
     expect(hideInputWindow).not.toHaveBeenCalled();
 
     releaseWrite();
     await pasted;
 
     expect(written).toEqual(['hello']);
+    expect(clearDraft).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
     expect(hideInputWindow).toHaveBeenCalled();
   });
 
@@ -117,12 +125,44 @@ describe('PasteHandler in an isolated instance', () => {
 
     await expect(paste('hello')).resolves.toEqual({ success: false, error: 'failed' });
     expect(activateAndPasteWithNativeTool).not.toHaveBeenCalled();
+    expect(hideInputWindow).not.toHaveBeenCalled();
+    expect(clearDraft).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
+
+  it.each(['pending', 'resolve', 'reject'] as const)(
+    'times out and retains the draft when the write is late (%s)', async completion => {
+      let resolveWrite!: () => void;
+      let rejectWrite!: (error: Error) => void;
+      (clipboard.writeText as unknown as Mock).mockImplementation(() => new Promise<void>((resolve, reject) => {
+        resolveWrite = resolve;
+        rejectWrite = reject;
+      }));
+
+      const pasted = paste('hello');
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(hideInputWindow).not.toHaveBeenCalled();
+      expect(clearDraft).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(pasted).resolves.toEqual({ success: false, error: 'failed' });
+      expect(vi.getTimerCount()).toBe(0);
+
+      if (completion === 'resolve') resolveWrite();
+      if (completion === 'reject') rejectWrite(new Error('late failure'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(clearDraft).not.toHaveBeenCalled();
+      expect(hideInputWindow).not.toHaveBeenCalled();
+      expect(activateAndPasteWithNativeTool).not.toHaveBeenCalled();
+      expect(pasteWithNativeTool).not.toHaveBeenCalled();
+    }
+  );
 
   it('writes the clipboard and pastes natively when not isolated', async () => {
     const result = await paste('hello');
 
     expect(result).toEqual({ success: true });
+    expect(vi.getTimerCount()).toBe(0);
     expect(clipboard.writeText).toHaveBeenCalledWith('hello');
     expect(activateAndPasteWithNativeTool).toHaveBeenCalledWith(previousApp);
   });

--- a/tests/unit/renderer-refactored.test.ts
+++ b/tests/unit/renderer-refactored.test.ts
@@ -386,23 +386,55 @@ describe('PromptLineRenderer (Refactored)', () => {
             expect((renderer as any).draftManager.saveDraftDebounced).toHaveBeenCalled();
         });
 
-        test('should not prevent default when no image', async () => {
-            mockIpcRenderer.invoke.mockImplementation((channel: string) => {
-                if (channel === 'paste-image') {
-                    return Promise.resolve({ success: false });
-                }
-                return Promise.resolve({});
-            });
-
-            const event = new KeyboardEvent('keydown', {
-                key: 'v',
-                metaKey: true
-            });
+        test.each([
+            ['No image in clipboard', undefined],
+            ['Operation failed', 'Image paste failed: Operation failed'],
+            ['Invalid file path', 'Image paste failed: Invalid file path'],
+            [undefined, 'Image paste failed: Operation failed']
+        ])('should preserve text and handle image failure %s', async (error, message) => {
+            mockIpcRenderer.invoke.mockImplementation((channel: string) =>
+                Promise.resolve(channel === 'paste-image' ? { success: false, error } : {})
+            );
+            const domManager = (renderer as any).domManager;
+            domManager.textarea.value = 'text already pasted';
+            const event = new KeyboardEvent('keydown', { key: 'v', metaKey: true });
             event.preventDefault = vi.fn();
 
             await (renderer as any).handleKeyDown(event);
+            await new Promise(resolve => setTimeout(resolve, 10));
 
             expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(domManager.textarea.value).toBe('text already pasted');
+            expect(domManager.setText).not.toHaveBeenCalled();
+            expect(domManager.insertTextAtCursor).not.toHaveBeenCalled();
+            if (message) {
+                expect(domManager.showError).toHaveBeenCalledExactlyOnceWith(message);
+            } else {
+                expect(domManager.showError).not.toHaveBeenCalled();
+            }
+        });
+
+        test('should report rejected image IPC without exposing exception details', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockIpcRenderer.invoke.mockImplementation((channel: string) =>
+                channel === 'paste-image'
+                    ? Promise.reject(new Error('Cannot write /private/secret/image.png'))
+                    : Promise.resolve({})
+            );
+            const domManager = (renderer as any).domManager;
+            domManager.textarea.value = 'text already pasted';
+            const event = new KeyboardEvent('keydown', { key: 'v', ctrlKey: true });
+            event.preventDefault = vi.fn();
+
+            await (renderer as any).handleKeyDown(event);
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(domManager.showError).toHaveBeenCalledExactlyOnceWith('Image paste failed: Operation failed');
+            expect(domManager.textarea.value).toBe('text already pasted');
+            expect(domManager.setText).not.toHaveBeenCalled();
+            expect(domManager.insertTextAtCursor).not.toHaveBeenCalled();
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            consoleSpy.mockRestore();
         });
     });
 


### PR DESCRIPTION
Clipboard image pastes currently re-encode PNGs, dropping color metadata, while pending clipboard writes can leave text pastes unresponsive and image paste failures are invisible to users.

- Validate clipboard PNG data and save the original bytes, preserving color metadata. Finder file URLs retain conversion to PNG for other image formats.
- Time out pending clipboard writes after two seconds and preserve the draft and window on failure. Late completion does not resume the failed paste operation.
- Display image paste failures through the existing error UI. An empty image clipboard still silently preserves normal text paste behavior.

Validation: 1,484 tests passed and 1 skipped; type checking and compilation passed; lint reported no errors. Real Electron checks confirmed PNG byte and metadata preservation. Reviewers also checked timeout boundary cases and six live renderer scenarios, including rejection and missing error details. Fresh subagents reviewed each issue with no findings, within the same parent session as implementation.

Limitations: the timeout cannot interrupt a synchronous main-thread stall or cancel an Electron clipboard write. Runtime fault injection was used for failure cases; a full system-clipboard end-to-end retest was not performed.
